### PR TITLE
worker: serve go-import meta for go install; classify repo as Go

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,9 @@
 * text=auto eol=lf
 *.png binary
 *.woff2 binary
+
+# Classify the repo by its product language (the Go CLI); the Worker/site
+# TypeScript otherwise outweighs it in linguist stats.
+web/** -linguist-detectable
+worker/** -linguist-detectable
+shared/** -linguist-detectable

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -128,6 +128,15 @@ export default {
   async fetch(request, env, executionContext): Promise<Response> {
     const url = new URL(request.url);
 
+    // `go install shell.online/cmd/shell@latest` resolves the module by
+    // requesting any path with ?go-get=1 and reading this meta tag.
+    if (url.searchParams.get("go-get") === "1") {
+      return new Response(
+        '<!doctype html><meta name="go-import" content="shell.online git https://github.com/TeoSlayer/shell.online">\n',
+        { headers: { "Content-Type": "text/html; charset=utf-8" } },
+      );
+    }
+
     if (url.pathname === "/api/health" && request.method === "GET") {
       return json({ ok: true, service: "shell.online", version: RELEASE_VERSION });
     }


### PR DESCRIPTION
Two small distribution fixes, no behavior change for existing users.

1. `go install shell.online/cmd/shell@latest` currently fails because the site serves no go-import meta. The Worker now answers any request carrying `?go-get=1` with the standard meta tag for module `shell.online`, which makes go install a zero-maintenance install path worth a README line.

2. Linguist classifies the repo as TypeScript because the Worker and site outweigh the Go CLI by line count, which costs the project its spot on Go-side discovery (trending/go, awesome-go eligibility). `.gitattributes` now marks `web/`, `worker/`, and `shared/` as non-detectable so the repo classifies by its product language.

Checked locally, `npx tsc -p tsconfig.worker.json --noEmit` passes. The go-get response is static HTML with no session or secret surface.
