### PR TITLE
Guard production deploys against missing downloads

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,3 +30,7 @@ Keep changes focused, add regression tests for fixes, and describe the user-visi
 Documentation copy lives in [`docs/content.json`](docs/content.json) and renders both the current site and tagged, release-selectable docs. Keep its version equal to `package.json`, preserve the schema, and run the SEO test through `npm run check` after editing it.
 
 E2EE is the default product invariant for new CLI sessions; only an explicit `--no-e2ee` may opt out. Changes to session startup, structured output, persistent state, or Docker entrypoints must preserve the browser-password flow, prevent accidental downgrade, and include regression tests. Update the built-in CLI help, README, security policy, agent skill, `public/llms.txt`, and versioned documentation together when that flow changes.
+
+## Production deployment
+
+Use `npm run deploy:production`. It rebuilds and verifies the complete web and download bundle before invoking Wrangler. Do not deploy directly after `npm run build:web`: Workers asset manifests are replaced atomically, so omitting `dist/downloads` would remove the public installers and binaries.

--- a/package.json
+++ b/package.json
@@ -20,9 +20,10 @@
     "build": "npm run check && npm run build:web && npm run build:cli && npm run verify:downloads",
     "build:cli": "sh ./scripts/build-cli.sh",
     "build:web": "vite build",
+    "deploy:production": "sh ./scripts/deploy-production.sh",
     "verify:downloads": "node ./scripts/verify-downloads.mjs",
     "check": "npm run typecheck && npm test",
-    "test": "vitest run && sh ./scripts/test-install.sh && sh ./scripts/test-docker-entrypoint.sh && sh ./scripts/test-qemu-linux.sh --check && node ./scripts/test-landing-seo.mjs",
+    "test": "vitest run && sh ./scripts/test-install.sh && sh ./scripts/test-docker-entrypoint.sh && sh ./scripts/test-deploy-production.sh && sh ./scripts/test-qemu-linux.sh --check && node ./scripts/test-landing-seo.mjs",
     "test:qemu:manifest": "sh ./scripts/test-qemu-linux.sh --check",
     "typecheck": "tsc -p tsconfig.worker.json --noEmit && tsc -p tsconfig.web.json --noEmit"
   },

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+config=${SHELL_ONLINE_WRANGLER_CONFIG:-wrangler.production.jsonc}
+
+if [ ! -f "$config" ]; then
+  printf 'Production Wrangler config not found: %s\n' "$config" >&2
+  exit 1
+fi
+
+# A Workers asset deployment replaces the previous manifest. Always rebuild and
+# verify the complete download bundle so a web-only deploy cannot remove it.
+npm run build
+npm run verify:downloads
+npx wrangler deploy --config "$config" "$@"

--- a/scripts/test-deploy-production.sh
+++ b/scripts/test-deploy-production.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+set -eu
+
+repository_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/shell-online-deploy-test.XXXXXX")
+trap 'rm -rf "$test_root"' EXIT HUP INT TERM
+
+fake_bin="$test_root/bin"
+command_log="$test_root/commands"
+config="$test_root/wrangler.production.jsonc"
+mkdir -p "$fake_bin"
+: > "$config"
+
+cat > "$fake_bin/npm" <<'SCRIPT'
+#!/bin/sh
+printf 'npm %s\n' "$*" >> "$SHELL_ONLINE_TEST_COMMAND_LOG"
+if [ "${SHELL_ONLINE_TEST_VERIFY_FAIL:-0}" = "1" ] && [ "$*" = "run verify:downloads" ]; then
+  exit 42
+fi
+SCRIPT
+
+cat > "$fake_bin/npx" <<'SCRIPT'
+#!/bin/sh
+printf 'npx %s\n' "$*" >> "$SHELL_ONLINE_TEST_COMMAND_LOG"
+SCRIPT
+
+chmod 755 "$fake_bin/npm" "$fake_bin/npx"
+
+SHELL_ONLINE_TEST_COMMAND_LOG="$command_log" \
+SHELL_ONLINE_WRANGLER_CONFIG="$config" \
+PATH="$fake_bin:$PATH" \
+  sh "$repository_root/scripts/deploy-production.sh"
+
+expected=$(printf 'npm run build\nnpm run verify:downloads\nnpx wrangler deploy --config %s\n' "$config")
+test "$(cat "$command_log")" = "$expected"
+
+: > "$command_log"
+set +e
+SHELL_ONLINE_TEST_VERIFY_FAIL=1 \
+SHELL_ONLINE_TEST_COMMAND_LOG="$command_log" \
+SHELL_ONLINE_WRANGLER_CONFIG="$config" \
+PATH="$fake_bin:$PATH" \
+  sh "$repository_root/scripts/deploy-production.sh"
+verification_status=$?
+set -e
+test "$verification_status" -eq 42
+test "$(cat "$command_log")" = "$(printf 'npm run build\nnpm run verify:downloads')"
+
+: > "$command_log"
+if SHELL_ONLINE_TEST_COMMAND_LOG="$command_log" \
+  SHELL_ONLINE_WRANGLER_CONFIG="$test_root/missing.jsonc" \
+  PATH="$fake_bin:$PATH" \
+  sh "$repository_root/scripts/deploy-production.sh" 2>/dev/null; then
+  printf 'Deployment unexpectedly accepted a missing Wrangler config.\n' >&2
+  exit 1
+fi
+test ! -s "$command_log"
+
+echo "production deployment guard tests passed"


### PR DESCRIPTION
Adds a single production deployment entry point that rebuilds and verifies the complete download bundle before Wrangler replaces the static asset manifest. Regression coverage proves a failed bundle verification or missing production config prevents deployment.