### PR TITLE
Harden app asset delivery

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -16,11 +16,6 @@ on:
         description: Apply pending database migrations before deploying
         type: boolean
         default: true
-  push:
-    branches: [main]
-    paths:
-      - app/**
-      - .github/workflows/deploy-app.yml
 
 permissions:
   contents: read

--- a/app/server/lib/static-files.test.ts
+++ b/app/server/lib/static-files.test.ts
@@ -47,6 +47,10 @@ describe("staticFiles", () => {
   it("lets a popup keep its opener, which Google sign-in needs", async () => {
     const response = await fetch(`${origin}/`);
     expect(response.headers.get("cross-origin-opener-policy")).toBe("same-origin-allow-popups");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(response.headers.get("x-frame-options")).toBe("DENY");
+    expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+    expect(response.headers.get("permissions-policy")).toBe("camera=(), microphone=(), geolocation=()");
   });
 
   it("caches fingerprinted assets forever and the document never", async () => {

--- a/app/server/lib/static-files.ts
+++ b/app/server/lib/static-files.ts
@@ -36,7 +36,9 @@ const TYPES: Record<string, string> = {
 const DOCUMENT_HEADERS: Record<string, string> = {
   "Cross-Origin-Opener-Policy": "same-origin-allow-popups",
   "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
   "Referrer-Policy": "no-referrer",
+  "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
 };
 
 export interface StaticFiles {

--- a/app/worker/index.test.ts
+++ b/app/worker/index.test.ts
@@ -1,0 +1,39 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it, vi } from "vitest";
+import worker, { type Env } from "./index";
+
+function environment(fetchAsset: Env["ASSETS"]["fetch"]): Env {
+  return {
+    ASSETS: { fetch: fetchAsset },
+    HYPERDRIVE: { connectionString: "postgres://unused" },
+    FIREBASE_PROJECT_ID: "test-project",
+    WEB_ORIGIN: "https://app.shell.online",
+    RELAY_URL: "https://shell.online",
+  };
+}
+
+describe("Cloudflare app assets", () => {
+  it("routes assets through the Worker in production", async () => {
+    const config = await readFile(new URL("../wrangler.jsonc", import.meta.url), "utf8");
+    expect(config).toMatch(/"run_worker_first"\s*:\s*true/);
+  });
+
+  it("adds the browser security headers to app documents", async () => {
+    const fetchAsset = vi.fn(async () =>
+      new Response("<!doctype html>", { headers: { "Content-Type": "text/html" } }),
+    );
+
+    const response = await worker.fetch(
+      new Request("https://app.shell.online/sessions/example"),
+      environment(fetchAsset),
+      { waitUntil: vi.fn() },
+    );
+
+    expect(fetchAsset).toHaveBeenCalledOnce();
+    expect(response.headers.get("Cross-Origin-Opener-Policy")).toBe("same-origin-allow-popups");
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(response.headers.get("X-Frame-Options")).toBe("DENY");
+    expect(response.headers.get("Referrer-Policy")).toBe("no-referrer");
+    expect(response.headers.get("Permissions-Policy")).toBe("camera=(), microphone=(), geolocation=()");
+  });
+});

--- a/app/worker/index.ts
+++ b/app/worker/index.ts
@@ -55,12 +55,16 @@ const RELAY_PREFIX = "/relay";
  * never resolves, so the header has to be on the document. The assets binding
  * does content types, caching and the SPA fallback but has no opinion about
  * this, so it is added on the way out; server/lib/static-files.ts sends the
- * same three headers, and vite.config.ts sends them in development.
+ * same headers, and vite.config.ts sends the popup header in development.
+ * wrangler.jsonc sets run_worker_first so Cloudflare Assets cannot bypass
+ * this function for a file that already exists.
  */
 const CLIENT_HEADERS: Record<string, string> = {
   "Cross-Origin-Opener-Policy": "same-origin-allow-popups",
   "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
   "Referrer-Policy": "no-referrer",
+  "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
 };
 
 /*

--- a/app/wrangler.jsonc
+++ b/app/wrangler.jsonc
@@ -50,6 +50,10 @@
   "assets": {
     "directory": "./dist",
     "binding": "ASSETS",
+    // Static files must pass through worker/index.ts so the browser receives
+    // the same anti-framing, referrer and popup-auth headers in production as
+    // it does from the Node and Vite servers.
+    "run_worker_first": true,
     // The client is a single page with its own router, so /sessions/abc is a
     // page rather than a file and a miss has to reach index.html.
     "not_found_handling": "single-page-application"


### PR DESCRIPTION
## What changed

- route Cloudflare static assets through the app Worker so production documents receive the intended browser security headers
- add anti-framing and permissions headers consistently to Worker and Node asset serving
- keep the credential-dependent deployment workflow manual, since this repository does not use GitHub-hosted production secrets
- add regression coverage for the Worker routing configuration and response headers

## Validation

- root test suite: 61 tests plus installer, Docker, deployment guard, QEMU manifest, SEO, and Formula checks
- app suite: 513 unit tests; 567 tests against disposable PostgreSQL 16
- Go race tests and vet
- app production build and Wrangler dry run using the existing live Cloudflare bindings
- npm audits: zero vulnerabilities
- live encrypted production session, browser input/output, local attach/detach, kill, and ended-session state
