### PR TITLE
Add mobile TUI navigation keys

### DIFF
--- a/tests/terminal-keyboard.test.ts
+++ b/tests/terminal-keyboard.test.ts
@@ -1,10 +1,22 @@
 import { describe, expect, it } from "vitest";
-import { terminalKeyAction } from "../web/terminal-keyboard";
+import { mobileTerminalKeyBytes, terminalKeyAction } from "../web/terminal-keyboard";
 
 const key = (value: string, ctrlKey = false, metaKey = false, keyCode = 0) =>
   ({ key: value, ctrlKey, metaKey, keyCode });
 
 describe("mobile and browser terminal keyboard handling", () => {
+  it("encodes the mobile TUI key deck", () => {
+    expect([...mobileTerminalKeyBytes("escape")!]).toEqual([27]);
+    expect([...mobileTerminalKeyBytes("tab")!]).toEqual([9]);
+    expect([...mobileTerminalKeyBytes("left")!]).toEqual([27, 91, 68]);
+    expect([...mobileTerminalKeyBytes("up")!]).toEqual([27, 91, 65]);
+    expect([...mobileTerminalKeyBytes("down")!]).toEqual([27, 91, 66]);
+    expect([...mobileTerminalKeyBytes("right")!]).toEqual([27, 91, 67]);
+    expect([...mobileTerminalKeyBytes("enter")!]).toEqual([13]);
+    expect([...mobileTerminalKeyBytes("interrupt")!]).toEqual([3]);
+    expect(mobileTerminalKeyBytes("unknown")).toBeNull();
+  });
+
   it("copies selected terminal text instead of sending Ctrl-C", () => {
     expect(terminalKeyAction(key("c", true), true).kind).toBe("copy-selection");
     expect(terminalKeyAction(key("c", false, true), true).kind).toBe("copy-selection");

--- a/web/main.ts
+++ b/web/main.ts
@@ -25,7 +25,7 @@ import {
 } from "../shared/github";
 import { TerminalWriteQueue } from "./terminal-writes";
 import { TerminalInputQueue } from "./terminal-input";
-import { terminalKeyAction } from "./terminal-keyboard";
+import { mobileTerminalKeyBytes, terminalKeyAction } from "./terminal-keyboard";
 import { DestructiveInputGuard } from "./destructive-input";
 import { BrowserFrameCipher, parseEncryptionFragment } from "./e2ee";
 import documentationContent from "../docs/content.json";
@@ -942,6 +942,16 @@ function renderTerminal(sessionId: string): void {
         <div id="terminal" class="terminal" aria-label="Shared interactive terminal"></div>
         <div id="terminal-input-warning" class="terminal-input-warning" role="status" aria-live="assertive" hidden></div>
       </div>
+      <nav id="mobile-terminal-keys" class="mobile-terminal-keys" aria-label="Terminal navigation keys">
+        <button type="button" data-terminal-key="escape" aria-label="Escape">esc</button>
+        <button type="button" data-terminal-key="tab" aria-label="Tab">tab</button>
+        <button type="button" data-terminal-key="left" aria-label="Left arrow">←</button>
+        <button type="button" data-terminal-key="up" aria-label="Up arrow">↑</button>
+        <button type="button" data-terminal-key="down" aria-label="Down arrow">↓</button>
+        <button type="button" data-terminal-key="right" aria-label="Right arrow">→</button>
+        <button type="button" data-terminal-key="enter" aria-label="Enter">enter</button>
+        <button type="button" data-terminal-key="interrupt" aria-label="Control C">ctrl-c</button>
+      </nav>
       <div id="encryption-gate" class="encryption-gate" hidden>
         <form id="encryption-form" class="encryption-panel">
           <span class="settings-kicker">Private terminal</span>
@@ -1023,6 +1033,9 @@ function renderTerminal(sessionId: string): void {
   const terminalElement = requiredElement("terminal");
   const terminalWrap = requiredElement("terminal-wrap");
   const terminalInputWarning = requiredElement("terminal-input-warning");
+  const mobileKeyButtons = Array.from(
+    document.querySelectorAll<HTMLButtonElement>("#mobile-terminal-keys [data-terminal-key]"),
+  );
   const sessionHeader = requiredElement("session-header");
   const sessionPage = document.querySelector<HTMLElement>(".session-page");
   if (!sessionPage) throw new Error("Missing session page");
@@ -1143,6 +1156,15 @@ function renderTerminal(sessionId: string): void {
   let outgoingFrames = Promise.resolve();
   let incomingFrames = Promise.resolve();
 
+  const syncMobileKeys = (): void => {
+    const disabled = stopped || readOnly || waitingForEncryptionKey ||
+      lastStatus !== "connected" || socket?.readyState !== WebSocket.OPEN ||
+      terminalElement.classList.contains("input-locked");
+    for (const button of mobileKeyButtons) button.disabled = disabled;
+  };
+
+  syncMobileKeys();
+
   terminalInput.setEncoder((chunk) => {
     const frame = encodeFrame(Opcode.Input, chunk);
     return frameCipher ? frameCipher.seal(frame) : frame;
@@ -1164,6 +1186,7 @@ function renderTerminal(sessionId: string): void {
     encryptionForm.querySelector<HTMLLabelElement>("label")!.hidden = !allowPassword;
     encryptionForm.querySelector<HTMLButtonElement>("button")!.hidden = !allowPassword;
     terminal.options.disableStdin = true;
+    syncMobileKeys();
     if (allowPassword) encryptionPassword.focus();
   };
 
@@ -1201,6 +1224,7 @@ function renderTerminal(sessionId: string): void {
       : "Shared interactive terminal");
     terminalElement.setAttribute("aria-readonly", String(readOnly));
     terminal.options.disableStdin = stopped || readOnly || terminalElement.classList.contains("input-locked");
+    syncMobileKeys();
     if (copyButton.dataset.state === undefined) copyButton.textContent = defaultCopyLabel();
     if (readOnly) {
       terminal.blur();
@@ -1314,6 +1338,7 @@ function renderTerminal(sessionId: string): void {
     identityElement.classList.toggle("has-typing", inputIsLocked);
     terminalElement.classList.toggle("input-locked", inputIsLocked);
     terminal.options.disableStdin = stopped || readOnly || inputIsLocked;
+    syncMobileKeys();
 
     presenceElement.replaceChildren();
     const visibleCount = compactPresenceQuery.matches ? 1 : 4;
@@ -1387,6 +1412,7 @@ function renderTerminal(sessionId: string): void {
       scheduleLatencyProbe(0);
     }
     renderConnectionStatus();
+    syncMobileKeys();
   };
 
   const scheduleLatencyProbe = (delay = 2_500): void => {
@@ -1521,6 +1547,7 @@ function renderTerminal(sessionId: string): void {
 
   const showMissingSession = (): void => {
     stopped = true;
+    sessionPage.classList.add("session-stopped");
     terminal.options.disableStdin = true;
     terminalWrites.enqueue(textEncoder.encode(
       "\x1b[2J\x1b[H\r\n  \x1b[1;37mSession no longer exists.\x1b[0m" +
@@ -1531,6 +1558,7 @@ function renderTerminal(sessionId: string): void {
 
   const showEndedSession = (): void => {
     stopped = true;
+    sessionPage.classList.add("session-stopped");
     terminal.options.disableStdin = true;
     terminalWrites.enqueue(textEncoder.encode(
       "\r\n\r\n  \x1b[1;37mSession ended.\x1b[0m" +
@@ -1773,6 +1801,25 @@ function renderTerminal(sessionId: string): void {
   terminal.onData((data) => {
     sendTerminalData(textEncoder.encode(data));
   });
+
+  const activateMobileKey = (button: HTMLButtonElement): void => {
+    const bytes = mobileTerminalKeyBytes(button.dataset.terminalKey);
+    if (bytes === null || button.disabled || terminal.options.disableStdin) return;
+    terminal.focus();
+    sendTerminalData(bytes);
+  };
+
+  for (const button of mobileKeyButtons) {
+    button.addEventListener("pointerdown", (event) => {
+      if (!event.isPrimary || (event.pointerType === "mouse" && event.button !== 0)) return;
+      event.preventDefault();
+      activateMobileKey(button);
+    });
+    button.addEventListener("click", (event) => {
+      if (event.detail !== 0) return;
+      activateMobileKey(button);
+    });
+  }
 
   // Legacy mouse protocols and a few terminal query responses contain raw
   // bytes that must not pass through UTF-8 encoding.

--- a/web/style.css
+++ b/web/style.css
@@ -1515,6 +1515,10 @@ a {
 
 .terminal-input-warning[hidden] { display: none; }
 
+.mobile-terminal-keys {
+  display: none;
+}
+
 .theme-light .terminal-input-warning {
   border-color: #dfc49c;
   background: #fff8eb;
@@ -1908,6 +1912,70 @@ a {
     padding:
       8px max(7px, env(safe-area-inset-right))
       max(6px, env(safe-area-inset-bottom)) max(7px, env(safe-area-inset-left));
+  }
+}
+
+@media (max-width: 760px), (pointer: coarse) {
+  .session-page {
+    grid-template-rows: 48px minmax(0, 1fr) auto;
+  }
+
+  .session-page.keyboard-open {
+    grid-template-rows: 36px minmax(0, 1fr) auto;
+  }
+
+  .mobile-terminal-keys {
+    display: grid;
+    min-height: 42px;
+    padding: 4px max(5px, env(safe-area-inset-right)) max(4px, env(safe-area-inset-bottom)) max(5px, env(safe-area-inset-left));
+    border-top: 1px solid #252a34;
+    background: #11141b;
+    grid-template-columns: repeat(8, minmax(0, 1fr));
+    gap: 4px;
+    user-select: none;
+  }
+
+  .mobile-terminal-keys button {
+    min-width: 0;
+    min-height: 34px;
+    padding: 0;
+    border: 1px solid #333a47;
+    border-radius: 7px;
+    background: #171b23;
+    box-shadow: inset 0 1px rgb(255 255 255 / 3%);
+    color: #c8cfdd;
+    font: 600 11px/1 "Uncut Sans", sans-serif;
+    letter-spacing: -0.01em;
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .mobile-terminal-keys button:active:not(:disabled) {
+    border-color: #66728a;
+    background: #252c38;
+    color: #fff;
+    transform: translateY(1px);
+  }
+
+  .mobile-terminal-keys button:disabled {
+    opacity: 0.32;
+  }
+
+  .session-page.theme-light .mobile-terminal-keys {
+    border-color: #d7dce5;
+    background: #f1f3f7;
+  }
+
+  .session-page.theme-light .mobile-terminal-keys button {
+    border-color: #cfd5df;
+    background: #fff;
+    box-shadow: 0 1px 2px rgb(42 52 72 / 7%);
+    color: #43506a;
+  }
+
+  .session-page.read-only .mobile-terminal-keys,
+  .session-page.session-stopped .mobile-terminal-keys {
+    display: none;
   }
 }
 

--- a/web/terminal-keyboard.ts
+++ b/web/terminal-keyboard.ts
@@ -3,6 +3,22 @@ export type TerminalKeyAction =
   | { kind: "copy-selection" }
   | { kind: "send"; bytes: Uint8Array };
 
+const mobileTerminalKeys: Record<string, readonly number[]> = {
+  escape: [27],
+  tab: [9],
+  left: [27, 91, 68],
+  up: [27, 91, 65],
+  down: [27, 91, 66],
+  right: [27, 91, 67],
+  enter: [13],
+  interrupt: [3],
+};
+
+export function mobileTerminalKeyBytes(key: string | undefined): Uint8Array | null {
+  if (key === undefined || !(key in mobileTerminalKeys)) return null;
+  return new Uint8Array(mobileTerminalKeys[key]);
+}
+
 export function terminalKeyAction(
   event: Pick<KeyboardEvent, "key" | "ctrlKey" | "metaKey" | "keyCode">,
   hasSelection: boolean,


### PR DESCRIPTION
## What changed
- add a compact mobile key deck for Esc, Tab, arrows, Enter, and Ctrl-C
- keep the controls inside the responsive viewport and preserve terminal focus on touch
- disable the controls while offline, read-only, encrypted-key-gated, or controlled by another typist
- hide them once a session ends
- add exact byte-sequence tests for every key

## Validation
- npm run check
- npm run build:web
- go test ./...
- live phone-sized browser test through a local Worker and PTY (Enter produced the next shell prompt)