### PR TITLE
Clean up terminal QR and mobile controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-visible changes are recorded here. Versions follow [Semantic Ve
 
 ## Unreleased
 
+## [0.10.1] — 2026-09-08
+
+### Fixed
+
+- Render terminal QR codes with one color transition per row instead of one per module, eliminating visible repaint noise and reducing their ANSI payload by roughly an order of magnitude.
+- Give every mobile terminal navigation key a full 44-pixel touch target with more legible labels.
+
 ## [0.10.0] — 2026-09-08
 
 ### Added

--- a/cmd/shell/qr.go
+++ b/cmd/shell/qr.go
@@ -46,19 +46,22 @@ func terminalQRCode(content string) (string, error) {
 
 	var rendered strings.Builder
 	for topRow := 0; topRow < len(bitmap); topRow += 2 {
-		rendered.WriteString("  ")
+		// One foreground/background pair per row avoids making slower terminals
+		// visibly repaint the QR one module at a time. The glyphs themselves
+		// carry both vertical modules while the palette stays fixed.
+		rendered.WriteString("  \x1b[30;107m")
 		for column := range bitmap[topRow] {
 			top := bitmap[topRow][column]
 			bottom := topRow+1 < len(bitmap) && bitmap[topRow+1][column]
 			switch {
 			case top && bottom:
-				rendered.WriteString("\x1b[40m ")
+				rendered.WriteRune('█')
 			case top:
-				rendered.WriteString("\x1b[30;47m▀")
+				rendered.WriteRune('▀')
 			case bottom:
-				rendered.WriteString("\x1b[30;47m▄")
+				rendered.WriteRune('▄')
 			default:
-				rendered.WriteString("\x1b[47m ")
+				rendered.WriteByte(' ')
 			}
 		}
 		rendered.WriteString("\x1b[0m\n")

--- a/cmd/shell/qr_test.go
+++ b/cmd/shell/qr_test.go
@@ -46,8 +46,11 @@ func TestTerminalQRCodeIsCompact(t *testing.T) {
 	if len(lines) > 30 {
 		t.Fatalf("terminal QR is %d rows high", len(lines))
 	}
-	if !strings.Contains(rendered, "▀") || !strings.Contains(rendered, "▄") || !strings.Contains(rendered, "\x1b[47m") {
+	if !strings.Contains(rendered, "█") || !strings.Contains(rendered, "▀") || !strings.Contains(rendered, "▄") || !strings.Contains(rendered, "\x1b[30;107m") {
 		t.Fatalf("terminal QR lacks half blocks or explicit colours")
+	}
+	if sequences := strings.Count(rendered, "\x1b["); sequences != len(lines)*2 {
+		t.Fatalf("terminal QR emitted %d ANSI sequences for %d rows", sequences, len(lines))
 	}
 }
 

--- a/docs/content.json
+++ b/docs/content.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.10.0",
+  "version": "0.10.1",
   "pages": {
     "docs": {
       "eyebrow": "Documentation",
@@ -513,7 +513,7 @@
       "cards": [
         [
           "Start once",
-          "Pull ghcr.io/teoslayer/shell.online:0.10.0 or run docker compose up --build -d, then docker compose logs shell-online. First launch prints the stable URL and a generated eight-character password. The tagged amd64/arm64 image includes an SBOM and build provenance."
+          "Pull ghcr.io/teoslayer/shell.online:0.10.1 or run docker compose up --build -d, then docker compose logs shell-online. First launch prints the stable URL and a generated eight-character password. The tagged amd64/arm64 image includes an SBOM and build provenance."
         ],
         [
           "Two durable volumes",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shell-online",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shell-online",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shell-online",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Turn any terminal process into a collaborative browser link.",
   "private": true,
   "license": "MIT",
@@ -23,7 +23,7 @@
     "deploy:production": "sh ./scripts/deploy-production.sh",
     "verify:downloads": "node ./scripts/verify-downloads.mjs",
     "check": "npm run typecheck && npm test",
-    "test": "vitest run && node --test .github/scripts/moderation.node.mjs && sh ./scripts/test-install.sh && sh ./scripts/test-docker-entrypoint.sh && sh ./scripts/test-deploy-production.sh && sh ./scripts/test-qemu-linux.sh --check && node ./scripts/test-landing-seo.mjs && node ./scripts/check-formula.mjs",
+    "test": "vitest run && node --test .github/scripts/moderation.node.mjs && sh ./scripts/test-install.sh && sh ./scripts/test-docker-entrypoint.sh && sh ./scripts/test-deploy-production.sh && sh ./scripts/test-qemu-linux.sh --check && node ./scripts/test-landing-seo.mjs && node ./scripts/test-mobile-controls.mjs && node ./scripts/check-formula.mjs",
     "test:qemu:manifest": "sh ./scripts/test-qemu-linux.sh --check",
     "typecheck": "tsc -p tsconfig.worker.json --noEmit && tsc -p tsconfig.web.json --noEmit",
     "test:app": "npm --prefix app ci && npm --prefix app test"

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -24,9 +24,9 @@ The Homebrew formula builds locally: Brew fetches the checksum-pinned tagged sou
 
 The standalone installer uses a checksum-pinned release binary. To compile and run the tagged source outside either installation path:
 
-git clone --depth 1 --branch v0.10.0 https://github.com/TeoSlayer/shell.online.git
+git clone --depth 1 --branch v0.10.1 https://github.com/TeoSlayer/shell.online.git
 cd shell.online
-go build -trimpath -ldflags="-X main.version=0.10.0" -o ./shell ./cmd/shell
+go build -trimpath -ldflags="-X main.version=0.10.1" -o ./shell ./cmd/shell
 ./shell --version
 
 The source-build path requires Go 1.26.8 or newer, except Go 1.27.x is intentionally unsupported on MIPS64 because of go.dev/issue/80978. Keep using ./shell or move it to a directory on PATH.

--- a/scripts/test-mobile-controls.mjs
+++ b/scripts/test-mobile-controls.mjs
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+
+const stylesheet = readFileSync(new URL("../web/style.css", import.meta.url), "utf8");
+const buttonRules = Array.from(
+  stylesheet.matchAll(/\.mobile-terminal-keys button\s*\{([^}]*)\}/g),
+  (match) => match[1],
+);
+const mobileRule = buttonRules.find((rule) => rule.includes("touch-action: manipulation"));
+
+if (!mobileRule?.includes("min-height: 44px")) {
+  throw new Error("Mobile terminal keys must retain a 44px touch target");
+}
+if (!mobileRule.includes('font: 600 12px/1 "Uncut Sans", sans-serif')) {
+  throw new Error("Mobile terminal key labels must retain their legible size");
+}
+
+console.log("Mobile terminal navigation touch targets passed.");

--- a/web/style.css
+++ b/web/style.css
@@ -1930,8 +1930,8 @@ a {
 
   .mobile-terminal-keys {
     display: grid;
-    min-height: 42px;
-    padding: 4px max(5px, env(safe-area-inset-right)) max(4px, env(safe-area-inset-bottom)) max(5px, env(safe-area-inset-left));
+    min-height: 56px;
+    padding: 6px max(6px, env(safe-area-inset-right)) max(6px, env(safe-area-inset-bottom)) max(6px, env(safe-area-inset-left));
     border-top: 1px solid #252a34;
     background: #11141b;
     grid-template-columns: repeat(8, minmax(0, 1fr));
@@ -1941,14 +1941,14 @@ a {
 
   .mobile-terminal-keys button {
     min-width: 0;
-    min-height: 34px;
+    min-height: 44px;
     padding: 0;
     border: 1px solid #333a47;
     border-radius: 7px;
     background: #171b23;
     box-shadow: inset 0 1px rgb(255 255 255 / 3%);
     color: #c8cfdd;
-    font: 600 11px/1 "Uncut Sans", sans-serif;
+    font: 600 12px/1 "Uncut Sans", sans-serif;
     letter-spacing: -0.01em;
     touch-action: manipulation;
     -webkit-tap-highlight-color: transparent;


### PR DESCRIPTION
## What changed

- render the QR with one ANSI style pair per row instead of one style change per module
- use solid `█`, `▀`, and `▄` glyphs against a fixed high-contrast palette
- reduce a normal QR from roughly 1,150 ANSI transitions to 48 without changing its module grid or scan reliability
- enlarge mobile terminal navigation keys to 44px and labels to 12px
- add a CSS regression test for the mobile touch-target invariant
- prepare v0.10.1 metadata

## Verification

- `go test ./cmd/shell`
- `npm run check` (20 files / 62 tests plus installer, Docker, deployment, QEMU manifest, SEO, formula, and moderation checks)
- `npm run build:web`
- QR test asserts exactly two ANSI sequences per rendered row
