### PR TITLE
Draw an in-app terminal at the size the process is running at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable user-visible changes are recorded here. Versions follow [Semantic Ve
 - Automatically delete unmistakably unrelated or spam issues and close equivalent pull requests only when two independent reviews agree at 98% confidence; preserve technical criticism and relevant but flawed contributions.
 - Use GitHub's current Copilot inference path rather than the retired GitHub Models endpoint.
 
+### Fixed
+
+- Draw a terminal opened in the web app at the size the process is actually running at. The pane sized the emulator to its own pixels instead, so a 120-column session was drawn at around 110 columns and 24 of its 36 rows: every long line wrapped a second time and the bottom third of anything full-screen was missing. It now scales the type to fit the session's grid, the way the standalone viewer already did, and follows that grid when a phone joins or leaves the session.
+
 ## [0.9.0] — 2026-09-08
 
 ### Added

--- a/app/scripts/check-protocol.mjs
+++ b/app/scripts/check-protocol.mjs
@@ -19,6 +19,8 @@ const upstream = process.env.SHELL_ONLINE_REPO ?? join(here, "..", "..");
 const FILES = [
   { vendored: "src/terminal/protocol.ts", source: "shared/protocol.ts" },
   { vendored: "src/terminal/e2ee.ts", source: "web/e2ee.ts" },
+  { vendored: "src/terminal/terminal-grid.ts", source: "shared/terminal-grid.ts" },
+  { vendored: "src/terminal/terminal-fit.ts", source: "web/terminal-fit.ts" },
 ];
 
 /* Copies kept in step within this repository rather than with shell.online. */

--- a/app/src/terminal/TerminalPane.tsx
+++ b/app/src/terminal/TerminalPane.tsx
@@ -4,6 +4,8 @@ import { FitAddon } from "@xterm/addon-fit";
 import { ArrowClockwise, LockKey } from "@phosphor-icons/react";
 import "@xterm/xterm/css/xterm.css";
 import { TerminalConnection, type ConnectionStatus } from "./connection";
+import { DESKTOP_TERMINAL_GRID, type TerminalGrid } from "./terminal-grid";
+import { fittedTerminalFontSize } from "./terminal-fit";
 import { encryptionFragment, resolveSessionSocket, sessionIdFromShareUrl } from "./socket-url";
 import { forget, passwordFor } from "../lib/session-passwords";
 import { openSealed } from "../lib/keypair";
@@ -31,6 +33,12 @@ const THEME = {
   selectionBackground: "#3a3f33",
 };
 
+/*
+ * The size the pane would like to draw at when the grid happens to fit. Every
+ * fit scales down from here; nothing scales the grid.
+ */
+const BASE_FONT_SIZE = 13;
+
 export function TerminalPane({
   shareUrl,
   active,
@@ -51,16 +59,52 @@ export function TerminalPane({
   /*
    * Only the visible pane measures itself. A hidden one is still laid out, so
    * it would measure fine here, but refusing to refit it at all means no
-   * future layout change can quietly resize somebody's running terminal.
+   * future layout change can quietly restyle somebody's running terminal.
    */
   const activeRef = useRef(active);
   activeRef.current = active;
 
+  /*
+   * The grid the process is running at, not the grid this pane could fit. The
+   * relay announces it and the CLI opens the PTY at it; a viewer's only say in
+   * the matter is how large to draw it.
+   */
+  const grid = useRef<TerminalGrid>(DESKTOP_TERMINAL_GRID);
+
+  /**
+   * Scales the font so the whole session grid fits this pane, then pins the
+   * terminal to that grid.
+   *
+   * The obvious thing — FitAddon.fit() — is wrong here. It picks the grid that
+   * fills the pane at a fixed font size, so a pane narrower than 120 columns
+   * renders a 120-column process at, say, 94: every long line wraps a second
+   * time and full-screen output loses its bottom rows. Nothing downstream can
+   * repair that, because the PTY is not the size the emulator thinks it is.
+   */
   const refit = useCallback(() => {
-    if (!activeRef.current || !fit.current || !terminal.current) return;
+    const term = terminal.current;
+    const fitAddon = fit.current;
+    if (!activeRef.current || !fitAddon || !term) return;
     try {
-      fit.current.fit();
-      connection.current?.resize(terminal.current.cols, terminal.current.rows);
+      term.options.fontSize = BASE_FONT_SIZE;
+      /* How much fits at the base size; the scale below is derived from it. */
+      const available = fitAddon.proposeDimensions();
+      if (!available) return;
+      const { cols, rows } = grid.current;
+      const fontSize = fittedTerminalFontSize(
+        BASE_FONT_SIZE,
+        available.cols,
+        available.rows,
+        100,
+        cols,
+        rows,
+      );
+      if (term.options.fontSize !== fontSize) term.options.fontSize = fontSize;
+      if (term.cols !== cols || term.rows !== rows) {
+        term.resize(cols, rows);
+      } else {
+        term.refresh(0, term.rows - 1);
+      }
     } catch {
       /* the node can be detached mid-teardown */
     }
@@ -69,6 +113,9 @@ export function TerminalPane({
   useEffect(() => {
     const node = mount.current;
     if (!node) return;
+
+    /* A pane reused for another session starts from the default again. */
+    grid.current = DESKTOP_TERMINAL_GRID;
 
     const resolved = resolveSessionSocket(
       shareUrl,
@@ -84,7 +131,10 @@ export function TerminalPane({
 
     const term = new Terminal({
       fontFamily: 'ui-monospace, "SFMono-Regular", "Menlo", "Consolas", monospace',
-      fontSize: 13,
+      fontSize: BASE_FONT_SIZE,
+      /* Opened at the session grid so the first frames land in the right shape. */
+      cols: grid.current.cols,
+      rows: grid.current.rows,
       lineHeight: 1.35,
       cursorBlink: true,
       convertEol: false,
@@ -124,6 +174,11 @@ export function TerminalPane({
         onReadOnly: (value) => {
           setReadOnly(value);
           term.options.disableStdin = value;
+        },
+        /* A phone joining takes the session to 80x24, and back when it leaves. */
+        onGrid: (next) => {
+          grid.current = next;
+          refit();
         },
       },
     });

--- a/app/src/terminal/connection.test.ts
+++ b/app/src/terminal/connection.test.ts
@@ -2,6 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TerminalConnection, type ConnectionStatus } from "./connection";
 import { Opcode, encodeFrame } from "./protocol";
 import { BrowserFrameCipher } from "./e2ee";
+import {
+  DESKTOP_TERMINAL_GRID,
+  MOBILE_TERMINAL_GRID,
+  type TerminalGrid,
+} from "./terminal-grid";
 
 /* A WebSocket stand-in that lets a test drive both directions by hand. */
 class FakeSocket {
@@ -61,10 +66,11 @@ interface Recorded {
   statuses: { status: ConnectionStatus; detail?: string }[];
   writes: { text: string; reset: boolean }[];
   readOnly: boolean[];
+  grids: TerminalGrid[];
 }
 
 function connect(fragment = "") {
-  const recorded: Recorded = { statuses: [], writes: [], readOnly: [] };
+  const recorded: Recorded = { statuses: [], writes: [], readOnly: [], grids: [] };
   const connection = new TerminalConnection({
     url: "ws://localhost:5173/relay/api/sessions/x/ws",
     fragment,
@@ -73,6 +79,7 @@ function connect(fragment = "") {
       onStatus: (status, detail) => recorded.statuses.push({ status, detail }),
       onData: (bytes, reset) => recorded.writes.push({ text: new TextDecoder().decode(bytes), reset }),
       onReadOnly: (value) => recorded.readOnly.push(value),
+      onGrid: (grid) => recorded.grids.push(grid),
     },
   });
   return { connection, recorded };
@@ -150,44 +157,22 @@ describe("plaintext session", () => {
     expect(FakeSocket.last!.sent).toHaveLength(0);
   });
 
-  it("sends a resize once and not again for the same size", async () => {
+  it("never asks the relay to resize the shared PTY", async () => {
+    /*
+     * The process keeps one grid for the whole session and every viewer scales
+     * it locally. A viewer that sent its own size would be asking for a size
+     * the relay discards anyway.
+     */
     const { connection } = connect();
     await connection.start();
     FakeSocket.last!.opened();
-    connection.resize(80, 24);
-    connection.resize(80, 24);
+    connection.send("ls\r");
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(FakeSocket.last!.sent).toHaveLength(1);
-    expect(new Uint8Array(FakeSocket.last!.sent[0] as ArrayBuffer)[0]).toBe(Opcode.Resize);
-  });
-
-  it("ignores a nonsense size", async () => {
-    const { connection } = connect();
-    await connection.start();
-    FakeSocket.last!.opened();
-    connection.resize(0, 0);
-    connection.resize(-1, 24);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(FakeSocket.last!.sent).toHaveLength(0);
-  });
-
-  it("re-asserts the size after a reconnect", async () => {
-    /* The PTY follows this viewer, so a fresh socket has to be told again. */
-    const { connection } = connect();
-    await connection.start();
-    FakeSocket.last!.opened();
-    connection.resize(120, 40);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    const first = FakeSocket.last!;
-
-    first.closedWith(1006);
-    await new Promise((resolve) => setTimeout(resolve, 900));
-    FakeSocket.last!.opened();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    expect(FakeSocket.created).toBe(2);
-    expect(new Uint8Array(FakeSocket.last!.sent[0] as ArrayBuffer)[0]).toBe(Opcode.Resize);
+    const opcodes = FakeSocket.last!.sent.map(
+      (payload) => new Uint8Array(payload as ArrayBuffer)[0],
+    );
+    expect(opcodes).not.toContain(Opcode.Resize);
   });
 });
 
@@ -328,7 +313,7 @@ describe("encrypted session", () => {
   });
 });
 
-describe("resize safety", () => {
+describe("the session grid", () => {
   async function connected() {
     const { connection, recorded } = connect();
     await connection.start();
@@ -336,54 +321,53 @@ describe("resize safety", () => {
     return { connection, recorded, socket: FakeSocket.last! };
   }
 
-  function resizes(socket: FakeSocket) {
-    return socket.sent
-      .map((payload) => new Uint8Array(payload as ArrayBuffer))
-      .filter((frame) => frame[0] === Opcode.Resize)
-      .map((frame) => {
-        const view = new DataView(frame.buffer, frame.byteOffset, frame.byteLength);
-        return { cols: view.getUint16(1), rows: view.getUint16(3) };
-      });
-  }
-
-  it("refuses a size a real terminal would never have", async () => {
+  it("starts on the grid the CLI opens a PTY at", async () => {
     /*
-     * A hidden pane used to measure about one column wide. Forwarding that
-     * resized the shared PTY to one column and wrecked anything full-screen.
+     * A viewer that connects before the first announcement still has to draw
+     * something, and desktop is what the process is actually running at.
      */
-    const { connection, socket } = await connected();
-    connection.resize(1, 24);
-    connection.resize(80, 1);
-    connection.resize(2, 2);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    expect(resizes(socket)).toEqual([]);
+    const { connection } = await connected();
+    expect(connection.grid).toEqual(DESKTOP_TERMINAL_GRID);
   });
 
-  it("keeps the last good size when a degenerate one arrives", async () => {
-    const { connection, socket } = await connected();
-    connection.resize(120, 40);
-    connection.resize(1, 1);
-    connection.resize(120, 40);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    /* The second 120x40 is a duplicate of the size still in force, not a
-       recovery from the sliver, so exactly one resize should have gone out. */
-    expect(resizes(socket)).toEqual([{ cols: 120, rows: 40 }]);
+  it("follows the relay onto the mobile grid and back", async () => {
+    const { connection, recorded, socket } = await connected();
+    socket.control({ type: "terminal_size", ...MOBILE_TERMINAL_GRID });
+    expect(connection.grid).toEqual(MOBILE_TERMINAL_GRID);
+    socket.control({ type: "terminal_size", ...DESKTOP_TERMINAL_GRID });
+    expect(connection.grid).toEqual(DESKTOP_TERMINAL_GRID);
+    expect(recorded.grids).toEqual([MOBILE_TERMINAL_GRID, DESKTOP_TERMINAL_GRID]);
   });
 
-  it("still accepts a small but plausible terminal", async () => {
-    const { connection, socket } = await connected();
-    connection.resize(20, 4);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(resizes(socket)).toEqual([{ cols: 20, rows: 4 }]);
+  it("reports a grid change once", async () => {
+    const { recorded, socket } = await connected();
+    socket.control({ type: "terminal_size", ...MOBILE_TERMINAL_GRID });
+    socket.control({ type: "terminal_size", ...MOBILE_TERMINAL_GRID });
+    expect(recorded.grids).toEqual([MOBILE_TERMINAL_GRID]);
   });
 
-  it("ignores a non-finite size rather than sending garbage", async () => {
+  it("refuses a grid the CLI would reject", async () => {
+    /*
+     * cmd/shell/session_unix.go only resizes the PTY to one of the two
+     * canonical grids. Drawing anything else means rendering a shape the
+     * process is not writing, which is the bug this whole model prevents.
+     */
+    const { connection, recorded, socket } = await connected();
+    socket.control({ type: "terminal_size", cols: 94, rows: 28 });
+    socket.control({ type: "terminal_size", cols: 0, rows: 0 });
+    socket.control({ type: "terminal_size", cols: "120", rows: "36" });
+    expect(connection.grid).toEqual(DESKTOP_TERMINAL_GRID);
+    expect(recorded.grids).toEqual([]);
+  });
+
+  it("keeps the grid across a reconnect", async () => {
     const { connection, socket } = await connected();
-    connection.resize(Number.NaN, 24);
-    connection.resize(80, Number.POSITIVE_INFINITY);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(resizes(socket)).toEqual([]);
+    socket.control({ type: "terminal_size", ...MOBILE_TERMINAL_GRID });
+    socket.closedWith(1006);
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    FakeSocket.last!.opened();
+
+    expect(FakeSocket.created).toBe(2);
+    expect(connection.grid).toEqual(MOBILE_TERMINAL_GRID);
   });
 });

--- a/app/src/terminal/connection.ts
+++ b/app/src/terminal/connection.ts
@@ -1,5 +1,10 @@
-import { Opcode, encodeFrame, encodeResize } from "./protocol";
+import { Opcode, encodeFrame } from "./protocol";
 import { BrowserFrameCipher, parseEncryptionFragment, type EncryptionFragment } from "./e2ee";
+import {
+  DESKTOP_TERMINAL_GRID,
+  MOBILE_TERMINAL_GRID,
+  type TerminalGrid,
+} from "./terminal-grid";
 
 export type ConnectionStatus =
   | "connecting"
@@ -15,6 +20,12 @@ export interface ConnectionEvents {
   /** Terminal bytes to write. `reset` means the screen should be cleared first. */
   onData(bytes: Uint8Array, reset: boolean): void;
   onReadOnly(readOnly: boolean): void;
+  /**
+   * The grid the PTY is running at, announced by the relay. It is a property
+   * of the session rather than of this viewer, and it changes when a phone
+   * joins or leaves.
+   */
+  onGrid(grid: TerminalGrid): void;
 }
 
 export interface ConnectionOptions {
@@ -30,12 +41,6 @@ export interface ConnectionOptions {
 
 const MAX_BACKOFF_MS = 10_000;
 
-/*
- * Below this a terminal is not a terminal, it is a measurement artefact from a
- * pane that is not laid out yet or not on screen.
- */
-const MIN_COLS = 20;
-const MIN_ROWS = 4;
 const CLOSE_ENDED = 4000;
 const CLOSE_MISSING = 4004;
 const CLOSE_DECRYPT_FAILED = 4003;
@@ -57,10 +62,21 @@ export class TerminalConnection {
   private stopped = false;
   private readOnly = false;
   private awaitingPassword = false;
-  private lastSize: { cols: number; rows: number } | null = null;
+  private currentGrid: TerminalGrid = DESKTOP_TERMINAL_GRID;
 
   constructor(private readonly options: ConnectionOptions) {
     this.descriptor = parseEncryptionFragment(options.fragment);
+  }
+
+  /**
+   * The grid the PTY is running at.
+   *
+   * Desktop until the relay says otherwise, which is what the CLI opens a PTY
+   * at, so a viewer that connects before the first announcement still renders
+   * at the right size instead of guessing from its own pixels.
+   */
+  get grid(): TerminalGrid {
+    return this.currentGrid;
   }
 
   /** True when the session is encrypted and no working key is held yet. */
@@ -104,24 +120,6 @@ export class TerminalConnection {
     void this.transmit(encodeFrame(Opcode.Input, bytes));
   }
 
-  /**
-   * Reports this viewer's terminal size to the relay, which resizes the shared
-   * PTY to match.
-   *
-   * A degenerate size is refused rather than sent. A hidden pane can measure
-   * as a sliver, and forwarding that would resize the real PTY to a column or
-   * two, destroying the layout of anything full-screen like htop. No terminal
-   * that small is worth honouring, so the last good size stands.
-   */
-  resize(cols: number, rows: number): void {
-    if (!Number.isFinite(cols) || !Number.isFinite(rows)) return;
-    if (cols < MIN_COLS || rows < MIN_ROWS) return;
-    /* The relay resizes the shared PTY, so only send an actual change. */
-    if (this.lastSize?.cols === cols && this.lastSize.rows === rows) return;
-    this.lastSize = { cols, rows };
-    void this.transmit(encodeResize(cols, rows));
-  }
-
   close(): void {
     this.stopped = true;
     if (this.retryTimer !== null) clearTimeout(this.retryTimer);
@@ -158,12 +156,6 @@ export class TerminalConnection {
     socket.addEventListener("open", () => {
       this.retryAttempt = 0;
       this.options.events.onStatus("connected");
-      /* The PTY size follows this viewer, so re-assert it on every connect. */
-      if (this.lastSize) {
-        const { cols, rows } = this.lastSize;
-        this.lastSize = null;
-        this.resize(cols, rows);
-      }
     });
 
     socket.addEventListener("message", (event: MessageEvent<string | ArrayBuffer>) => {
@@ -232,7 +224,7 @@ export class TerminalConnection {
   }
 
   private handleControl(raw: string): void {
-    let message: { readOnly?: unknown; status?: unknown };
+    let message: { readOnly?: unknown; status?: unknown; type?: unknown; cols?: unknown; rows?: unknown };
     try {
       message = JSON.parse(raw) as typeof message;
     } catch {
@@ -245,6 +237,26 @@ export class TerminalConnection {
     if (message.status === "exited") {
       this.options.events.onStatus("ended");
     }
+    if (message.type === "terminal_size") {
+      this.adoptGrid(message.cols, message.rows);
+    }
+  }
+
+  /*
+   * Only the two grids the CLI will actually open a PTY at are honoured. It
+   * refuses anything else (`isCanonicalTerminalSize`), so rendering a size it
+   * would have rejected is how a viewer ends up drawing 94 columns of a
+   * 120-column process.
+   */
+  private adoptGrid(cols: unknown, rows: unknown): void {
+    if (typeof cols !== "number" || typeof rows !== "number") return;
+    const grid = [DESKTOP_TERMINAL_GRID, MOBILE_TERMINAL_GRID].find(
+      (candidate) => candidate.cols === cols && candidate.rows === rows,
+    );
+    if (!grid) return;
+    if (grid.cols === this.currentGrid.cols && grid.rows === this.currentGrid.rows) return;
+    this.currentGrid = grid;
+    this.options.events.onGrid(grid);
   }
 
   private scheduleRetry(): void {

--- a/app/src/terminal/terminal-fit.ts
+++ b/app/src/terminal/terminal-fit.ts
@@ -1,0 +1,38 @@
+/*
+ * Vendored verbatim from shell.online: web/terminal-fit.ts
+ *
+ * How a viewer fits the fixed session grid into its own viewport: by scaling
+ * the font, never by changing the number of columns. The standalone viewer
+ * and this app have to agree here, or the same session renders at two
+ * different sizes. Checked by `npm run check:protocol`. Do not edit here.
+ */
+/**
+ * Scale the current session-wide terminal grid into an individual viewport.
+ */
+export function fittedTerminalFontSize(
+  baseFontSize: number,
+  availableColumns: number,
+  availableRows: number,
+  zoomPercent = 100,
+  terminalColumns = 80,
+  terminalRows = 24,
+): number {
+  if (
+    !Number.isFinite(baseFontSize) ||
+    !Number.isFinite(availableColumns) ||
+    !Number.isFinite(availableRows) ||
+    !Number.isFinite(zoomPercent) ||
+    baseFontSize <= 0 ||
+    availableColumns <= 0 ||
+    availableRows <= 0
+  ) {
+    return Math.max(4, baseFontSize || 14);
+  }
+
+  const fitScale = Math.min(
+    availableColumns / terminalColumns,
+    availableRows / terminalRows,
+  );
+  const scaled = baseFontSize * fitScale * (zoomPercent / 100) * 0.985;
+  return Math.min(32, Math.max(4, Math.floor(scaled * 4) / 4));
+}

--- a/app/src/terminal/terminal-grid.ts
+++ b/app/src/terminal/terminal-grid.ts
@@ -1,0 +1,19 @@
+/*
+ * Vendored verbatim from shell.online: shared/terminal-grid.ts
+ *
+ * The session-wide grid the relay picks and the CLI opens the PTY at. It is
+ * copied rather than reimplemented so the app cannot disagree with the relay
+ * about how big a terminal is, and checked by `npm run check:protocol`, which
+ * fails if the upstream file changes. Do not edit here; edit upstream.
+ */
+export interface TerminalGrid {
+  cols: number;
+  rows: number;
+}
+
+export const DESKTOP_TERMINAL_GRID: TerminalGrid = { cols: 120, rows: 36 };
+export const MOBILE_TERMINAL_GRID: TerminalGrid = { cols: 80, rows: 24 };
+
+export function terminalGridForDevices(devices: readonly string[]): TerminalGrid {
+  return devices.includes("mobile") ? MOBILE_TERMINAL_GRID : DESKTOP_TERMINAL_GRID;
+}


### PR DESCRIPTION
A session keeps one grid for its whole life. `cmd/shell/session_unix.go` opens the PTY at 120×36, or 80×24 once a phone is watching, and `isCanonicalTerminalSize` refuses anything else. The relay announces which of the two is in force as a `terminal_size` message and accepts a viewer's resize frame only as a no-op (`worker/index.ts`, "the process keeps one stable grid and each viewer scales it locally"). Every viewer fits that fixed grid into its own viewport by scaling the font, which is what `web/terminal-fit.ts` exists for.

The web app's pane never got that message. It ran `FitAddon.fit()`, sized the emulator to its own pixels, and reported that size to the relay, which discards it. `terminal_size` was not handled at all.

## What that looked like

Measured in a 900×520 pane against a real local session running at 120×36:

| | columns × rows | 120-character line |
|---|---|---|
| Standalone viewer | 120 × 36 | fits |
| App pane, before | **110 × 24** | wraps, 10 characters onto a second row |
| App pane, after | 120 × 36 | fits |

Every line past column 110 wrapped a second time and a third of the screen was never drawn, so `htop`, `vim`, or a coding agent came out unreadable. Nothing downstream could repair it, because the PTY was not the size the emulator thought it was.

## The change

- `TerminalPane` scales the font to fit the announced grid and pins the emulator to that grid, instead of reshaping the grid to the pane.
- `TerminalConnection` learns the grid from `terminal_size`, honouring only the two grids the CLI will actually accept, and exposes it as `grid` plus an `onGrid` event. It no longer sends resize frames.
- `terminal-grid.ts` and `terminal-fit.ts` are vendored from `shared/` and `web/` the way `protocol.ts` and `e2ee.ts` already are, and `check:protocol` covers them. The whole failure was the app holding its own opinion about how big a terminal is.

## Verification

Against a local stack (relay on `wrangler dev`, app on the dev server, a real `shell` session):

- desktop viewer only: pane draws 120×36, the 120-character line unwrapped, font scaled to 8.5px;
- a phone joins: the PTY moves to 80×24 and the pane follows, 24 rows at 12.75px;
- the phone leaves: back to 120×36.

512 app tests pass, including new coverage for the grid handshake: the default before any announcement, following the relay onto the mobile grid and back, reporting a change once, refusing a grid the CLI would reject, and surviving a reconnect. `check:protocol` passes, `tsc -b` and the production build are clean, and no new lint warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQLKwv7a63XiRjaMABrCzR