### PR TITLE
Restore and verify download distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   web:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -23,6 +23,12 @@ jobs:
       - run: npm ci
       - run: npm run check
       - run: npm run build:web
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Build and verify download bundle
+        run: npm run build:cli && npm run verify:downloads
 
   cli:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
   },
   "type": "module",
   "scripts": {
-    "build": "npm run check && npm run build:web && npm run build:cli",
+    "build": "npm run check && npm run build:web && npm run build:cli && npm run verify:downloads",
     "build:cli": "sh ./scripts/build-cli.sh",
     "build:web": "vite build",
+    "verify:downloads": "node ./scripts/verify-downloads.mjs",
     "check": "npm run typecheck && npm test",
     "test": "vitest run && sh ./scripts/test-install.sh && sh ./scripts/test-docker-entrypoint.sh && node ./scripts/test-landing-seo.mjs",
     "typecheck": "tsc -p tsconfig.worker.json --noEmit && tsc -p tsconfig.web.json --noEmit"

--- a/public/install
+++ b/public/install
@@ -77,6 +77,12 @@ download() {
 
 download "$binary_url" "$temporary_dir/shell"
 download "$base_url/downloads/SHA256SUMS" "$temporary_dir/SHA256SUMS"
+manifest_first_line=$(sed -n '1p' "$temporary_dir/SHA256SUMS")
+case "$manifest_first_line" in
+  '<!doctype html'*|'<html'*)
+    fail "expected a checksum manifest, received HTML from $base_url/downloads/SHA256SUMS"
+    ;;
+esac
 expected=$(awk -v filename="$binary_name" '$2 == filename { print $1; exit }' "$temporary_dir/SHA256SUMS")
 
 case "$expected" in

--- a/scripts/build-cli.sh
+++ b/scripts/build-cli.sh
@@ -66,3 +66,4 @@ printf '%s  %s\n' "$release_checksum" "$(basename "$release_metadata")" >> "$che
 
 printf 'Release %s checksums:\n' "$version"
 cat "$checksum_manifest"
+node ./scripts/verify-downloads.mjs "$output_dir"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -86,6 +86,18 @@ fi
 assert_contains "$output" "downloaded binary failed checksum verification"
 test ! -e "$bad_install/shell"
 
+html_downloads=$test_root/html/downloads
+mkdir -p "$html_downloads"
+cp "$downloads/$binary_name" "$html_downloads/$binary_name"
+printf '%s\n' '<!doctype html>' '<title>shell.online</title>' > "$html_downloads/SHA256SUMS"
+if output=$(SHELL_ONLINE_BASE_URL=file://$test_root/html \
+  SHELL_ONLINE_INSTALL_DIR=$test_root/html-install sh "$installer" 2>&1); then
+  printf 'HTML manifest unexpectedly succeeded.\n' >&2
+  exit 1
+fi
+assert_contains "$output" "expected a checksum manifest, received HTML"
+test ! -e "$test_root/html-install/shell"
+
 if output=$(SHELL_ONLINE_INSTALL_DIR=relative/path sh "$installer" 2>&1); then
   printf 'Relative install directory unexpectedly succeeded.\n' >&2
   exit 1

--- a/scripts/verify-downloads.mjs
+++ b/scripts/verify-downloads.mjs
@@ -1,0 +1,85 @@
+import { createHash } from "node:crypto";
+import { readFile, stat } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const directory = resolve(process.argv[2] ?? "dist/downloads");
+const packageMetadata = JSON.parse(await readFile(resolve("package.json"), "utf8"));
+const binaries = [
+  "shell-darwin-amd64",
+  "shell-darwin-arm64",
+  "shell-linux-amd64",
+  "shell-linux-arm64",
+];
+const signedArtifacts = [...binaries, "install", "SKILL.md", "release.json"];
+const requiredFiles = [
+  ...signedArtifacts,
+  ...binaries.map((name) => `${name}.sha256`),
+  "release.json.sha256",
+  "SHA256SUMS",
+];
+
+function fail(message) {
+  throw new Error(`invalid download bundle: ${message}`);
+}
+
+async function digest(filename) {
+  const body = await readFile(resolve(directory, filename));
+  if (body.subarray(0, 32).toString("utf8").trimStart().toLowerCase().startsWith("<!doctype html")) {
+    fail(`${filename} contains HTML`);
+  }
+  return createHash("sha256").update(body).digest("hex");
+}
+
+for (const filename of requiredFiles) {
+  let details;
+  try {
+    details = await stat(resolve(directory, filename));
+  } catch {
+    fail(`${filename} is missing`);
+  }
+  if (!details.isFile() || details.size === 0) fail(`${filename} is empty`);
+}
+for (const filename of binaries) {
+  const details = await stat(resolve(directory, filename));
+  if (details.size < 1_000_000) fail(`${filename} is implausibly small (${details.size} bytes)`);
+}
+
+const manifestText = await readFile(resolve(directory, "SHA256SUMS"), "utf8");
+const manifest = new Map();
+for (const line of manifestText.trim().split("\n")) {
+  const match = line.match(/^([a-f0-9]{64}) {2}(\S+)$/);
+  if (!match || manifest.has(match[2])) fail(`SHA256SUMS contains an invalid entry: ${line}`);
+  manifest.set(match[2], match[1]);
+}
+for (const filename of signedArtifacts) {
+  const expected = manifest.get(filename);
+  if (!expected) fail(`SHA256SUMS has no entry for ${filename}`);
+  const actual = await digest(filename);
+  if (actual !== expected) fail(`${filename} checksum is ${actual}, expected ${expected}`);
+}
+
+for (const filename of [...binaries, "release.json"]) {
+  const sidecar = (await readFile(resolve(directory, `${filename}.sha256`), "utf8")).trim();
+  const expected = `${manifest.get(filename)}  ${filename}`;
+  if (sidecar !== expected) fail(`${filename}.sha256 does not match SHA256SUMS`);
+}
+
+let release;
+try {
+  release = JSON.parse(await readFile(resolve(directory, "release.json"), "utf8"));
+} catch {
+  fail("release.json is not valid JSON");
+}
+if (release.version !== packageMetadata.version) {
+  fail(`release.json version ${release.version ?? "<missing>"} does not match package ${packageMetadata.version}`);
+}
+if (release.algorithm !== "sha256" || typeof release.artifacts !== "object" || release.artifacts === null) {
+  fail("release.json has invalid metadata");
+}
+for (const filename of [...binaries, "install", "SKILL.md"]) {
+  if (release.artifacts[filename] !== manifest.get(filename)) {
+    fail(`release.json checksum for ${filename} does not match SHA256SUMS`);
+  }
+}
+
+console.log(`Verified ${requiredFiles.length} download files for shell ${packageMetadata.version}.`);

--- a/shared/download-assets.ts
+++ b/shared/download-assets.ts
@@ -1,0 +1,4 @@
+export function downloadAssetIsSpaFallback(pathname: string, contentType: string | null): boolean {
+  return pathname.startsWith("/downloads/") &&
+    (contentType?.toLowerCase().startsWith("text/html") ?? false);
+}

--- a/tests/download-assets.test.ts
+++ b/tests/download-assets.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { downloadAssetIsSpaFallback } from "../shared/download-assets";
+
+describe("download asset routing", () => {
+  it("detects the SPA page returned for a missing download", () => {
+    expect(downloadAssetIsSpaFallback("/downloads/release.json", "text/html; charset=utf-8")).toBe(true);
+  });
+
+  it("keeps real download responses and unrelated HTML pages", () => {
+    expect(downloadAssetIsSpaFallback("/downloads/release.json", "application/json")).toBe(false);
+    expect(downloadAssetIsSpaFallback("/downloads/shell-linux-amd64", "application/octet-stream")).toBe(false);
+    expect(downloadAssetIsSpaFallback("/docs/", "text/html")).toBe(false);
+  });
+});

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -11,6 +11,7 @@ import {
 } from "./analytics";
 import { isStatsRange } from "../shared/stats";
 import { RELEASE_VERSION } from "../shared/release";
+import { downloadAssetIsSpaFallback } from "../shared/download-assets";
 import { viewerFrameAction } from "../shared/session-access";
 import { terminalGridForDevices } from "../shared/terminal-grid";
 import { persistentSessionID } from "../shared/persistent-session";
@@ -236,7 +237,16 @@ export default {
       return json({ error: "not found" }, 404);
     }
 
-    const assetResponse = await env.ASSETS.fetch(request);
+    let assetResponse = await env.ASSETS.fetch(request);
+    if (downloadAssetIsSpaFallback(url.pathname, assetResponse.headers.get("Content-Type"))) {
+      assetResponse = new Response("Download not found\n", {
+        status: 404,
+        headers: {
+          "Cache-Control": "no-store",
+          "Content-Type": "text/plain; charset=utf-8",
+        },
+      });
+    }
     const response = secureAssetResponse(assetResponse, url.pathname, url.hostname);
     recordAssetAnalytics(request, env, url, response, executionContext);
     return response;


### PR DESCRIPTION
## What changed
- prevent Cloudflare's SPA fallback from returning landing-page HTML with HTTP 200 for missing `/downloads/*` files
- make the installer identify an HTML checksum manifest directly and fail with an accurate error
- verify all 13 expected distribution files, binary sizes, sidecar hashes, the canonical manifest, and release metadata
- make every CLI bundle build run that verifier
- add a PR CI step that builds the full four-platform download bundle after the web build and verifies it
- add regressions for download fallback detection and HTML installer responses

## Validation
- `npm run build` (19 test files / 60 tests, installer, Docker, SEO, four platform binaries, 13-file bundle verification)
- `go test ./...`

Closes #26