### PR TITLE
Explain full viewer sessions and keep retrying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-visible changes are recorded here. Versions follow [Semantic Ve
 
 ## Unreleased
 
+### Fixed
+
+- Tell viewers when a session's 16 browser slots are full and keep retrying automatically instead of showing the same `Offline` state as an expired link.
+
 ### Added
 
 - Add LLM-assisted issue intake, pull-request diff review, changelog suggestions, and generated GitHub release notes.

--- a/shared/session-capacity.ts
+++ b/shared/session-capacity.ts
@@ -1,0 +1,20 @@
+export const MAX_SESSION_VIEWERS = 16;
+export const SESSION_FULL_CLOSE_CODE = 4005;
+export const SESSION_FULL_CLOSE_REASON = "session is full";
+
+export type ViewerAdmission =
+  | { accepted: true }
+  | { accepted: false; closeCode: number; reason: string };
+
+export function viewerAdmission(activeViewers: number): ViewerAdmission {
+  if (activeViewers < MAX_SESSION_VIEWERS) return { accepted: true };
+  return {
+    accepted: false,
+    closeCode: SESSION_FULL_CLOSE_CODE,
+    reason: SESSION_FULL_CLOSE_REASON,
+  };
+}
+
+export function isSessionFullClose(code: number): boolean {
+  return code === SESSION_FULL_CLOSE_CODE;
+}

--- a/tests/session-capacity.test.ts
+++ b/tests/session-capacity.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSessionFullClose,
+  MAX_SESSION_VIEWERS,
+  SESSION_FULL_CLOSE_CODE,
+  SESSION_FULL_CLOSE_REASON,
+  viewerAdmission,
+} from "../shared/session-capacity";
+
+describe("session viewer capacity", () => {
+  it("admits viewers until all slots are occupied", () => {
+    expect(viewerAdmission(MAX_SESSION_VIEWERS - 1)).toEqual({ accepted: true });
+  });
+
+  it("turns a full session into a browser-visible WebSocket close", () => {
+    expect(viewerAdmission(MAX_SESSION_VIEWERS)).toEqual({
+      accepted: false,
+      closeCode: SESSION_FULL_CLOSE_CODE,
+      reason: SESSION_FULL_CLOSE_REASON,
+    });
+    expect(viewerAdmission(MAX_SESSION_VIEWERS + 1).accepted).toBe(false);
+    expect(isSessionFullClose(SESSION_FULL_CLOSE_CODE)).toBe(true);
+    expect(isSessionFullClose(4000)).toBe(false);
+    expect(isSessionFullClose(4004)).toBe(false);
+  });
+});

--- a/web/main.ts
+++ b/web/main.ts
@@ -17,6 +17,10 @@ import {
   Opcode,
 } from "../shared/protocol";
 import { readOnlyFromControlMessage } from "../shared/session-access";
+import {
+  isSessionFullClose,
+  MAX_SESSION_VIEWERS,
+} from "../shared/session-capacity";
 import { RELEASE_CHECKSUMS_PATH, RELEASE_VERSION } from "../shared/release";
 import {
   formatGitHubStarCount,
@@ -925,7 +929,7 @@ function renderTerminal(sessionId: string): void {
           <span id="session-label">terminal</span>
           <span id="session-access" class="session-access" hidden>View only</span>
           <span id="session-encryption" class="session-access encryption" hidden>End-to-end encrypted</span>
-          <span id="session-status" class="status offline"><i></i><b>Offline</b></span>
+          <span id="session-status" class="status offline" role="status" aria-live="polite"><i></i><b>Offline</b></span>
           <span id="typing-status" class="typing-status" hidden></span>
         </div>
         <div class="session-actions">
@@ -1162,6 +1166,7 @@ function renderTerminal(sessionId: string): void {
   let encryptedSession = false;
   let persistentSession = false;
   let waitingForEncryptionKey = false;
+  let waitingForCapacity = false;
   let outgoingFrames = Promise.resolve();
   let incomingFrames = Promise.resolve();
 
@@ -1402,12 +1407,18 @@ function renderTerminal(sessionId: string): void {
 
   const renderConnectionStatus = (): void => {
     const online = lastStatus === "connected" && latencyMilliseconds !== null;
+    const waitingForSlot = lastStatus === "full";
+    const offlineLabel = waitingForSlot ? "Full · waiting" : "Offline";
     statusElement.className = `status ${online ? "connected" : "offline"} state-${lastStatus}`;
     statusElement.setAttribute(
       "aria-label",
-      online ? `${latencyMilliseconds} millisecond round-trip latency to the shared machine` : "Offline",
+      online
+        ? `${latencyMilliseconds} millisecond round-trip latency to the shared machine`
+        : waitingForSlot
+          ? `Session full; waiting for one of ${MAX_SESSION_VIEWERS} viewer slots`
+          : "Offline",
     );
-    if (statusText) statusText.textContent = online ? `${latencyMilliseconds} ms` : "Offline";
+    if (statusText) statusText.textContent = online ? `${latencyMilliseconds} ms` : offlineLabel;
     renderLatencyGraph();
   };
 
@@ -1576,7 +1587,22 @@ function renderTerminal(sessionId: string): void {
     setStatus("exited");
   };
 
-  const retryOrShowMissing = async (): Promise<void> => {
+  const showSessionFull = (): void => {
+    if (!waitingForCapacity) {
+      waitingForCapacity = true;
+      sessionPage.classList.add("session-full");
+      terminal.options.disableStdin = true;
+      terminal.blur();
+      helperTextarea?.blur();
+      terminalWrites.enqueue(textEncoder.encode(
+        "\x1b[2J\x1b[H\r\n  \x1b[1;37mSession is full.\x1b[0m" +
+        `\r\n  \x1b[90m${MAX_SESSION_VIEWERS} viewers are connected. You will join automatically when a slot opens.\x1b[0m\r\n`,
+      ), true);
+    }
+    setStatus("full");
+  };
+
+  const retryOrShowMissing = async (retryStatus = "disconnected"): Promise<void> => {
     try {
       const response = await fetch(`/api/sessions/${sessionId}`, {
         cache: "no-store",
@@ -1591,7 +1617,7 @@ function renderTerminal(sessionId: string): void {
     }
 
     if (stopped) return;
-    setStatus("disconnected");
+    setStatus(retryStatus);
     const delay = Math.min(10_000, 500 * 2 ** retryAttempt) + Math.random() * 250;
     retryAttempt += 1;
     retryTimer = window.setTimeout(connect, delay);
@@ -1599,16 +1625,15 @@ function renderTerminal(sessionId: string): void {
 
   const connect = (): void => {
     if (stopped) return;
-    setStatus("connecting");
+    setStatus(waitingForCapacity ? "full" : "connecting");
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
     socket = new WebSocket(`${protocol}//${window.location.host}/api/sessions/${sessionId}/ws`);
     socket.binaryType = "arraybuffer";
 
     socket.addEventListener("open", () => {
-      retryAttempt = 0;
       terminalInput.flush();
       scheduleFit();
-      if (!compactSessionQuery.matches && !readOnly) terminal.focus();
+      if (!waitingForCapacity && !compactSessionQuery.matches && !readOnly) terminal.focus();
     });
 
     socket.addEventListener("message", (event: MessageEvent<string | ArrayBuffer>) => {
@@ -1663,6 +1688,11 @@ function renderTerminal(sessionId: string): void {
         showEndedSession();
         return;
       }
+      if (isSessionFullClose(event.code)) {
+        showSessionFull();
+        void retryOrShowMissing("full");
+        return;
+      }
       if (waitingForEncryptionKey || stopped || lastStatus === "exited") return;
       setStatus("disconnected");
       void retryOrShowMissing();
@@ -1694,6 +1724,12 @@ function renderTerminal(sessionId: string): void {
     } catch {
       return;
     }
+
+    // Any server message means this retry was admitted. The next snapshot
+    // replaces the local capacity notice with the live terminal.
+    retryAttempt = 0;
+    waitingForCapacity = false;
+    sessionPage.classList.remove("session-full");
 
     const messageReadOnly = readOnlyFromControlMessage(message);
     if (messageReadOnly !== null) applyReadOnly(messageReadOnly);

--- a/web/style.css
+++ b/web/style.css
@@ -996,6 +996,15 @@ a {
   color: #7e899d;
 }
 
+.status.state-full {
+  color: #d8b879;
+}
+
+.status.state-full i {
+  background: #d7a84d;
+  box-shadow: 0 0 0 3px rgb(215 168 77 / 14%);
+}
+
 .typing-status {
   max-width: min(22vw, 190px);
   overflow: hidden;
@@ -1615,6 +1624,15 @@ a {
 
 .session-page.theme-light .status.offline {
   color: #6d778a;
+}
+
+.session-page.theme-light .status.state-full {
+  color: #8a641b;
+}
+
+.session-page.theme-light .status.state-full i {
+  background: #b9811c;
+  box-shadow: 0 0 0 3px rgb(185 129 28 / 12%);
 }
 
 .session-page.theme-light .status i {

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -13,6 +13,10 @@ import { isStatsRange } from "../shared/stats";
 import { RELEASE_VERSION } from "../shared/release";
 import { downloadAssetIsSpaFallback } from "../shared/download-assets";
 import { viewerFrameAction } from "../shared/session-access";
+import {
+  MAX_SESSION_VIEWERS,
+  viewerAdmission,
+} from "../shared/session-capacity";
 import { terminalGridForDevices } from "../shared/terminal-grid";
 import { persistentSessionID } from "../shared/persistent-session";
 import {
@@ -44,7 +48,6 @@ import {
 
 export { StatsStore };
 
-const MAX_VIEWERS = 16;
 const MAX_LIVE_FRAME_BYTES = 64 * 1024;
 const MAX_INPUT_FRAME_BYTES = 16 * 1024 + 1;
 const MAX_SNAPSHOT_BYTES = 512 * 1024;
@@ -857,11 +860,20 @@ export class TerminalSession extends DurableObject<Env> {
       role = "host";
     }
 
-    if (
-      role === "viewer" &&
-      this.state.getWebSockets("viewer").filter((socket) => socket.readyState === 1).length >= MAX_VIEWERS
-    ) {
-      return json({ error: "session is full" }, 429);
+    const activeViewerCount = role === "viewer"
+      ? this.state.getWebSockets("viewer").filter((socket) => socket.readyState === 1).length
+      : 0;
+    const admission = viewerAdmission(activeViewerCount);
+    if (role === "viewer" && !admission.accepted) {
+      // The browser WebSocket API hides an HTTP rejection's status and body.
+      // Complete the upgrade, then close with a reason the page can render.
+      const pair = new WebSocketPair();
+      const client = pair[0];
+      const server = pair[1];
+      server.serializeAttachment({ role: "viewer", id: 0, ended: true } satisfies SocketAttachment);
+      this.state.acceptWebSocket(server, ["rejected"]);
+      safeClose(server, admission.closeCode, admission.reason);
+      return new Response(null, { status: 101, webSocket: client });
     }
 
     if (role === "host") {
@@ -1431,10 +1443,10 @@ export class TerminalSession extends DurableObject<Env> {
         .map((socket) => readAttachment(socket)?.guestNumber)
         .filter((value): value is number => typeof value === "number"),
     );
-    for (let number = 1; number <= MAX_VIEWERS; number += 1) {
+    for (let number = 1; number <= MAX_SESSION_VIEWERS; number += 1) {
       if (!used.has(number)) return number;
     }
-    return MAX_VIEWERS;
+    return MAX_SESSION_VIEWERS;
   }
 
   private claimInputLease(


### PR DESCRIPTION
## Summary

- replace the opaque HTTP 429 at the 16-viewer cap with an accepted WebSocket that closes using dedicated code 4005
- show a distinct **Full · waiting** state and an explicit terminal notice instead of the generic Offline page
- preserve exponential retry backoff and join automatically as soon as a slot opens
- centralize the viewer limit and close-code contract for relay, browser, and tests

Closes #44.

## Verification

- `npm run check` — 20 test files / 63 tests, moderation, installer, Docker entrypoint, deploy guard, QEMU manifest, SEO
- `go test -race ./...`
- `go vet ./...`
- `npm run build:web`
- local Wrangler/Durable Object smoke: 16 viewers connected; viewer 17 received code 4005 and reason `session is full`; after one viewer disconnected, the waiting viewer connected successfully
