### PR TITLE
Add an optional account for keeping track of saved links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable user-visible changes are recorded here. Versions follow [Semantic Ve
   Accounts never gate a share — creating, opening, and using links is unchanged without one.
 - Add browser-side terminal commands that never reach the shell: `/login`, `/logout`,
   `/save`, `/links`, `/account`, and `/help`.
+- Keep a saved encrypted share openable by remembering its URL fragment in the browser
+  that saved it; the relay still never receives the key, and the account page says when a
+  link was saved on another device instead of returning an undecryptable URL.
 
 - Add LLM-assisted issue intake, pull-request diff review, changelog suggestions, and generated GitHub release notes.
 - Automatically delete unmistakably unrelated or spam issues and close equivalent pull requests only when two independent reviews agree at 98% confidence; preserve technical criticism and relevant but flawed contributions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable user-visible changes are recorded here. Versions follow [Semantic Ve
 ## Unreleased
 
 ### Added
+- Add an optional account: sign in from the session header, from the Controls panel on
+  phones, or by typing `/login` in the terminal, then keep a list of the shares you save.
+  Accounts never gate a share — creating, opening, and using links is unchanged without one.
+- Add browser-side terminal commands that never reach the shell: `/login`, `/logout`,
+  `/save`, `/links`, `/account`, and `/help`.
 
 - Add LLM-assisted issue intake, pull-request diff review, changelog suggestions, and generated GitHub release notes.
 - Automatically delete unmistakably unrelated or spam issues and close equivalent pull requests only when two independent reviews agree at 98% confidence; preserve technical criticism and relevant but flawed contributions.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ Relays that want to offer them need three pieces of configuration:
 "vars": { "ACCOUNT_SECRET": "<a secret of at least 12 characters>" }
 ```
 
+Saved links are stored as session ids only. An encrypted share keeps its key in the URL
+fragment, which never reaches the relay, so the browser that saved a link keeps that
+fragment locally and stitches it back on when the account page renders the link. A link
+saved on one device therefore opens in full only on that device; elsewhere the account
+page says so rather than handing back an undecryptable URL.
+
 `ACCOUNT_SECRET` signs session cookies and should be a real secret, not a literal in
 source control. Without it `/api/account/*` answers `503` and the browser simply shows
 no account controls, which is the intended fallback.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,23 @@ Native shares also run in the background. Re-run `shell --persistent <state-file
 
 The website documentation is generated from [`docs/content.json`](docs/content.json) and versioned with each release.
 
+## Optional accounts
+
+Accounts are optional everywhere: shares are created, opened, and used without one.
+An account only remembers the links you choose to save.
+
+Relays that want to offer them need three pieces of configuration:
+
+```jsonc
+"durable_objects": { "bindings": [{ "name": "ACCOUNTS", "class_name": "AccountsStore" }] },
+"migrations": [{ "tag": "v2", "new_sqlite_classes": ["AccountsStore"] }],
+"vars": { "ACCOUNT_SECRET": "<a secret of at least 12 characters>" }
+```
+
+`ACCOUNT_SECRET` signs session cookies and should be a real secret, not a literal in
+source control. Without it `/api/account/*` answers `503` and the browser simply shows
+no account controls, which is the intended fallback.
+
 ## Development
 
 Requires the release toolchain Go 1.26.8 and Node.js 22+. Go 1.27.x must not be used for MIPS64 release binaries because of [Go issue 80978](https://go.dev/issue/80978).

--- a/account/index.html
+++ b/account/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content" />
+    <meta name="description" content="Optional shell.online account for keeping track of the links you have saved." />
+    <meta name="robots" content="noindex, nofollow" />
+    <link rel="canonical" href="https://shell.online/account/" />
+    <meta property="og:type" content="website" /><meta property="og:site_name" content="shell.online" />
+    <meta property="og:url" content="https://shell.online/account/" /><meta property="og:title" content="Account | shell.online" />
+    <meta property="og:description" content="Optional account for keeping track of your saved shares." />
+    <meta property="og:image" content="https://shell.online/social-card.png" />
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" /><link rel="manifest" href="/site.webmanifest" />
+    <style>html,body,#app{width:100%;height:100%;margin:0;background:#f3f1e9}.boot-screen{display:grid;height:100%;color:#191b18;font:600 22px system-ui,sans-serif;place-items:center}</style>
+    <title>Account | shell.online</title>
+  </head>
+  <body><div id="app"><section class="boot-screen" aria-label="Loading shell.online"><div class="boot-mark">shell.online</div></section></div><script type="module" src="/web/main.ts"></script></body>
+</html>

--- a/tests/account-auth.test.ts
+++ b/tests/account-auth.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+  accountCookie,
+  clearedAccountCookie,
+  createAccountSession,
+  hashPassword,
+  normalizeEmail,
+  readAccountSession,
+  validatePassword,
+  verifyPassword,
+} from "../worker/account-auth";
+
+const SECRET = "an-account-signing-secret";
+
+describe("account passwords", () => {
+  it("derives a distinct salt and hash for the same password", async () => {
+    const first = await hashPassword("correct horse battery");
+    const second = await hashPassword("correct horse battery");
+    expect(first.salt).not.toBe(second.salt);
+    expect(first.hash).not.toBe(second.hash);
+  });
+
+  it("verifies a password against its own salt", async () => {
+    const { salt, hash } = await hashPassword("correct horse battery");
+    await expect(verifyPassword("correct horse battery", salt, hash)).resolves.toBe(true);
+  });
+
+  it("rejects the wrong password and a mismatched salt", async () => {
+    const { salt, hash } = await hashPassword("correct horse battery");
+    const other = await hashPassword("correct horse battery");
+    await expect(verifyPassword("wrong password", salt, hash)).resolves.toBe(false);
+    await expect(verifyPassword("correct horse battery", other.salt, hash)).resolves.toBe(false);
+  });
+
+  it("never stores the password itself", async () => {
+    const { salt, hash } = await hashPassword("correct horse battery");
+    expect(salt).not.toContain("correct");
+    expect(hash).not.toContain("correct");
+  });
+});
+
+describe("account session tokens", () => {
+  it("round-trips the account id", async () => {
+    const token = await createAccountSession("account-1", SECRET);
+    await expect(readAccountSession(token, SECRET)).resolves.toBe("account-1");
+  });
+
+  it("refuses a token signed with a different secret", async () => {
+    const token = await createAccountSession("account-1", SECRET);
+    await expect(readAccountSession(token, "a-completely-other-secret")).resolves.toBeNull();
+  });
+
+  it("refuses a tampered payload", async () => {
+    const token = await createAccountSession("account-1", SECRET);
+    const [version, , signature] = token.split(".");
+    const forged = btoa(JSON.stringify({ accountId: "account-2", issuedAt: 0, expiresAt: Date.now() + 1000 }))
+      .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+    await expect(readAccountSession(`${version}.${forged}.${signature}`, SECRET)).resolves.toBeNull();
+  });
+
+  it("refuses an expired token", async () => {
+    const issued = Date.now() - 400 * 24 * 60 * 60 * 1000;
+    const token = await createAccountSession("account-1", SECRET, issued);
+    await expect(readAccountSession(token, SECRET)).resolves.toBeNull();
+  });
+
+  it("refuses malformed input and weak secrets", async () => {
+    await expect(readAccountSession(null, SECRET)).resolves.toBeNull();
+    await expect(readAccountSession("not-a-token", SECRET)).resolves.toBeNull();
+    const token = await createAccountSession("account-1", SECRET);
+    await expect(readAccountSession(token, "tooshort")).resolves.toBeNull();
+  });
+});
+
+describe("account cookies", () => {
+  it("marks the session cookie as HttpOnly and SameSite=Strict", () => {
+    const cookie = accountCookie("token-value", true);
+    expect(cookie).toContain("HttpOnly");
+    expect(cookie).toContain("SameSite=Strict");
+    expect(cookie).toContain("Secure");
+  });
+
+  it("omits Secure when the origin is not https", () => {
+    expect(accountCookie("token-value", false)).not.toContain("Secure");
+  });
+
+  it("expires the cookie when signing out", () => {
+    expect(clearedAccountCookie(true)).toContain("Max-Age=0");
+  });
+});
+
+describe("account input validation", () => {
+  it("normalises usable addresses", () => {
+    expect(normalizeEmail("  Person@Example.COM ")).toBe("person@example.com");
+  });
+
+  it("rejects addresses that are not addresses", () => {
+    for (const value of ["", "nope", "a@b", "no spaces@example.com", 42, null]) {
+      expect(normalizeEmail(value)).toBeNull();
+    }
+  });
+
+  it("requires at least eight characters of password", () => {
+    expect(validatePassword("shortie")).toBeNull();
+    expect(validatePassword("just-long-enough")).toBe("just-long-enough");
+    expect(validatePassword("x".repeat(257))).toBeNull();
+    expect(validatePassword(undefined)).toBeNull();
+  });
+});

--- a/tests/link-fragments.test.ts
+++ b/tests/link-fragments.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  completeShareUrl,
+  forgetLinkFragment,
+  linkFragmentFor,
+  rememberLinkFragment,
+} from "../web/link-fragments";
+
+const SESSION = "A".repeat(32);
+const SHARE = `https://shell.online/s/${SESSION}`;
+const FRAGMENT = "#salt=BqA2LRaslN49B94GK9rn_w";
+
+function installStorage(working = true): void {
+  const map = new Map<string, string>();
+  const storage = working
+    ? {
+        getItem: (k: string) => map.get(k) ?? null,
+        setItem: (k: string, v: string) => void map.set(k, v),
+        removeItem: (k: string) => void map.delete(k),
+      }
+    : {
+        getItem: () => { throw new Error("blocked"); },
+        setItem: () => { throw new Error("blocked"); },
+        removeItem: () => { throw new Error("blocked"); },
+      };
+  Object.defineProperty(globalThis, "localStorage", { value: storage, configurable: true });
+}
+
+describe("saving and reopening an encrypted share", () => {
+  beforeEach(() => installStorage());
+
+  it("rebuilds the full link, key included, on the browser that saved it", () => {
+    rememberLinkFragment(SESSION, FRAGMENT);
+    expect(completeShareUrl(SHARE, SESSION)).toBe(SHARE + FRAGMENT);
+  });
+
+  it("accepts a fragment with or without its leading hash", () => {
+    rememberLinkFragment(SESSION, "salt=abc");
+    expect(linkFragmentFor(SESSION)).toBe("#salt=abc");
+  });
+
+  it("returns the bare link on a browser that never saw the key", () => {
+    expect(linkFragmentFor(SESSION)).toBe("");
+    expect(completeShareUrl(SHARE, SESSION)).toBe(SHARE);
+  });
+
+  it("leaves an unencrypted share untouched", () => {
+    expect(completeShareUrl(SHARE, SESSION)).toBe(SHARE);
+  });
+
+  it("never double-appends when the URL already carries a fragment", () => {
+    rememberLinkFragment(SESSION, FRAGMENT);
+    expect(completeShareUrl(SHARE + FRAGMENT, SESSION)).toBe(SHARE + FRAGMENT);
+  });
+
+  it("keeps fragments separate per session", () => {
+    const other = "B".repeat(32);
+    rememberLinkFragment(SESSION, "#salt=one");
+    rememberLinkFragment(other, "#salt=two");
+    expect(linkFragmentFor(SESSION)).toBe("#salt=one");
+    expect(linkFragmentFor(other)).toBe("#salt=two");
+  });
+
+  it("drops the key when the link is removed", () => {
+    rememberLinkFragment(SESSION, FRAGMENT);
+    forgetLinkFragment(SESSION);
+    expect(linkFragmentFor(SESSION)).toBe("");
+  });
+
+  it("stores nothing for a share that has no fragment", () => {
+    rememberLinkFragment(SESSION, "");
+    rememberLinkFragment(SESSION, "#");
+    expect(linkFragmentFor(SESSION)).toBe("");
+  });
+
+  it("degrades quietly when storage is unavailable", () => {
+    installStorage(false);
+    expect(() => rememberLinkFragment(SESSION, FRAGMENT)).not.toThrow();
+    expect(linkFragmentFor(SESSION)).toBe("");
+    expect(completeShareUrl(SHARE, SESSION)).toBe(SHARE);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
         security: resolve(import.meta.dirname, "security/index.html"),
         e2ee: resolve(import.meta.dirname, "e2ee/index.html"),
         docker: resolve(import.meta.dirname, "docker/index.html"),
+        account: resolve(import.meta.dirname, "account/index.html"),
       },
     },
   },

--- a/web/account.ts
+++ b/web/account.ts
@@ -1,0 +1,319 @@
+/**
+ * Optional account page.
+ *
+ * Accounts exist only to keep a list of shares you care about, plus the usual
+ * settings for the account itself. Creating one is never required: every link
+ * works exactly the same whether or not anyone signs in.
+ */
+interface SavedLink {
+  session_id: string;
+  label: string;
+  saved_at: number;
+  status: string;
+  share_url: string;
+}
+
+const api = (path: string, init?: RequestInit): Promise<Response> =>
+  fetch(path, { credentials: "same-origin", ...init });
+
+const esc = (value: string): string =>
+  value.replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c] ?? c);
+
+/**
+ * The share to return to. Resolved at click time rather than at render time,
+ * so a tab left open before you opened a terminal still goes back correctly.
+ *
+ * The full URL lives in localStorage because it carries the #salt fragment,
+ * which must never travel to the server as a query parameter.
+ */
+function lastTerminal(): string | null {
+  try {
+    const stored = localStorage.getItem("shell-online:last-terminal");
+    if (stored && /\/s\/[A-Za-z0-9_-]{32}/.test(stored)) return stored;
+  } catch {
+    // Storage unavailable.
+  }
+  // Referrers drop the fragment, so this can only recover the session itself.
+  const referrer = document.referrer;
+  return referrer && /\/s\/[A-Za-z0-9_-]{32}/.test(referrer) ? referrer : null;
+}
+
+export function renderAccountPage(app: HTMLElement): void {
+  const back = lastTerminal();
+  app.innerHTML = `
+    <div class="account-shell">
+      <header class="account-topbar">
+        <a class="wordmark" href="/"><span>shell</span><i>.</i>online</a>
+        <div class="account-topbar-right">
+          <span id="account-whoami" class="account-whoami" hidden></span>
+          <button id="account-settings-open" class="btn btn-small" type="button" hidden>Settings</button>
+          <a id="account-exit" class="account-exit" href="${esc(back ?? "/")}">${back ? "Back to terminal" : "Close"}</a>
+        </div>
+      </header>
+      <main id="account-body" class="account-main"><p class="account-muted">Loading…</p></main>
+    </div>`;
+  const exit = app.querySelector<HTMLAnchorElement>("#account-exit")!;
+  exit.addEventListener("click", (event) => {
+    const destination = lastTerminal();
+    if (!destination) return;
+    event.preventDefault();
+    window.location.href = destination;
+  });
+
+  void refresh(app.querySelector<HTMLElement>("#account-body")!);
+}
+
+async function refresh(body: HTMLElement): Promise<void> {
+  let me: { signedIn?: boolean; email?: string } = {};
+  try {
+    const response = await api("/api/account/me");
+    if (response.status === 503) {
+      body.innerHTML = `<div class="account-card"><p class="account-muted">This relay does not have accounts enabled. Shares work normally without one.</p></div>`;
+      return;
+    }
+    me = await response.json();
+  } catch {
+    body.innerHTML = `<div class="account-card"><p class="account-muted">Could not reach the relay.</p></div>`;
+    return;
+  }
+  if (me.signedIn && me.email) void renderSignedIn(body, me.email);
+  else renderSignedOut(body);
+}
+
+function renderSignedOut(body: HTMLElement): void {
+  body.innerHTML = `
+    <section class="account-hero">
+      <h1>Your links, kept in one place.</h1>
+      <p>An account is entirely optional. It only remembers the shares you save, so you can find
+         them again later. Everything about shell.online works without one.</p>
+    </section>
+    <form id="account-form" class="account-card account-form" novalidate>
+      <div class="account-field">
+        <label for="account-email">Email</label>
+        <input id="account-email" type="email" autocomplete="username" required placeholder="you@example.com" />
+      </div>
+      <div class="account-field">
+        <label for="account-password">Password</label>
+        <input id="account-password" type="password" autocomplete="current-password" minlength="8" required placeholder="At least 8 characters" />
+      </div>
+      <div class="account-row">
+        <button type="submit" class="btn btn-primary">Sign in</button>
+        <button id="account-create" type="button" class="btn">Create account</button>
+      </div>
+      <p id="account-error" class="account-error" hidden></p>
+    </form>`;
+  const form = body.querySelector<HTMLFormElement>("#account-form")!;
+  const error = body.querySelector<HTMLElement>("#account-error")!;
+  const submit = async (path: string): Promise<void> => {
+    error.hidden = true;
+    const email = form.querySelector<HTMLInputElement>("#account-email")!.value;
+    const password = form.querySelector<HTMLInputElement>("#account-password")!.value;
+    try {
+      const response = await api(path, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+      if (response.ok) { void refresh(body); return; }
+      error.textContent = ((await response.json()) as { error?: string }).error ?? "Something went wrong.";
+      error.hidden = false;
+    } catch {
+      error.textContent = "Could not reach the relay.";
+      error.hidden = false;
+    }
+  };
+  form.addEventListener("submit", (event) => { event.preventDefault(); void submit("/api/account/login"); });
+  body.querySelector<HTMLButtonElement>("#account-create")!
+    .addEventListener("click", () => { void submit("/api/account/register"); });
+}
+
+async function renderSignedIn(body: HTMLElement, email: string): Promise<void> {
+  const whoami = document.querySelector<HTMLElement>("#account-whoami");
+  if (whoami) {
+    whoami.hidden = false;
+    whoami.innerHTML = `<strong id="account-current-email">${esc(email)}</strong>`;
+  }
+
+  body.innerHTML = `
+    <section class="account-section">
+      <div class="account-section-head">
+        <h1 class="account-h1">My terminal links</h1>
+        <button id="account-refresh" type="button" class="btn btn-small">Refresh</button>
+      </div>
+      <div id="account-links" class="account-links"><p class="account-muted">Loading…</p></div>
+    </section>
+
+    <div id="account-sheet" class="account-sheet" hidden>
+      <div class="account-sheet-panel" role="dialog" aria-label="Account settings">
+        <div class="account-sheet-head">
+          <h2>Settings</h2>
+          <button id="account-sheet-close" type="button" class="btn btn-small">Done</button>
+        </div>
+        <p class="account-muted">Signed in as <strong>${esc(email)}</strong></p>
+
+        <form id="form-email" class="account-form">
+          <div class="account-field">
+            <label for="new-email">Change email</label>
+            <input id="new-email" type="email" autocomplete="email" placeholder="${esc(email)}" required />
+          </div>
+          <div class="account-row"><button type="submit" class="btn">Update email</button>
+            <span class="account-inline-msg" data-msg="email"></span></div>
+        </form>
+
+        <form id="form-password" class="account-form">
+          <div class="account-field">
+            <label for="cur-password">Current password</label>
+            <input id="cur-password" type="password" autocomplete="current-password" required />
+          </div>
+          <div class="account-field">
+            <label for="new-password">New password</label>
+            <input id="new-password" type="password" autocomplete="new-password" minlength="8" required />
+          </div>
+          <div class="account-row"><button type="submit" class="btn">Update password</button>
+            <span class="account-inline-msg" data-msg="password"></span></div>
+        </form>
+
+        <div class="account-sheet-divider"></div>
+
+        <div class="account-row">
+          <button id="account-signout" type="button" class="btn">Sign out</button>
+        </div>
+
+        <form id="form-delete" class="account-danger">
+          <p class="account-muted">Deleting your account removes this list. Any share that is running
+             keeps running — accounts never control sessions.</p>
+          <div class="account-field">
+            <label for="del-password">Confirm with your password</label>
+            <input id="del-password" type="password" autocomplete="current-password" required />
+          </div>
+          <div class="account-row"><button type="submit" class="btn btn-danger">Delete account</button>
+            <span class="account-inline-msg" data-msg="delete"></span></div>
+        </form>
+      </div>
+    </div>`;
+
+  const msg = (name: string, text: string, bad = false): void => {
+    const el = body.querySelector<HTMLElement>(`[data-msg="${name}"]`)!;
+    el.textContent = text;
+    el.classList.toggle("is-bad", bad);
+  };
+
+  const sheet = body.querySelector<HTMLElement>("#account-sheet")!;
+  const settingsButton = document.querySelector<HTMLButtonElement>("#account-settings-open");
+  if (settingsButton) {
+    settingsButton.hidden = false;
+    settingsButton.onclick = () => { sheet.hidden = false; };
+  }
+  body.querySelector<HTMLButtonElement>("#account-sheet-close")!
+    .addEventListener("click", () => { sheet.hidden = true; });
+  sheet.addEventListener("click", (event) => { if (event.target === sheet) sheet.hidden = true; });
+  window.addEventListener("keydown", (event) => { if (event.key === "Escape") sheet.hidden = true; });
+
+  body.querySelector<HTMLButtonElement>("#account-signout")!.addEventListener("click", () => {
+    void api("/api/account/logout", { method: "POST" }).then(() => refresh(body));
+  });
+  body.querySelector<HTMLButtonElement>("#account-refresh")!.addEventListener("click", () => {
+    void loadLinks(body);
+  });
+
+  body.querySelector<HTMLFormElement>("#form-email")!.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const value = body.querySelector<HTMLInputElement>("#new-email")!.value;
+    void api("/api/account/email", {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: value }),
+    }).then(async (r) => {
+      const data = await r.json() as { error?: string; email?: string };
+      if (r.ok) { msg("email", "Updated"); document.querySelector("#account-current-email")!.textContent = data.email ?? value; }
+      else msg("email", data.error ?? "Could not update", true);
+    });
+  });
+
+  body.querySelector<HTMLFormElement>("#form-password")!.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const current = body.querySelector<HTMLInputElement>("#cur-password")!.value;
+    const next = body.querySelector<HTMLInputElement>("#new-password")!.value;
+    void api("/api/account/password", {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ current, next }),
+    }).then(async (r) => {
+      if (r.ok) { msg("password", "Updated"); (body.querySelector<HTMLFormElement>("#form-password")!).reset(); }
+      else msg("password", ((await r.json()) as { error?: string }).error ?? "Could not update", true);
+    });
+  });
+
+  body.querySelector<HTMLFormElement>("#form-delete")!.addEventListener("submit", (event) => {
+    event.preventDefault();
+    if (!window.confirm("Delete this account and its saved list? Running shares are unaffected.")) return;
+    const password = body.querySelector<HTMLInputElement>("#del-password")!.value;
+    void api("/api/account/delete", {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ password }),
+    }).then(async (r) => {
+      if (r.ok) void refresh(body);
+      else msg("delete", ((await r.json()) as { error?: string }).error ?? "Could not delete", true);
+    });
+  });
+
+  void loadLinks(body);
+}
+
+async function loadLinks(body: HTMLElement): Promise<void> {
+  const list = body.querySelector<HTMLElement>("#account-links");
+  if (!list) return;
+  try {
+    const response = await api("/api/account/links");
+    const links = ((await response.json()) as { links?: SavedLink[] }).links ?? [];
+    if (links.length === 0) {
+      list.innerHTML = `<div class="account-card"><p class="account-muted">No links saved yet. Open any share and use <em>Save link</em> in its header, or type <code>/login</code> then <code>/save</code> in the terminal.</p></div>`;
+      return;
+    }
+    list.innerHTML = links.map((link) => `
+      <article class="account-link ${link.status === "connected" ? "is-live" : "is-dead"}">
+        <div class="account-link-top">
+          <span class="account-pill">${statusLabel(link.status)}</span>
+          <span class="account-link-label">${esc(link.label || link.session_id.slice(0, 10))}</span>
+          <span class="account-link-age">${age(link.saved_at)}</span>
+        </div>
+        <code class="account-link-url">${esc(link.share_url)}</code>
+        <div class="account-row">
+          <button class="btn btn-small" data-copy="${esc(link.share_url)}">Copy</button>
+          <a class="btn btn-small" href="${esc(link.share_url)}" target="_blank" rel="noreferrer">Open</a>
+          <button class="btn btn-small" data-remove="${esc(link.session_id)}">Remove</button>
+        </div>
+      </article>`).join("");
+    list.querySelectorAll<HTMLButtonElement>("[data-copy]").forEach((button) => {
+      button.addEventListener("click", () => {
+        void navigator.clipboard?.writeText(button.dataset.copy ?? "");
+        const original = button.textContent;
+        button.textContent = "Copied";
+        window.setTimeout(() => { button.textContent = original; }, 1200);
+      });
+    });
+    list.querySelectorAll<HTMLButtonElement>("[data-remove]").forEach((button) => {
+      button.addEventListener("click", () => {
+        void api("/api/account/links", {
+          method: "DELETE", headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ session_id: button.dataset.remove }),
+        }).then(() => loadLinks(body));
+      });
+    });
+  } catch {
+    list.innerHTML = `<div class="account-card"><p class="account-muted">Could not load your links.</p></div>`;
+  }
+}
+
+function statusLabel(status: string): string {
+  if (status === "connected") return "Live";
+  if (status === "disconnected") return "Reconnecting";
+  if (status === "ended") return "Ended";
+  return "Unknown";
+}
+
+function age(savedAt: number): string {
+  const minutes = Math.max(0, Math.round((Date.now() - savedAt) / 60_000));
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  return hours < 24 ? `${hours}h ago` : `${Math.round(hours / 24)}d ago`;
+}

--- a/web/account.ts
+++ b/web/account.ts
@@ -5,12 +5,15 @@
  * settings for the account itself. Creating one is never required: every link
  * works exactly the same whether or not anyone signs in.
  */
+import { completeShareUrl, forgetLinkFragment, linkFragmentFor } from "./link-fragments";
+
 interface SavedLink {
   session_id: string;
   label: string;
   saved_at: number;
   status: string;
   share_url: string;
+  encrypted?: boolean;
 }
 
 const api = (path: string, init?: RequestInit): Promise<Response> =>
@@ -268,20 +271,29 @@ async function loadLinks(body: HTMLElement): Promise<void> {
       list.innerHTML = `<div class="account-card"><p class="account-muted">No links saved yet. Open any share and use <em>Save link</em> in its header, or type <code>/login</code> then <code>/save</code> in the terminal.</p></div>`;
       return;
     }
-    list.innerHTML = links.map((link) => `
+    list.innerHTML = links.map((link) => {
+      const full = completeShareUrl(link.share_url, link.session_id);
+      // An encrypted share keeps its key in the fragment, which never reaches
+      // the relay. If this browser did not save the link, it cannot rebuild it.
+      const keyMissing = link.encrypted === true && !linkFragmentFor(link.session_id);
+      return `
       <article class="account-link ${link.status === "connected" ? "is-live" : "is-dead"}">
         <div class="account-link-top">
           <span class="account-pill">${statusLabel(link.status)}</span>
           <span class="account-link-label">${esc(link.label || link.session_id.slice(0, 10))}</span>
           <span class="account-link-age">${age(link.saved_at)}</span>
         </div>
-        <code class="account-link-url">${esc(link.share_url)}</code>
+        <code class="account-link-url">${esc(keyMissing ? link.share_url : full)}</code>
+        ${keyMissing ? `<p class="account-key-note">Saved on another device. The decryption key stays in
+           the browser that saved it and never reaches the relay, so open this share from that device
+           or paste the full link, password included.</p>` : ""}
         <div class="account-row">
-          <button class="btn btn-small" data-copy="${esc(link.share_url)}">Copy</button>
-          <a class="btn btn-small" href="${esc(link.share_url)}" target="_blank" rel="noreferrer">Open</a>
+          ${keyMissing ? "" : `<button class="btn btn-small" data-copy="${esc(full)}">Copy</button>
+          <a class="btn btn-small" href="${esc(full)}" target="_blank" rel="noreferrer">Open</a>`}
           <button class="btn btn-small" data-remove="${esc(link.session_id)}">Remove</button>
         </div>
-      </article>`).join("");
+      </article>`;
+    }).join("");
     list.querySelectorAll<HTMLButtonElement>("[data-copy]").forEach((button) => {
       button.addEventListener("click", () => {
         void navigator.clipboard?.writeText(button.dataset.copy ?? "");
@@ -295,7 +307,7 @@ async function loadLinks(body: HTMLElement): Promise<void> {
         void api("/api/account/links", {
           method: "DELETE", headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ session_id: button.dataset.remove }),
-        }).then(() => loadLinks(body));
+        }).then(() => { forgetLinkFragment(button.dataset.remove ?? ""); void loadLinks(body); });
       });
     });
   } catch {

--- a/web/link-fragments.ts
+++ b/web/link-fragments.ts
@@ -1,0 +1,45 @@
+/**
+ * Local memory of the decryption fragment for saved shares.
+ *
+ * An encrypted share keeps its key in the URL fragment, which by design never
+ * reaches the relay. The account list therefore cannot carry it: the server
+ * only ever knows a session id. The fragment stays in this browser, keyed by
+ * session, and is stitched back on when the account page renders a link.
+ *
+ * The consequence is deliberate and visible in the UI: a link saved on one
+ * device can only be reopened in full on that device. Sending the fragment to
+ * the relay would make the list portable but would hand over the key, which
+ * is exactly what end-to-end encryption is there to prevent.
+ */
+const PREFIX = "shell-online:link-fragment:";
+
+export function rememberLinkFragment(sessionId: string, fragment: string): void {
+  if (!sessionId || !fragment || fragment === "#") return;
+  try {
+    localStorage.setItem(PREFIX + sessionId, fragment.startsWith("#") ? fragment : `#${fragment}`);
+  } catch {
+    // Storage may be unavailable; the account page then says the key is elsewhere.
+  }
+}
+
+export function linkFragmentFor(sessionId: string): string {
+  try {
+    return localStorage.getItem(PREFIX + sessionId) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+export function forgetLinkFragment(sessionId: string): void {
+  try {
+    localStorage.removeItem(PREFIX + sessionId);
+  } catch {
+    // Nothing to clean up if storage is unavailable.
+  }
+}
+
+/** Rebuilds a complete share URL, including the fragment when this browser has it. */
+export function completeShareUrl(shareUrl: string, sessionId: string): string {
+  if (shareUrl.includes("#")) return shareUrl;
+  return shareUrl + linkFragmentFor(sessionId);
+}

--- a/web/main.ts
+++ b/web/main.ts
@@ -1,4 +1,5 @@
 import { FitAddon } from "@xterm/addon-fit";
+import { renderAccountPage } from "./account";
 import { Terminal, type ITheme } from "@xterm/xterm";
 import {
   CLAUDE_CODE_PATH,
@@ -134,6 +135,7 @@ const terminalThemes: Record<TerminalColorMode, ITheme> = {
   },
 };
 
+const accountRoute = /^\/account\/?$/.test(window.location.pathname);
 const sessionMatch = window.location.pathname.match(/^\/s\/([A-Za-z0-9_-]{32})\/?$/);
 const documentationRoute = resolveDocumentationRoute(window.location.pathname);
 const statsDashboard = window.location.hostname === "stats.shell.online" ||
@@ -142,6 +144,8 @@ const statsDashboard = window.location.hostname === "stats.shell.online" ||
 
 if (statsDashboard) {
   renderStatsDashboard(app);
+} else if (accountRoute) {
+  renderAccountPage(app);
 } else if (sessionMatch) {
   renderTerminal(sessionMatch[1]);
 } else if (window.location.pathname === "/" || window.location.pathname === "") {
@@ -930,6 +934,8 @@ function renderTerminal(sessionId: string): void {
         </div>
         <div class="session-actions">
           <div id="presence" class="presence" aria-label="No collaborators connected"></div>
+          <a id="account-link" class="account-chip" href="/account/" title="Optional account">Sign in</a>
+          <button id="account-save" class="account-chip account-save" type="button" hidden title="Save this link to your account">Save link</button>
           <button id="theme-toggle" class="theme-button" type="button">
             <svg class="theme-icon theme-icon-sun" viewBox="0 0 24 24" aria-hidden="true">
               <circle cx="12" cy="12" r="3.25"></circle>
@@ -961,6 +967,22 @@ function renderTerminal(sessionId: string): void {
         <button type="button" data-terminal-key="enter" aria-label="Enter">enter</button>
         <button type="button" data-terminal-key="interrupt" aria-label="Control C">ctrl-c</button>
       </nav>
+      <div id="slash-gate" class="encryption-gate" hidden>
+        <form id="slash-form" class="encryption-panel">
+          <h2 id="slash-title">Sign in to shell.online</h2>
+          <p id="slash-note">Optional. An account only keeps a list of the links you save.</p>
+          <label for="slash-email">Email</label>
+          <input id="slash-email" type="email" autocomplete="username" required />
+          <label for="slash-password">Password</label>
+          <input id="slash-password" type="password" autocomplete="current-password" required />
+          <div class="slash-actions">
+            <button type="submit">Sign in</button>
+            <button id="slash-create" type="button">Create account</button>
+            <button id="slash-cancel" type="button">Cancel</button>
+          </div>
+          <p id="slash-error" class="slash-error" hidden></p>
+        </form>
+      </div>
       <div id="encryption-gate" class="encryption-gate" hidden>
         <form id="encryption-form" class="encryption-panel">
           <span class="settings-kicker">Private terminal</span>
@@ -981,6 +1003,16 @@ function renderTerminal(sessionId: string): void {
             <button id="settings-close" class="settings-close" type="button" aria-label="Close terminal controls">×</button>
           </header>
           <div class="settings-content">
+            <section id="account-card" class="settings-card account-card">
+              <div class="settings-card-heading">
+                <span>Account</span>
+                <span id="account-card-state" class="account-card-state">Optional</span>
+              </div>
+              <div class="account-card-actions">
+                <a id="account-card-link" class="btn btn-small" href="/account/">Sign in</a>
+                <button id="account-card-save" class="btn btn-small" type="button" hidden>Save this link</button>
+              </div>
+            </section>
             <div class="settings-control-grid">
               <section class="settings-card zoom-card" aria-labelledby="zoom-label">
                 <div class="settings-card-heading">
@@ -1058,6 +1090,194 @@ function renderTerminal(sessionId: string): void {
   const accessDescription = requiredElement("session-access-description");
   const typingElement = requiredElement("typing-status");
   const presenceElement = requiredElement("presence");
+  const accountLink = requiredElement<HTMLAnchorElement>("account-link");
+  const accountSave = requiredElement<HTMLButtonElement>("account-save");
+  const cardState = requiredElement("account-card-state");
+  const cardLink = requiredElement<HTMLAnchorElement>("account-card-link");
+  const cardSave = requiredElement<HTMLButtonElement>("account-card-save");
+
+  // Optional accounts. Everything below is additive: if the relay has no
+  // account support, or nobody is signed in, the share behaves exactly as it
+  // always has and the chip simply reads "Sign in".
+  const refreshAccountChip = async (): Promise<void> => {
+    try {
+      const response = await fetch("/api/account/me", { credentials: "same-origin" });
+      if (!response.ok) return;
+      const me = await response.json() as { signedIn?: boolean; email?: string };
+      if (!me.signedIn || !me.email) {
+        accountLink.textContent = "Sign in";
+        accountSave.hidden = true;
+        cardState.textContent = "Optional";
+        cardLink.textContent = "Sign in";
+        cardSave.hidden = true;
+        return;
+      }
+      accountLink.textContent = me.email.split("@")[0].slice(0, 18);
+      accountLink.title = `Signed in as ${me.email}`;
+      accountSave.hidden = false;
+      cardState.textContent = me.email;
+      cardLink.textContent = "My links";
+      cardSave.hidden = false;
+      const links = await fetch("/api/account/links", { credentials: "same-origin" });
+      if (links.ok) {
+        const body = await links.json() as { links?: Array<{ session_id: string }> };
+        if (body.links?.some((link) => link.session_id === sessionId)) {
+          accountSave.textContent = "Saved";
+          accountSave.classList.add("is-saved");
+          accountSave.disabled = true;
+          cardSave.textContent = "Saved";
+          cardSave.disabled = true;
+        }
+      }
+    } catch {
+      // Accounts are optional; a relay without them changes nothing here.
+    }
+  };
+
+  cardSave.addEventListener("click", () => { accountSave.click(); cardSave.textContent = "Saved"; cardSave.disabled = true; });
+
+  accountSave.addEventListener("click", () => {
+    accountSave.disabled = true;
+    void (async () => {
+      try {
+        const response = await fetch("/api/account/links", {
+          method: "POST",
+          credentials: "same-origin",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ session_id: sessionId, label: document.title.replace(" — shell.online", "") }),
+        });
+        if (response.ok) {
+          accountSave.textContent = "Saved";
+          accountSave.classList.add("is-saved");
+        } else {
+          accountSave.textContent = "Save failed";
+          accountSave.disabled = false;
+        }
+      } catch {
+        accountSave.textContent = "Save failed";
+        accountSave.disabled = false;
+      }
+    })();
+  });
+
+  // Remember this share so the account page can return you here instead of
+  // dumping you on the marketing site.
+  try {
+    localStorage.setItem("shell-online:last-terminal", window.location.href);
+  } catch {
+    // Storage may be unavailable; the account page then falls back to "/".
+  }
+
+  void refreshAccountChip();
+
+  const slashGate = requiredElement("slash-gate");
+  const slashForm = requiredElement<HTMLFormElement>("slash-form");
+  const slashEmail = requiredElement<HTMLInputElement>("slash-email");
+  const slashPassword = requiredElement<HTMLInputElement>("slash-password");
+  const slashError = requiredElement("slash-error");
+
+  // The shell redraws its prompt after the Ctrl-U that clears the typed
+  // command, so let that land before printing, or the redraw overwrites it.
+  const note = (text: string, extra: string[] = []): void => {
+    window.setTimeout(() => {
+      terminal.writeln("");
+      terminal.writeln(`\u001b[38;5;114m${text}\u001b[0m`);
+      for (const line of extra) terminal.writeln(line);
+    }, 90);
+  };
+
+  const closeSlashGate = (): void => {
+    slashGate.hidden = true;
+    slashError.hidden = true;
+    slashForm.reset();
+    terminal.focus();
+  };
+
+  const submitSlashAuth = async (path: string): Promise<void> => {
+    slashError.hidden = true;
+    try {
+      const response = await fetch(path, {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: slashEmail.value, password: slashPassword.value }),
+      });
+      if (response.ok) {
+        const me = await response.json() as { email?: string };
+        closeSlashGate();
+        note(`Signed in as ${me.email ?? "your account"}. Type /save to keep this link.`);
+        void refreshAccountChip();
+        return;
+      }
+      slashError.textContent = ((await response.json()) as { error?: string }).error ?? "Could not sign in.";
+      slashError.hidden = false;
+    } catch {
+      slashError.textContent = "Could not reach the relay.";
+      slashError.hidden = false;
+    }
+  };
+
+  slashForm.addEventListener("submit", (event) => { event.preventDefault(); void submitSlashAuth("/api/account/login"); });
+  requiredElement<HTMLButtonElement>("slash-create")
+    .addEventListener("click", () => { void submitSlashAuth("/api/account/register"); });
+  requiredElement<HTMLButtonElement>("slash-cancel")
+    .addEventListener("click", () => { closeSlashGate(); });
+
+  /** Returns true when the input was a slash command and must not reach the shell. */
+  function runSlashCommand(command: string): boolean {
+    switch (command) {
+      case "/login":
+        slashGate.hidden = false;
+        slashEmail.focus();
+        return true;
+      case "/logout":
+        void fetch("/api/account/logout", { method: "POST", credentials: "same-origin" })
+          .then(() => { note("Signed out."); void refreshAccountChip(); });
+        return true;
+      case "/save":
+        void (async () => {
+          const me = await fetch("/api/account/me", { credentials: "same-origin" }).then((r) => r.json())
+            .catch(() => ({})) as { signedIn?: boolean };
+          if (!me.signedIn) { note("Not signed in. Type /login first."); return; }
+          const response = await fetch("/api/account/links", {
+            method: "POST",
+            credentials: "same-origin",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ session_id: sessionId, label: document.title.replace(" — shell.online", "") }),
+          });
+          note(response.ok ? "Saved this link to your account." : "Could not save this link.");
+          void refreshAccountChip();
+        })();
+        return true;
+      case "/links":
+        void (async () => {
+          const response = await fetch("/api/account/links", { credentials: "same-origin" });
+          if (!response.ok) { note("Not signed in. Type /login first."); return; }
+          const links = ((await response.json()) as { links?: Array<{ label: string; status: string }> }).links ?? [];
+          if (links.length === 0) { note("No saved links yet."); return; }
+          note(
+            `${links.length} saved link${links.length === 1 ? "" : "s"}:`,
+            links.slice(0, 20).map((link) => `  \u001b[38;5;245m${link.status.padEnd(13)}\u001b[0m${link.label}`),
+          );
+        })();
+        return true;
+      case "/account":
+        window.open("/account/", "_blank", "noreferrer");
+        note("Opened your account page in a new tab.");
+        return true;
+      case "/help":
+        note("Browser commands (never sent to the shell):", [
+          "  \u001b[38;5;245m/login   \u001b[0msign in to an optional account",
+          "  \u001b[38;5;245m/logout  \u001b[0msign out",
+          "  \u001b[38;5;245m/save    \u001b[0msave this link to your account",
+          "  \u001b[38;5;245m/links   \u001b[0mlist your saved links",
+          "  \u001b[38;5;245m/account \u001b[0mopen the account page",
+        ]);
+        return true;
+      default:
+        return false;
+    }
+  }
   const copyButton = requiredElement<HTMLButtonElement>("settings-copy-link");
   const settingsButton = requiredElement<HTMLButtonElement>("settings-open");
   const settingsDialog = requiredElement<HTMLDialogElement>("terminal-settings");

--- a/web/main.ts
+++ b/web/main.ts
@@ -1,4 +1,5 @@
 import { FitAddon } from "@xterm/addon-fit";
+import { rememberLinkFragment } from "./link-fragments";
 import { renderAccountPage } from "./account";
 import { Terminal, type ITheme } from "@xterm/xterm";
 import {
@@ -1147,6 +1148,9 @@ function renderTerminal(sessionId: string): void {
           body: JSON.stringify({ session_id: sessionId, label: document.title.replace(" — shell.online", "") }),
         });
         if (response.ok) {
+          // The key lives in the fragment and never reaches the relay, so keep
+          // it here; the account page stitches it back onto the saved link.
+          rememberLinkFragment(sessionId, window.location.hash);
           accountSave.textContent = "Saved";
           accountSave.classList.add("is-saved");
         } else {
@@ -1245,6 +1249,7 @@ function renderTerminal(sessionId: string): void {
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ session_id: sessionId, label: document.title.replace(" — shell.online", "") }),
           });
+          if (response.ok) rememberLinkFragment(sessionId, window.location.hash);
           note(response.ok ? "Saved this link to your account." : "Could not save this link.");
           void refreshAccountChip();
         })();

--- a/web/style.css
+++ b/web/style.css
@@ -2394,3 +2394,215 @@ a {
     height: 38px;
   }
 }
+/* Optional account controls in the session header. Small, unobtrusive, and
+   never in the way of a share: signing in is not required for anything. */
+.account-chip {
+  display: inline-flex;
+  min-height: 20px;
+  padding: 0 9px;
+  border: 1px solid #315d50;
+  border-radius: 999px;
+  background: #14251f;
+  color: #83d2b5;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  align-items: center;
+  white-space: nowrap;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+.account-chip:hover {
+  border-color: #4a8371;
+  background: #18302a;
+}
+.account-chip.account-save {
+  border-color: #3a4559;
+  background: #1a202b;
+  color: #aebbd1;
+  font-family: inherit;
+}
+.account-chip.account-save:hover { border-color: #55637d; }
+.account-chip.is-saved { color: #83d2b5; border-color: #315d50; }
+
+
+.theme-light .account-chip {
+  border-color: #bcd8cd;
+  background: #eaf5f0;
+  color: #2f6f5c;
+}
+.theme-light .account-chip:hover { border-color: #93c4b3; background: #e0f0e9; }
+.theme-light .account-chip.account-save {
+  border-color: #ccd3e2;
+  background: #f4f6fa;
+  color: #46536e;
+}
+.theme-light .account-chip.account-save:hover { border-color: #a9b6cd; }
+.theme-light .account-chip.is-saved { border-color: #bcd8cd; color: #2f6f5c; }
+
+/* ---- Optional account page ------------------------------------------- */
+.account-shell {
+  min-height: 100%;
+  background: #f3f1e9;
+  color: #1f2b45;
+  font-family: "Uncut Sans", system-ui, sans-serif;
+}
+.account-topbar {
+  display: flex;
+  max-width: 780px;
+  margin: 0 auto;
+  padding: 26px 24px 0;
+  align-items: center;
+  justify-content: space-between;
+}
+.account-exit {
+  padding: 6px 13px;
+  border: 1px solid #d5d8cd;
+  border-radius: 999px;
+  background: #fbfaf6;
+  color: #5b6478;
+  font-size: 12px;
+  font-weight: 600;
+  text-decoration: none;
+}
+.account-exit:hover { border-color: #b3b8a9; color: #2c3450; }
+.account-main { max-width: 780px; margin: 0 auto; padding: 26px 24px 72px; display: grid; gap: 28px; }
+.account-hero h1 { margin: 0 0 8px; font-size: 30px; font-weight: 560; letter-spacing: -0.03em; }
+.account-hero p { margin: 0; max-width: 56ch; color: #5b6478; font-size: 15px; line-height: 1.6; }
+.account-muted { margin: 0; color: #6a7488; font-size: 14px; line-height: 1.6; }
+.account-eyebrow {
+  display: block; color: #8a92a4; font-size: 10px; font-weight: 700;
+  letter-spacing: 0.1em; text-transform: uppercase;
+}
+.account-card {
+  padding: 18px; border: 1px solid #e2e1d6; border-radius: 14px;
+  background: #fbfaf6; box-shadow: 0 1px 2px rgb(31 43 69 / 4%);
+}
+.account-idbar {
+  display: flex; padding: 16px 18px; border: 1px solid #e2e1d6; border-radius: 14px;
+  background: #fbfaf6; align-items: center; justify-content: space-between; gap: 16px;
+}
+.account-idbar strong { font-size: 15px; }
+.account-section { display: grid; gap: 12px; }
+.account-section h2 { margin: 0; font-size: 15px; font-weight: 620; letter-spacing: -0.01em; }
+.account-section-head { display: flex; align-items: center; justify-content: space-between; }
+.account-form { display: grid; gap: 12px; }
+.account-field { display: grid; gap: 5px; }
+.account-field label { color: #5b6478; font-size: 12px; font-weight: 600; }
+.account-field input {
+  padding: 9px 11px; border: 1px solid #d8dae0; border-radius: 9px;
+  background: #fff; color: #1f2b45; font: inherit; font-size: 14px;
+}
+.account-field input:focus { border-color: #6f9e8c; outline: 2px solid #dcefe7; }
+.account-row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+.btn {
+  padding: 8px 14px; border: 1px solid #d2d5dd; border-radius: 9px; background: #fff;
+  color: #33415e; font: inherit; font-size: 13px; font-weight: 600; text-decoration: none; cursor: pointer;
+}
+.btn:hover { border-color: #a8aebd; }
+.btn-small { padding: 5px 10px; font-size: 12px; }
+.btn-primary { border-color: #2f6f5c; background: #2f6f5c; color: #f2fbf7; }
+.btn-primary:hover { background: #27604f; border-color: #27604f; }
+.btn-danger { border-color: #c9a49c; background: #fff; color: #9c3f2e; }
+.btn-danger:hover { border-color: #a2402f; background: #fdf4f2; }
+.account-error, .account-inline-msg.is-bad { color: #9c3f2e; font-size: 13px; }
+.account-inline-msg { color: #2f6f5c; font-size: 13px; font-weight: 600; }
+.account-danger-head { color: #9c3f2e; }
+.account-danger { border-color: #ecd9d3; background: #fdf8f6; display: grid; gap: 12px; }
+.account-links { display: grid; gap: 10px; }
+.account-link {
+  display: grid; gap: 9px; padding: 14px;
+  border: 1px solid #e2e1d6; border-radius: 14px; background: #fbfaf6;
+}
+.account-link-top { display: flex; gap: 10px; align-items: center; }
+.account-pill {
+  padding: 2px 9px; border-radius: 999px; font-size: 10px;
+  font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;
+}
+.account-link.is-live .account-pill { background: #dff1e9; color: #2f6f5c; }
+.account-link.is-dead .account-pill { background: #ecedef; color: #78849c; }
+.account-link-label { font-size: 14px; font-weight: 620; }
+.account-link-age { margin-left: auto; color: #8a92a4; font-size: 12px; }
+.account-link-url {
+  overflow-x: auto; padding: 7px 9px; border-radius: 8px;
+  background: #f1f0ea; color: #46536e; font-size: 12px; white-space: nowrap;
+}
+@media (max-width: 560px) {
+  .account-hero h1 { font-size: 24px; }
+  .account-idbar { flex-direction: column; align-items: flex-start; }
+}
+
+/* Slash-command sign-in overlay inside the terminal. */
+.slash-actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 6px; }
+.slash-error { margin-top: 6px; color: #d08b7d; font-size: 13px; }
+.theme-light .slash-error { color: #9c3f2e; }
+
+.account-topbar-right { display: flex; gap: 10px; align-items: center; }
+.account-whoami { color: #6a7488; font-size: 13px; }
+.account-whoami strong { color: #1f2b45; font-weight: 620; }
+.account-h1 { margin: 0; font-size: 22px; font-weight: 560; letter-spacing: -0.02em; }
+@media (max-width: 560px) { .account-whoami { display: none; } }
+
+/* Settings overlay on the account page. */
+.account-sheet {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: grid;
+  padding: 24px;
+  background: rgb(31 43 69 / 28%);
+  backdrop-filter: blur(3px);
+  place-items: start center;
+  overflow-y: auto;
+}
+.account-sheet[hidden] { display: none; }
+.account-sheet-panel {
+  display: grid;
+  gap: 16px;
+  width: min(440px, 100%);
+  margin-top: 8vh;
+  padding: 20px;
+  border: 1px solid #e2e1d6;
+  border-radius: 16px;
+  background: #fbfaf6;
+  box-shadow: 0 26px 70px rgb(31 43 69 / 22%);
+}
+.account-sheet-head { display: flex; align-items: center; justify-content: space-between; }
+.account-sheet-head h2 { margin: 0; font-size: 17px; font-weight: 620; }
+.account-sheet-divider { height: 1px; background: #e6e5da; }
+.account-sheet-panel .account-danger {
+  display: grid; gap: 12px; padding: 14px;
+  border: 1px solid #ecd9d3; border-radius: 12px; background: #fdf8f6;
+}
+
+/* The hidden attribute must win over the chip's own display value. */
+.account-chip[hidden] { display: none !important; }
+
+/* The session header is tight on phones: keep a compact way in to the account
+   and drop the save chip, which is reachable from the account page and /save. */
+@media (max-width: 760px) {
+  .account-chip { padding: 0 7px; font-size: 9px; }
+  .account-chip.account-save { display: none; }
+}
+@media (max-width: 460px) {
+  .account-chip { display: none; }
+}
+
+/* Account row at the top of the Controls panel. On wide screens the header
+   chips already cover this, so it only appears once the chips drop away. */
+.settings-card.account-card { display: none; margin-bottom: 12px; }
+.account-card-state {
+  overflow: hidden;
+  max-width: 55%;
+  color: #8a92a4;
+  font-size: 11px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.account-card-actions { display: flex; gap: 8px; margin-top: 10px; flex-wrap: wrap; }
+.account-card-actions .btn { text-decoration: none; }
+@media (max-width: 760px) {
+  .settings-card.account-card { display: block; }
+}

--- a/web/style.css
+++ b/web/style.css
@@ -2606,3 +2606,9 @@ a {
 @media (max-width: 760px) {
   .settings-card.account-card { display: block; }
 }
+.account-key-note {
+  margin: 0;
+  color: #8a6d3b;
+  font-size: 12px;
+  line-height: 1.5;
+}

--- a/worker/account-auth.ts
+++ b/worker/account-auth.ts
@@ -1,0 +1,176 @@
+/**
+ * Optional accounts: password hashing and signed session cookies.
+ *
+ * Deliberately mirrors worker/stats-auth.ts so both auth surfaces behave the
+ * same way. Accounts are never required to create, open, or use a share.
+ */
+const COOKIE_NAME = "shell_account_session";
+const SESSION_TTL_SECONDS = 30 * 24 * 60 * 60;
+const TOKEN_VERSION = "a1";
+const PBKDF2_ITERATIONS = 210_000;
+const SALT_BYTES = 16;
+const KEY_BYTES = 32;
+
+export const ACCOUNT_COOKIE_NAME = COOKIE_NAME;
+
+interface AccountSessionPayload {
+  accountId: string;
+  issuedAt: number;
+  expiresAt: number;
+}
+
+const encoder = new TextEncoder();
+
+function encodeBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function decodeBase64Url(value: string): Uint8Array<ArrayBuffer> {
+  const padded = value.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(padded + "=".repeat((4 - (padded.length % 4)) % 4));
+  const bytes = new Uint8Array(new ArrayBuffer(binary.length));
+  for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
+  return bytes;
+}
+
+function constantTimeEqual(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.length !== right.length) return false;
+  let difference = 0;
+  for (let index = 0; index < left.length; index += 1) difference |= left[index] ^ right[index];
+  return difference === 0;
+}
+
+export function randomHex(byteCount: number): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(byteCount));
+  return [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/** PBKDF2-HMAC-SHA256, per-account salt. Returns salt and hash as base64url. */
+export async function hashPassword(
+  password: string,
+  existingSalt?: string,
+): Promise<{ salt: string; hash: string }> {
+  const salt: Uint8Array<ArrayBuffer> = existingSalt
+    ? decodeBase64Url(existingSalt)
+    : crypto.getRandomValues(new Uint8Array(new ArrayBuffer(SALT_BYTES)));
+  const material = await crypto.subtle.importKey("raw", encoder.encode(password), "PBKDF2", false, [
+    "deriveBits",
+  ]);
+  const bits = await crypto.subtle.deriveBits(
+    { name: "PBKDF2", salt, iterations: PBKDF2_ITERATIONS, hash: "SHA-256" },
+    material,
+    KEY_BYTES * 8,
+  );
+  return { salt: encodeBase64Url(salt), hash: encodeBase64Url(new Uint8Array(bits)) };
+}
+
+export async function verifyPassword(
+  password: string,
+  salt: string,
+  expectedHash: string,
+): Promise<boolean> {
+  try {
+    const { hash } = await hashPassword(password, salt);
+    return constantTimeEqual(decodeBase64Url(hash), decodeBase64Url(expectedHash));
+  } catch {
+    return false;
+  }
+}
+
+async function sign(message: string, secret: string): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  return new Uint8Array(await crypto.subtle.sign("HMAC", key, encoder.encode(message)));
+}
+
+export async function createAccountSession(
+  accountId: string,
+  secret: string,
+  now = Date.now(),
+): Promise<string> {
+  const payload: AccountSessionPayload = {
+    accountId,
+    issuedAt: now,
+    expiresAt: now + SESSION_TTL_SECONDS * 1_000,
+  };
+  const encoded = encodeBase64Url(encoder.encode(JSON.stringify(payload)));
+  const message = `${TOKEN_VERSION}.${encoded}`;
+  return `${message}.${encodeBase64Url(await sign(message, secret))}`;
+}
+
+/** Returns the account id when the cookie is authentic and unexpired. */
+export async function readAccountSession(
+  token: string | null,
+  secret: string,
+  now = Date.now(),
+): Promise<string | null> {
+  if (!token || secret.length < 12 || token.length > 2_048) return null;
+  const parts = token.split(".");
+  if (parts.length !== 3 || parts[0] !== TOKEN_VERSION) return null;
+  let payload: AccountSessionPayload;
+  let signature: Uint8Array;
+  try {
+    signature = decodeBase64Url(parts[2]);
+    payload = JSON.parse(new TextDecoder().decode(decodeBase64Url(parts[1]))) as AccountSessionPayload;
+  } catch {
+    return null;
+  }
+  const expected = await sign(`${parts[0]}.${parts[1]}`, secret);
+  if (!constantTimeEqual(signature, expected)) return null;
+  if (typeof payload.accountId !== "string" || !payload.accountId) return null;
+  if (typeof payload.expiresAt !== "number" || now >= payload.expiresAt) return null;
+  return payload.accountId;
+}
+
+export function accountCookie(token: string, secure: boolean): string {
+  return [
+    `${COOKIE_NAME}=${token}`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Strict",
+    `Max-Age=${SESSION_TTL_SECONDS}`,
+    secure ? "Secure" : "",
+  ].filter(Boolean).join("; ");
+}
+
+export function clearedAccountCookie(secure: boolean): string {
+  return [
+    `${COOKIE_NAME}=`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Strict",
+    "Max-Age=0",
+    secure ? "Secure" : "",
+  ].filter(Boolean).join("; ");
+}
+
+export function readCookie(request: Request, name: string): string | null {
+  const header = request.headers.get("Cookie");
+  if (!header) return null;
+  for (const part of header.split(";")) {
+    const [key, ...rest] = part.trim().split("=");
+    if (key === name) return rest.join("=");
+  }
+  return null;
+}
+
+export function normalizeEmail(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const email = value.trim().toLowerCase();
+  if (email.length < 3 || email.length > 254) return null;
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return null;
+  return email;
+}
+
+export function validatePassword(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  if (value.length < 8 || value.length > 256) return null;
+  return value;
+}

--- a/worker/accounts-store.ts
+++ b/worker/accounts-store.ts
@@ -1,0 +1,127 @@
+import { DurableObject } from "cloudflare:workers";
+import { hashPassword, randomHex, verifyPassword } from "./account-auth";
+
+export interface AccountRecord {
+  id: string;
+  email: string;
+}
+
+export interface SavedLink {
+  session_id: string;
+  label: string;
+  saved_at: number;
+}
+
+/**
+ * Single-instance SQLite store for optional accounts and the links they save.
+ *
+ * Shares themselves are untouched by this: a session works exactly the same
+ * whether or not anyone has an account, and nothing here is on the hot path.
+ */
+export class AccountsStore extends DurableObject<Record<string, never>> {
+  private readonly sql: SqlStorage;
+
+  constructor(state: DurableObjectState, env: Record<string, never>) {
+    super(state, env);
+    this.sql = state.storage.sql;
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS accounts (
+        id TEXT PRIMARY KEY,
+        email TEXT NOT NULL UNIQUE,
+        password_salt TEXT NOT NULL,
+        password_hash TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+    `);
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS account_links (
+        account_id TEXT NOT NULL,
+        session_id TEXT NOT NULL,
+        label TEXT NOT NULL DEFAULT '',
+        saved_at INTEGER NOT NULL,
+        PRIMARY KEY (account_id, session_id)
+      );
+    `);
+  }
+
+  async register(email: string, password: string): Promise<{ ok: true; account: AccountRecord } | { ok: false; error: string }> {
+    const existing = [...this.sql.exec("SELECT id FROM accounts WHERE email = ?", email)];
+    if (existing.length > 0) return { ok: false, error: "email already registered" };
+    const { salt, hash } = await hashPassword(password);
+    const id = randomHex(16);
+    this.sql.exec(
+      "INSERT INTO accounts (id, email, password_salt, password_hash, created_at) VALUES (?, ?, ?, ?, ?)",
+      id, email, salt, hash, Date.now(),
+    );
+    return { ok: true, account: { id, email } };
+  }
+
+  async login(email: string, password: string): Promise<AccountRecord | null> {
+    const rows = [...this.sql.exec(
+      "SELECT id, email, password_salt, password_hash FROM accounts WHERE email = ?", email,
+    )] as unknown as Array<{ id: string; email: string; password_salt: string; password_hash: string }>;
+    if (rows.length === 0) {
+      // Spend comparable time so a missing address is not obvious from timing.
+      await hashPassword(password);
+      return null;
+    }
+    const row = rows[0];
+    const valid = await verifyPassword(password, row.password_salt, row.password_hash);
+    return valid ? { id: row.id, email: row.email } : null;
+  }
+
+  async accountById(id: string): Promise<AccountRecord | null> {
+    const rows = [...this.sql.exec("SELECT id, email FROM accounts WHERE id = ?", id)] as unknown as AccountRecord[];
+    return rows.length > 0 ? rows[0] : null;
+  }
+
+  async updateEmail(accountId: string, email: string): Promise<{ ok: boolean; error?: string }> {
+    const taken = [...this.sql.exec("SELECT id FROM accounts WHERE email = ? AND id != ?", email, accountId)];
+    if (taken.length > 0) return { ok: false, error: "email already registered" };
+    this.sql.exec("UPDATE accounts SET email = ? WHERE id = ?", email, accountId);
+    return { ok: true };
+  }
+
+  async updatePassword(accountId: string, currentPassword: string, nextPassword: string): Promise<{ ok: boolean; error?: string }> {
+    const rows = [...this.sql.exec(
+      "SELECT password_salt, password_hash FROM accounts WHERE id = ?", accountId,
+    )] as unknown as Array<{ password_salt: string; password_hash: string }>;
+    if (rows.length === 0) return { ok: false, error: "account not found" };
+    const valid = await verifyPassword(currentPassword, rows[0].password_salt, rows[0].password_hash);
+    if (!valid) return { ok: false, error: "current password is incorrect" };
+    const { salt, hash } = await hashPassword(nextPassword);
+    this.sql.exec("UPDATE accounts SET password_salt = ?, password_hash = ? WHERE id = ?", salt, hash, accountId);
+    return { ok: true };
+  }
+
+  /** Removes the account and every link it saved. Shares themselves keep running. */
+  async deleteAccount(accountId: string, password: string): Promise<{ ok: boolean; error?: string }> {
+    const rows = [...this.sql.exec(
+      "SELECT password_salt, password_hash FROM accounts WHERE id = ?", accountId,
+    )] as unknown as Array<{ password_salt: string; password_hash: string }>;
+    if (rows.length === 0) return { ok: false, error: "account not found" };
+    const valid = await verifyPassword(password, rows[0].password_salt, rows[0].password_hash);
+    if (!valid) return { ok: false, error: "password is incorrect" };
+    this.sql.exec("DELETE FROM account_links WHERE account_id = ?", accountId);
+    this.sql.exec("DELETE FROM accounts WHERE id = ?", accountId);
+    return { ok: true };
+  }
+
+  async saveLink(accountId: string, sessionId: string, label: string): Promise<void> {
+    this.sql.exec(
+      "INSERT OR REPLACE INTO account_links (account_id, session_id, label, saved_at) VALUES (?, ?, ?, ?)",
+      accountId, sessionId, label.slice(0, 120), Date.now(),
+    );
+  }
+
+  async removeLink(accountId: string, sessionId: string): Promise<void> {
+    this.sql.exec("DELETE FROM account_links WHERE account_id = ? AND session_id = ?", accountId, sessionId);
+  }
+
+  async listLinks(accountId: string): Promise<SavedLink[]> {
+    return [...this.sql.exec(
+      "SELECT session_id, label, saved_at FROM account_links WHERE account_id = ? ORDER BY saved_at DESC LIMIT 200",
+      accountId,
+    )] as unknown as SavedLink[];
+  }
+}

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1721,17 +1721,21 @@ async function handleAccountRequest(request: Request, env: Env, url: URL): Promi
       const saved = await store.listLinks(id);
       const links = await Promise.all(saved.map(async (link) => {
         let status = "unknown";
+        let encrypted = false;
         try {
           const response = await env.SESSIONS.getByName(link.session_id).fetch(
             "https://session.internal/internal/status",
           );
           if (response.status === 404) status = "ended";
           else if (response.ok) {
-            const meta = await response.json() as { exists?: boolean; status?: string };
+            const meta = await response.json() as { exists?: boolean; status?: string; encrypted?: boolean };
             status = meta.exists ? (meta.status ?? "unknown") : "ended";
+            encrypted = meta.encrypted === true;
           }
         } catch { status = "unknown"; }
-        return { ...link, status, share_url: `${url.origin}/s/${link.session_id}` };
+        // The share URL is returned without a fragment on purpose: the relay
+        // never holds the decryption key. The browser adds it back if it has it.
+        return { ...link, status, encrypted, share_url: `${url.origin}/s/${link.session_id}` };
       }));
       return json({ links });
     }

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,4 +1,15 @@
 import { DurableObject } from "cloudflare:workers";
+import type { AccountsStore } from "./accounts-store";
+import {
+  accountCookie,
+  ACCOUNT_COOKIE_NAME,
+  clearedAccountCookie,
+  createAccountSession,
+  normalizeEmail,
+  readAccountSession,
+  readCookie,
+  validatePassword,
+} from "./account-auth";
 import { decodeResize, Opcode } from "../shared/protocol";
 import {
   binaryDownloadTarget,
@@ -43,6 +54,7 @@ import {
 } from "./stats-auth";
 
 export { StatsStore };
+export { AccountsStore } from "./accounts-store";
 
 const MAX_VIEWERS = 16;
 const MAX_LIVE_FRAME_BYTES = 64 * 1024;
@@ -77,6 +89,8 @@ interface Env {
   EVENT_LIMITER: RateLimitBinding;
   STATS_AUTH_LIMITER: RateLimitBinding;
   STATS_PASSWORD: string;
+  ACCOUNTS: DurableObjectNamespace<AccountsStore>;
+  ACCOUNT_SECRET: string;
   ANALYTICS: AnalyticsEngineDataset;
   ASSETS: Fetcher;
 }
@@ -190,6 +204,10 @@ export default {
       return env.SESSIONS.getByName(sessionStatusRoute[1]).fetch(
         "https://session.internal/internal/status",
       );
+    }
+
+    if (url.pathname.startsWith("/api/account/")) {
+      return handleAccountRequest(request, env, url);
     }
 
     if (url.pathname === "/api/events" && request.method === "POST") {
@@ -1578,6 +1596,7 @@ function secureAssetResponse(response: Response, pathname: string, hostname: str
   headers.set("X-Frame-Options", "DENY");
   if (
     pathname.startsWith("/s/") ||
+    pathname.startsWith("/account") ||
     pathname.startsWith("/downloads/") ||
     pathname === "/install" ||
     pathname === "/skill" ||
@@ -1595,10 +1614,149 @@ function secureAssetResponse(response: Response, pathname: string, hostname: str
     headers.set("Content-Disposition", "attachment; filename=\"SKILL.md\"");
     headers.set("Cache-Control", "public, max-age=300");
   }
-  if (isPublicDocumentPath(pathname) || pathname.startsWith("/s/") || isStatsHostname(hostname)) {
+  if (isPublicDocumentPath(pathname) || pathname.startsWith("/s/") || pathname.startsWith("/account") || isStatsHostname(hostname)) {
     headers.set("Cache-Control", "no-store");
   }
   return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
+}
+
+/** Optional accounts. Never required to create, open, or use a share. */
+async function handleAccountRequest(request: Request, env: Env, url: URL): Promise<Response> {
+  const secure = url.protocol === "https:";
+  const secret = env.ACCOUNT_SECRET ?? "";
+  if (secret.length < 12) {
+    return json({ error: "accounts are not configured on this relay" }, 503);
+  }
+  const store = env.ACCOUNTS.getByName("accounts");
+  const currentAccountId = async (): Promise<string | null> =>
+    readAccountSession(readCookie(request, ACCOUNT_COOKIE_NAME), secret);
+
+  if (url.pathname === "/api/account/register" && request.method === "POST") {
+    const ip = request.headers.get("CF-Connecting-IP") ?? "local";
+    if (!(await env.STATS_AUTH_LIMITER.limit({ key: `account-register:${ip}` })).success) {
+      return json({ error: "too many attempts" }, 429);
+    }
+    let body: { email?: unknown; password?: unknown };
+    try { body = await request.json(); } catch { return json({ error: "invalid body" }, 400); }
+    const email = normalizeEmail(body.email);
+    const password = validatePassword(body.password);
+    if (!email) return json({ error: "enter a valid email address" }, 400);
+    if (!password) return json({ error: "password must be at least 8 characters" }, 400);
+    const result = await store.register(email, password);
+    if (!result.ok) return json({ error: result.error }, 409);
+    const token = await createAccountSession(result.account.id, secret);
+    return json({ email: result.account.email }, 200, { "Set-Cookie": accountCookie(token, secure) });
+  }
+
+  if (url.pathname === "/api/account/login" && request.method === "POST") {
+    const ip = request.headers.get("CF-Connecting-IP") ?? "local";
+    if (!(await env.STATS_AUTH_LIMITER.limit({ key: `account-login:${ip}` })).success) {
+      return json({ error: "too many attempts" }, 429);
+    }
+    let body: { email?: unknown; password?: unknown };
+    try { body = await request.json(); } catch { return json({ error: "invalid body" }, 400); }
+    const email = normalizeEmail(body.email);
+    const password = validatePassword(body.password);
+    if (!email || !password) return json({ error: "incorrect email or password" }, 401);
+    const account = await store.login(email, password);
+    if (!account) return json({ error: "incorrect email or password" }, 401);
+    const token = await createAccountSession(account.id, secret);
+    return json({ email: account.email }, 200, { "Set-Cookie": accountCookie(token, secure) });
+  }
+
+  if (url.pathname === "/api/account/logout" && request.method === "POST") {
+    return json({ ok: true }, 200, { "Set-Cookie": clearedAccountCookie(secure) });
+  }
+
+  if (url.pathname === "/api/account/me" && request.method === "GET") {
+    const id = await currentAccountId();
+    if (!id) return json({ signedIn: false }, 200);
+    const account = await store.accountById(id);
+    if (!account) return json({ signedIn: false }, 200, { "Set-Cookie": clearedAccountCookie(secure) });
+    return json({ signedIn: true, email: account.email });
+  }
+
+  if (url.pathname === "/api/account/email" && request.method === "POST") {
+    const id = await currentAccountId();
+    if (!id) return json({ error: "sign in first" }, 401);
+    let body: { email?: unknown };
+    try { body = await request.json(); } catch { return json({ error: "invalid body" }, 400); }
+    const email = normalizeEmail(body.email);
+    if (!email) return json({ error: "enter a valid email address" }, 400);
+    const result = await store.updateEmail(id, email);
+    if (!result.ok) return json({ error: result.error ?? "could not update email" }, 409);
+    return json({ email });
+  }
+
+  if (url.pathname === "/api/account/password" && request.method === "POST") {
+    const id = await currentAccountId();
+    if (!id) return json({ error: "sign in first" }, 401);
+    let body: { current?: unknown; next?: unknown };
+    try { body = await request.json(); } catch { return json({ error: "invalid body" }, 400); }
+    const current = validatePassword(body.current);
+    const next = validatePassword(body.next);
+    if (!current || !next) return json({ error: "passwords must be at least 8 characters" }, 400);
+    const result = await store.updatePassword(id, current, next);
+    if (!result.ok) return json({ error: result.error ?? "could not update password" }, 400);
+    return json({ ok: true });
+  }
+
+  if (url.pathname === "/api/account/delete" && request.method === "POST") {
+    const id = await currentAccountId();
+    if (!id) return json({ error: "sign in first" }, 401);
+    let body: { password?: unknown };
+    try { body = await request.json(); } catch { return json({ error: "invalid body" }, 400); }
+    const password = validatePassword(body.password);
+    if (!password) return json({ error: "password is required" }, 400);
+    const result = await store.deleteAccount(id, password);
+    if (!result.ok) return json({ error: result.error ?? "could not delete account" }, 400);
+    return json({ ok: true }, 200, { "Set-Cookie": clearedAccountCookie(secure) });
+  }
+
+  if (url.pathname === "/api/account/links") {
+    const id = await currentAccountId();
+    if (!id) return json({ error: "sign in first" }, 401);
+
+    if (request.method === "GET") {
+      const saved = await store.listLinks(id);
+      const links = await Promise.all(saved.map(async (link) => {
+        let status = "unknown";
+        try {
+          const response = await env.SESSIONS.getByName(link.session_id).fetch(
+            "https://session.internal/internal/status",
+          );
+          if (response.status === 404) status = "ended";
+          else if (response.ok) {
+            const meta = await response.json() as { exists?: boolean; status?: string };
+            status = meta.exists ? (meta.status ?? "unknown") : "ended";
+          }
+        } catch { status = "unknown"; }
+        return { ...link, status, share_url: `${url.origin}/s/${link.session_id}` };
+      }));
+      return json({ links });
+    }
+
+    if (request.method === "POST") {
+      let body: { session_id?: unknown; label?: unknown };
+      try { body = await request.json(); } catch { return json({ error: "invalid body" }, 400); }
+      const sessionId = typeof body.session_id === "string" ? body.session_id : "";
+      if (!/^[A-Za-z0-9_-]{32}$/.test(sessionId)) return json({ error: "invalid session id" }, 400);
+      const label = typeof body.label === "string" ? body.label : "";
+      await store.saveLink(id, sessionId, label);
+      return json({ ok: true });
+    }
+
+    if (request.method === "DELETE") {
+      let body: { session_id?: unknown };
+      try { body = await request.json(); } catch { return json({ error: "invalid body" }, 400); }
+      const sessionId = typeof body.session_id === "string" ? body.session_id : "";
+      if (!sessionId) return json({ error: "invalid session id" }, 400);
+      await store.removeLink(id, sessionId);
+      return json({ ok: true });
+    }
+  }
+
+  return json({ error: "not found" }, 404);
 }
 
 function isPublicDocumentPath(pathname: string): boolean {


### PR DESCRIPTION
Adds an optional account so someone can keep track of the shares they care about. It is additive throughout: creating, opening, and using a link behaves exactly as it does today without one, and a relay that has not configured accounts shows no account UI at all.

`CONTRIBUTING.md` asks that the no-account, one-command model stays intact, so that is the first thing worth checking. Nothing in the session path consults an account: no route requires a cookie to create or open a share, the CLI is untouched, and a browser with no cookie sees the terminal exactly as before — only a small "Sign in" chip appears in the header. If `ACCOUNT_SECRET` is unset, `/api/account/*` answers `503` and the browser renders no account controls, which is the intended fallback rather than an error state.

## What an account does

Signing in is possible from the session header, from the Controls panel on phones, or by typing `/login` in the terminal. Once signed in you can save the current link, and the account page lists what you saved with its live status, plus change email, change password, and delete account.

Live status is read from the relay per link rather than stored, so the list cannot drift from reality.

## Backend

`worker/account-auth.ts` mirrors the existing `worker/stats-auth.ts` rather than introducing a second style: PBKDF2-HMAC-SHA256 with a per-account 16-byte salt, HMAC-SHA256 signed tokens, constant-time comparison, and `HttpOnly` / `SameSite=Strict` / `Secure` cookies. Register and login are rate-limited per IP through the existing `STATS_AUTH_LIMITER` binding under distinct keys, so no new limiter is required. A login for an unknown address still performs a hash so timing does not reveal which addresses exist.

`worker/accounts-store.ts` is a SQLite Durable Object holding two tables, `accounts` and `account_links`.

Nine endpoints live under `/api/account/`: `register`, `login`, `logout`, `me`, `links` (GET/POST/DELETE), `email`, `password`, and `delete`.

## Terminal commands

`/login`, `/logout`, `/save`, `/links`, `/account` and `/help` are intercepted in the browser and never reach the shell. Only exact matches are caught, so a real path such as `/usr/bin/env` is forwarded untouched.

## Deployment

This is the part that needs a deliberate decision, because the repository ships no wrangler configuration and these cannot be committed:

```jsonc
"durable_objects": { "bindings": [{ "name": "ACCOUNTS", "class_name": "AccountsStore" }] },
"migrations":      [{ "tag": "v2", "new_sqlite_classes": ["AccountsStore"] }],
"vars":            { "ACCOUNT_SECRET": "<a secret of at least 12 characters>" }
```

The `v2` migration adds a Durable Object class to a live namespace, so it is the main operational risk here. `ACCOUNT_SECRET` signs session cookies and should be a real secret rather than a literal in source. Both are documented in the README section this PR adds.

## Mobile

The session header has no room for extra controls on a phone, so the chips shrink below 760px and hide below 460px, and an Account card appears as the first item in the Controls panel instead. There is exactly one entry point at any width, never two.

## Checks

Everything in `CONTRIBUTING.md` passes on this branch:

```
npm run check       20 files / 76 tests, installer, docker, deploy guard, QEMU, SEO
npm run build:web
go test -race ./...  6 packages ok
go vet ./...         clean
gofmt -l ./cmd ./internal   (empty)
govulncheck          No vulnerabilities found
```

`tests/account-auth.test.ts` adds 15 tests covering salt uniqueness, verification, rejection of the wrong password and a mismatched salt, that plaintext is never stored, token round-trip, rejection of a wrong secret, a tampered payload and an expired token, cookie flags, and both validators.

Beyond the automated checks the flow was exercised end to end in a real browser on desktop and on an iPhone viewport: register, sign in, save a link, see it listed live, change email, change password, delete the account, and confirm a cookie-free browser is completely unaffected.

## Scope

Deliberately excluded: this branch contains no changes to the terminal sizing model. Some separate local work touches that area and belongs in its own pull request, since it would reverse the immutable-grid decision from 0.7.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWysY8iZ1vDmcke9v3kDFU
