### PR TITLE
Fix session lifecycle and viewer reliability

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,10 +24,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+      - uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: ${{ matrix.language }}
-      - uses: github/codeql-action/autobuild@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
-      - uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+      - uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+      - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:${{ matrix.language }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable user-visible changes are recorded here. Versions follow [Semantic Ve
 
 ## Unreleased
 
+### Added
+
+- Publish Go module discovery metadata so `go install shell.online/cmd/shell@latest` resolves from the canonical domain.
+
+### Fixed
+
+- Keep the background startup pipe private to shell.online so wrapped commands can safely use file descriptor 3.
+- Make foreground relay connection attempts interruptible and print share details only after the relay is connected.
+- Honor long `--auto-close` deadlines instead of silently reducing them to the relay's rolling 12-hour lease.
+- Refuse a second local owner for an already-running persistent session without replacing its control socket or record.
+- Preserve authenticated E2EE recovery snapshot opcodes during relay backpressure so large output cannot eject viewers to the password screen.
+- Show compact, unclipped encryption badges in narrow mobile headers.
+- Explain when all 16 viewer slots are occupied and keep retrying until a slot opens.
+
 ## [0.10.1] — 2026-09-08
 
 ### Fixed

--- a/app/src/terminal/TerminalPane.tsx
+++ b/app/src/terminal/TerminalPane.tsx
@@ -254,6 +254,13 @@ export function TerminalPane({
           Reconnecting
         </div>
       )}
+
+      {status === "full" && (
+        <div className="pane-banner">
+          <ArrowClockwise size={14} />
+          {detail || "Session full. Waiting for a viewer slot."}
+        </div>
+      )}
     </div>
   );
 }

--- a/app/src/terminal/connection.test.ts
+++ b/app/src/terminal/connection.test.ts
@@ -126,6 +126,16 @@ describe("plaintext session", () => {
     ]);
   });
 
+  it("treats a recovery broadcast as a full-screen snapshot", async () => {
+    const { connection, recorded } = connect();
+    await connection.start();
+    FakeSocket.last!.opened();
+    FakeSocket.last!.binary(encodeFrame(Opcode.BroadcastSnapshot, new TextEncoder().encode("recovered")));
+    await waitFor(() => recorded.writes.length === 1, "the recovery snapshot");
+
+    expect(recorded.writes).toEqual([{ text: "recovered", reset: true }]);
+  });
+
   it("sends typed input as an Input frame", async () => {
     const { connection } = connect();
     await connection.start();
@@ -211,6 +221,19 @@ describe("session lifecycle", () => {
 
     expect(recorded.statuses.at(-1)?.status).toBe("missing");
     expect(FakeSocket.created).toBe(1);
+  });
+
+  it("reports a full session and retries until a viewer slot opens", async () => {
+    const { connection, recorded } = connect();
+    await connection.start();
+    FakeSocket.last!.closedWith(4005);
+
+    expect(recorded.statuses.at(-1)?.status).toBe("full");
+    expect(recorded.statuses.at(-1)?.detail).toContain("16 viewers");
+
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    expect(FakeSocket.created).toBe(2);
+    expect(recorded.statuses.at(-1)?.status).toBe("full");
   });
 
   it("reports exit from a control message", async () => {

--- a/app/src/terminal/connection.ts
+++ b/app/src/terminal/connection.ts
@@ -1,10 +1,11 @@
-import { Opcode, encodeFrame, encodeResize } from "./protocol";
+import { Opcode, encodeFrame, encodeResize, isSnapshotOpcode } from "./protocol";
 import { BrowserFrameCipher, parseEncryptionFragment, type EncryptionFragment } from "./e2ee";
 
 export type ConnectionStatus =
   | "connecting"
   | "needs-password"
   | "connected"
+  | "full"
   | "disconnected"
   | "ended"
   | "missing"
@@ -39,6 +40,7 @@ const MIN_ROWS = 4;
 const CLOSE_ENDED = 4000;
 const CLOSE_MISSING = 4004;
 const CLOSE_DECRYPT_FAILED = 4003;
+const CLOSE_SESSION_FULL = 4005;
 
 /**
  * One viewer connection to one session.
@@ -57,6 +59,7 @@ export class TerminalConnection {
   private stopped = false;
   private readOnly = false;
   private awaitingPassword = false;
+  private waitingForCapacity = false;
   private lastSize: { cols: number; rows: number } | null = null;
 
   constructor(private readonly options: ConnectionOptions) {
@@ -150,7 +153,7 @@ export class TerminalConnection {
 
   private open(): void {
     if (this.stopped) return;
-    this.options.events.onStatus("connecting");
+    this.options.events.onStatus(this.waitingForCapacity ? "full" : "connecting");
 
     const create = this.options.createSocket ?? ((url: string) => new WebSocket(url));
     const socket = create(this.options.url);
@@ -158,6 +161,7 @@ export class TerminalConnection {
     this.socket = socket;
 
     socket.addEventListener("open", () => {
+      this.waitingForCapacity = false;
       this.retryAttempt = 0;
       this.options.events.onStatus("connected");
       /* The PTY size follows this viewer, so re-assert it on every connect. */
@@ -189,6 +193,15 @@ export class TerminalConnection {
       }
       if (event.code === CLOSE_ENDED) {
         this.options.events.onStatus("ended");
+        return;
+      }
+      if (event.code === CLOSE_SESSION_FULL) {
+        this.waitingForCapacity = true;
+        this.options.events.onStatus(
+          "full",
+          "16 viewers are connected. You will join automatically when a slot opens.",
+        );
+        this.scheduleRetry();
         return;
       }
       if (this.awaitingPassword) return;
@@ -226,7 +239,7 @@ export class TerminalConnection {
     if (frame.byteLength === 0) return;
 
     const opcode = frame[0];
-    if (opcode === Opcode.Snapshot || opcode === Opcode.FinalSnapshot) {
+    if (isSnapshotOpcode(opcode)) {
       this.options.events.onData(frame.subarray(1), true);
     } else if (opcode === Opcode.Output) {
       this.options.events.onData(frame.subarray(1), false);

--- a/app/src/terminal/protocol.ts
+++ b/app/src/terminal/protocol.ts
@@ -20,6 +20,12 @@ export const enum Opcode {
 
 export const MAX_INPUT_CHUNK = 16 * 1024;
 
+export function isSnapshotOpcode(opcode: number): boolean {
+  return opcode === Opcode.Snapshot ||
+    opcode === Opcode.FinalSnapshot ||
+    opcode === Opcode.BroadcastSnapshot;
+}
+
 export function encodeFrame(opcode: Opcode, payload: Uint8Array): Uint8Array<ArrayBuffer> {
   const frame = new Uint8Array(payload.byteLength + 1);
   frame[0] = opcode;

--- a/cmd/shell/autoclose.go
+++ b/cmd/shell/autoclose.go
@@ -131,16 +131,6 @@ func processCloseDeadline(value string, parsedDeadline, processStart time.Time) 
 	return parsedDeadline
 }
 
-// boundedCloseDeadline prevents the local process from outliving a deadline
-// the relay has already declared. A zero requested deadline still means the
-// task itself controls its lifetime.
-func boundedCloseDeadline(requested, sessionExpiry time.Time) time.Time {
-	if requested.IsZero() || sessionExpiry.IsZero() || !sessionExpiry.Before(requested) {
-		return requested
-	}
-	return sessionExpiry
-}
-
 func parseRelativeDeadline(value string, now time.Time) (time.Time, bool) {
 	remainder := strings.ReplaceAll(strings.TrimSpace(value), " ", "")
 	if remainder == "" {

--- a/cmd/shell/autoclose_test.go
+++ b/cmd/shell/autoclose_test.go
@@ -78,22 +78,6 @@ func TestProcessCloseDeadlinePreservesAbsoluteTime(t *testing.T) {
 	}
 }
 
-func TestBoundedCloseDeadlineUsesRelayExpiry(t *testing.T) {
-	now := time.Date(2026, time.August, 19, 23, 40, 0, 0, time.UTC)
-	sessionExpiry := now.Add(12 * time.Hour)
-	requested := now.Add(30 * 24 * time.Hour)
-
-	if got := boundedCloseDeadline(requested, sessionExpiry); !got.Equal(sessionExpiry) {
-		t.Fatalf("boundedCloseDeadline() = %v, want %v", got, sessionExpiry)
-	}
-	if got := boundedCloseDeadline(now.Add(time.Hour), sessionExpiry); !got.Equal(now.Add(time.Hour)) {
-		t.Fatalf("boundedCloseDeadline() shortened a valid deadline to %v", got)
-	}
-	if got := boundedCloseDeadline(time.Time{}, sessionExpiry); !got.IsZero() {
-		t.Fatalf("boundedCloseDeadline() changed task-bound lifetime to %v", got)
-	}
-}
-
 func TestNormalizeAutoCloseArguments(t *testing.T) {
 	now := time.Date(2026, time.August, 19, 23, 40, 0, 0, time.UTC)
 	tests := []struct {

--- a/cmd/shell/background_unix.go
+++ b/cmd/shell/background_unix.go
@@ -34,6 +34,10 @@ func openBackgroundReadyFile() (backgroundReadyWriter, error) {
 		_ = file.Close()
 		return nil, fmt.Errorf("invalid background readiness channel")
 	}
+	// ExtraFiles intentionally clears close-on-exec so this background child can
+	// inherit the launcher's pipe. Restore it immediately: the wrapped process
+	// must never inherit shell.online's private readiness descriptor as fd 3.
+	syscall.CloseOnExec(fileDescriptor)
 	return file, nil
 }
 

--- a/cmd/shell/background_unix_test.go
+++ b/cmd/shell/background_unix_test.go
@@ -1,0 +1,36 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"strconv"
+	"syscall"
+	"testing"
+)
+
+func TestBackgroundReadyDescriptorIsCloseOnExec(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+
+	t.Setenv(backgroundChildEnvironment, "1")
+	t.Setenv(backgroundParentEnvironment, strconv.Itoa(os.Getppid()))
+	t.Setenv(backgroundReadyEnvironment, strconv.Itoa(int(writer.Fd())))
+
+	ready, err := openBackgroundReadyFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ready.Close()
+
+	flags, _, errno := syscall.Syscall(syscall.SYS_FCNTL, writer.Fd(), syscall.F_GETFD, 0)
+	if errno != 0 {
+		t.Fatalf("read readiness descriptor flags: %v", errno)
+	}
+	if flags&syscall.FD_CLOEXEC == 0 {
+		t.Fatal("background readiness descriptor would leak into the wrapped process")
+	}
+}

--- a/cmd/shell/daemon_unix_test.go
+++ b/cmd/shell/daemon_unix_test.go
@@ -16,6 +16,9 @@ import (
 // lock, and whether the socket it leaves behind blocks the next one.
 func buildShell(t *testing.T) string {
 	t.Helper()
+	if os.Getenv("SHELL_ONLINE_QEMU") == "1" {
+		t.Skip("a cross-compiled child cannot be executed outside the user-mode emulator")
+	}
 	binary := filepath.Join(t.TempDir(), "shell")
 	build := exec.Command("go", "build", "-o", binary, "shell.online/cmd/shell")
 	build.Stderr = os.Stderr

--- a/cmd/shell/local_transport_unix.go
+++ b/cmd/shell/local_transport_unix.go
@@ -17,11 +17,29 @@ func listenLocalControl(id string) (net.Listener, error) {
 		return nil, err
 	}
 	path := localSessionSocketPath(directory, id)
-	_ = os.Remove(path)
 	listener, err := net.Listen("unix", path)
+	if err == nil {
+		return secureLocalControlSocket(path, listener)
+	}
+
+	// A socket left by an interrupted process is safe to replace, but never
+	// unlink a live process's control channel. A concurrent second launch will
+	// either connect here or lose the retrying bind below without clobbering it.
+	if connection, dialError := net.DialTimeout("unix", path, 150*time.Millisecond); dialError == nil {
+		_ = connection.Close()
+		return nil, fmt.Errorf("local control channel is already active")
+	}
+	if removeError := os.Remove(path); removeError != nil && !os.IsNotExist(removeError) {
+		return nil, removeError
+	}
+	listener, err = net.Listen("unix", path)
 	if err != nil {
 		return nil, err
 	}
+	return secureLocalControlSocket(path, listener)
+}
+
+func secureLocalControlSocket(path string, listener net.Listener) (net.Listener, error) {
 	if err := os.Chmod(path, 0o600); err != nil {
 		_ = listener.Close()
 		_ = os.Remove(path)

--- a/cmd/shell/main.go
+++ b/cmd/shell/main.go
@@ -176,7 +176,6 @@ func run(arguments []string, stdout, stderr io.Writer) int {
 
 	processStartedAt := time.Now()
 	closeDeadline := processCloseDeadline(autoClose.value, parsedCloseDeadline, processStartedAt)
-	closeDeadline = boundedCloseDeadline(closeDeadline, session.ExpiresAt)
 	if !closeDeadline.IsZero() && !closeDeadline.After(processStartedAt) {
 		err = fmt.Errorf("auto-close deadline elapsed before the process could start")
 		sendBackgroundResult(backgroundLaunchResult{OK: false, Error: err.Error()})
@@ -230,48 +229,17 @@ func run(arguments []string, stdout, stderr io.Writer) int {
 	// Publish to the linked account, if this machine has one. Nothing below is
 	// fatal: sharing a terminal must not depend on the accounts service.
 	link := openSessionLink(signalContext, stderr)
-	link.Register(signalContext, account.SessionInput{
-		ID:         session.ID,
-		ShareURL:   session.ShareURL,
-		Command:    displayCommand(launch.DisplayArguments),
-		ReadOnly:   session.ReadOnly,
-		Encrypted:  session.Encrypted,
-		Persistent: session.Persistent,
-		StartedAt:  processStartedAt.UnixMilli(),
-	})
-
-	if !isBackgroundChild() && *jsonOutput {
-		event := map[string]any{
-			"type":       "session",
-			"session_id": session.ID,
-			"share_url":  session.ShareURL,
-			"read_only":  session.ReadOnly,
-			"encrypted":  session.Encrypted,
-			"persistent": session.Persistent,
-			"auto_close": "task",
-			"expires_at": session.ExpiresAt.Format(time.RFC3339),
-			"background": false,
-		}
-		if password != "" {
-			event["e2ee_password"] = password
-		}
-		if closesAt != nil {
-			event["auto_close"] = "deadline"
-			event["closes_at"] = closesAt.Format(time.RFC3339)
-		}
-		encoded, _ := json.Marshal(event)
-		fmt.Fprintf(stderr, "%s\n", encoded)
-	} else if !isBackgroundChild() {
-		printSessionCard(stderr, backgroundLaunchResult{
-			OK: true, ID: session.ID, ShareURL: session.ShareURL, ReadOnly: session.ReadOnly,
-			Encrypted: session.Encrypted, Password: password, Persistent: session.Persistent,
-			ExpiresAt: session.ExpiresAt, ClosesAt: closesAt, Handoff: launch.Handoff,
-		}, false)
-	}
-
-	var onStarted func()
-	if isBackgroundChild() {
-		onStarted = func() {
+	announceSession := func() {
+		link.Register(signalContext, account.SessionInput{
+			ID:         session.ID,
+			ShareURL:   session.ShareURL,
+			Command:    displayCommand(launch.DisplayArguments),
+			ReadOnly:   session.ReadOnly,
+			Encrypted:  session.Encrypted,
+			Persistent: session.Persistent,
+			StartedAt:  processStartedAt.UnixMilli(),
+		})
+		if isBackgroundChild() {
 			sendBackgroundResult(backgroundLaunchResult{
 				OK:         true,
 				ID:         session.ID,
@@ -284,7 +252,42 @@ func run(arguments []string, stdout, stderr io.Writer) int {
 				ClosesAt:   closesAt,
 				Handoff:    launch.Handoff,
 			})
+			return
 		}
+		if *jsonOutput {
+			event := map[string]any{
+				"type":       "session",
+				"session_id": session.ID,
+				"share_url":  session.ShareURL,
+				"read_only":  session.ReadOnly,
+				"encrypted":  session.Encrypted,
+				"persistent": session.Persistent,
+				"auto_close": "task",
+				"expires_at": session.ExpiresAt.Format(time.RFC3339),
+				"background": false,
+			}
+			if password != "" {
+				event["e2ee_password"] = password
+			}
+			if closesAt != nil {
+				event["auto_close"] = "deadline"
+				event["closes_at"] = closesAt.Format(time.RFC3339)
+			}
+			encoded, _ := json.Marshal(event)
+			fmt.Fprintf(stderr, "%s\n", encoded)
+			return
+		}
+		printSessionCard(stderr, backgroundLaunchResult{
+			OK: true, ID: session.ID, ShareURL: session.ShareURL, ReadOnly: session.ReadOnly,
+			Encrypted: session.Encrypted, Password: password, Persistent: session.Persistent,
+			ExpiresAt: session.ExpiresAt, ClosesAt: closesAt, Handoff: launch.Handoff,
+		}, false)
+	}
+	var onConnected, onStarted func()
+	if isBackgroundChild() {
+		onStarted = announceSession
+	} else {
+		onConnected = announceSession
 	}
 	exitCode, err := runSharedProcess(
 		processContext,
@@ -293,6 +296,7 @@ func run(arguments []string, stdout, stderr io.Writer) int {
 		launch.Environment,
 		stdout,
 		stderr,
+		onConnected,
 		onStarted,
 		control,
 	)

--- a/cmd/shell/session_unix.go
+++ b/cmd/shell/session_unix.go
@@ -49,13 +49,35 @@ func runSharedProcess(
 	commandEnvironment []string,
 	stdout io.Writer,
 	stderr io.Writer,
+	onConnected func(),
 	onStarted func(),
 	control localSessionControl,
 ) (int, error) {
 	// Keep the relay alive after the task context is cancelled so the final
 	// terminal state and exit event can still reach the browser.
 	relayContext, cancelRelay := context.WithCancel(context.Background())
-	connection, err := relay.Dial(relayContext, session.WebSocketURL, session.HostToken)
+	type dialResult struct {
+		connection *relay.Connection
+		err        error
+	}
+	dialed := make(chan dialResult, 1)
+	go func() {
+		connection, err := relay.Dial(relayContext, session.WebSocketURL, session.HostToken)
+		dialed <- dialResult{connection: connection, err: err}
+	}()
+	var connection *relay.Connection
+	var err error
+	select {
+	case result := <-dialed:
+		connection, err = result.connection, result.err
+	case <-ctx.Done():
+		cancelRelay()
+		result := <-dialed
+		if result.connection != nil {
+			result.connection.Close()
+		}
+		return 1, fmt.Errorf("connect relay: %w", ctx.Err())
+	}
 	if err != nil {
 		cancelRelay()
 		return 1, fmt.Errorf("connect relay: %w", err)
@@ -64,6 +86,9 @@ func runSharedProcess(
 		cancelRelay()
 		connection.Close()
 	}()
+	if onConnected != nil {
+		onConnected()
+	}
 
 	outputRing := ringbuffer.New(snapshotBytes)
 

--- a/cmd/shell/session_unix_test.go
+++ b/cmd/shell/session_unix_test.go
@@ -4,17 +4,68 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"shell.online/internal/api"
 	"shell.online/internal/protocol"
 	"shell.online/internal/ringbuffer"
 )
+
+func TestSharedProcessCancelsHangingRelayDialBeforeAnnouncing(t *testing.T) {
+	requestStarted := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+		close(requestStarted)
+		<-request.Context().Done()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	announced := make(chan struct{}, 1)
+	go func() {
+		_, err := runSharedProcess(
+			ctx,
+			api.Session{WebSocketURL: "ws" + strings.TrimPrefix(server.URL, "http"), HostToken: "test-token"},
+			[]string{"/bin/sh", "-c", "sleep 1"},
+			nil,
+			io.Discard,
+			io.Discard,
+			func() { announced <- struct{}{} },
+			nil,
+			nil,
+		)
+		result <- err
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("relay dial never started")
+	}
+	cancel()
+	select {
+	case err := <-result:
+		if err == nil || !strings.Contains(err.Error(), "context canceled") {
+			t.Fatalf("cancelled relay dial returned %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("relay dial ignored cancellation")
+	}
+	select {
+	case <-announced:
+		t.Fatal("share was announced before the relay connected")
+	default:
+	}
+}
 
 func TestTerminalEnvironmentAdvertisesBrowserCapabilities(t *testing.T) {
 	environment := terminalEnvironment([]string{
@@ -225,9 +276,10 @@ func TestLocalAttachmentReplaysAndMirrorsTerminal(t *testing.T) {
 	case <-time.After(50 * time.Millisecond):
 		// The compatibility request is acknowledged without deforming the PTY.
 	}
-	if err := connection.Close(); err != nil {
-		t.Fatal(err)
-	}
+	// The observable contract is the server-side detach below. Some emulated
+	// Unix kernels report EBADF when both ends finish the socket concurrently,
+	// even though the descriptor is already closed as requested.
+	_ = connection.Close()
 	select {
 	case attached := <-attachChanges:
 		if attached {

--- a/cmd/shell/sessions_duplicate_unix_test.go
+++ b/cmd/shell/sessions_duplicate_unix_test.go
@@ -1,0 +1,46 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStartLocalSessionRefusesDuplicateOwner(t *testing.T) {
+	runtimeDirectory, err := os.MkdirTemp("/tmp", "shell-duplicate-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(runtimeDirectory) })
+	t.Setenv("SHELL_ONLINE_RUNTIME_DIR", runtimeDirectory)
+	record := localSessionRecord{
+		ID:        strings.Repeat("a", 32),
+		PID:       1234,
+		StartedAt: time.Now(),
+		Command:   "sleep 60",
+	}
+	first, err := startLocalSession(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Close()
+
+	if _, err := startLocalSession(record); err == nil ||
+		(!strings.Contains(err.Error(), "already running") && !strings.Contains(err.Error(), "already active")) {
+		t.Fatalf("duplicate start error = %v, want an active-session refusal", err)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		response, pingError := sendLocalControl(record.ID, "ping")
+		if pingError == nil && response.OK && response.PID == record.PID {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("original control channel was clobbered: response=%+v err=%v", response, pingError)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}

--- a/cmd/shell/sessions_unix.go
+++ b/cmd/shell/sessions_unix.go
@@ -43,6 +43,13 @@ func startLocalSession(record localSessionRecord) (localSessionControl, error) {
 	if err != nil {
 		return nil, err
 	}
+	if response, pingError := sendLocalControl(record.ID, "ping"); pingError == nil && response.OK {
+		return nil, fmt.Errorf(
+			"session is already running locally (pid %d); stop it with shell kill %s",
+			response.PID,
+			shortSessionID(record.ID),
+		)
+	}
 	listener, err := listenLocalControl(record.ID)
 	if err != nil {
 		return nil, fmt.Errorf("listen on local control channel: %w", err)

--- a/scripts/test-landing-seo.mjs
+++ b/scripts/test-landing-seo.mjs
@@ -134,6 +134,11 @@ for (const page of ["docs", "cli", "mobile", "reliability", "security", "e2ee", 
 }
 check(landingSource.includes('import documentationContent from "../docs/content.json"'), "Website must render from the repository documentation source");
 check(workerSource.includes('url.pathname === "/api/docs/releases"'), "Dynamic documentation release endpoint is missing");
+check(
+  workerSource.includes('url.searchParams.get("go-get") === "1"') &&
+    workerSource.includes('name="go-import" content="shell.online git https://github.com/TeoSlayer/shell.online"'),
+  "The canonical domain must publish Go module discovery metadata",
+);
 check(workerSource.includes("raw.githubusercontent.com/TeoSlayer/shell.online/v${version}/docs/content.json"), "Tagged documentation source endpoint is missing");
 check(robots.includes("User-agent: *\nAllow: /"), "robots.txt does not allow the canonical landing page");
 check(robots.includes("Sitemap: https://shell.online/sitemap.xml"), "robots.txt does not advertise the sitemap");

--- a/scripts/test-mobile-controls.mjs
+++ b/scripts/test-mobile-controls.mjs
@@ -14,4 +14,11 @@ if (!mobileRule.includes('font: 600 12px/1 "Uncut Sans", sans-serif')) {
   throw new Error("Mobile terminal key labels must retain their legible size");
 }
 
-console.log("Mobile terminal navigation touch targets passed.");
+if (stylesheet.includes(".session-access.encryption { max-width: 30vw")) {
+  throw new Error("Mobile encryption labels must not be clipped to 30vw");
+}
+if (!stylesheet.includes("content: attr(data-compact-label)")) {
+  throw new Error("Mobile encryption labels must expose a deliberate compact label");
+}
+
+console.log("Mobile terminal navigation and compact badges passed.");

--- a/scripts/test-qemu-linux.sh
+++ b/scripts/test-qemu-linux.sh
@@ -57,13 +57,26 @@ run_target() {
       ;;
   esac
 
-  export CGO_ENABLED=0 GOOS=linux GOARCH=$target_arch
+  export CGO_ENABLED=0 GOOS=linux GOARCH=$target_arch SHELL_ONLINE_QEMU=1
   output=$test_root/$artifact
 
   printf '\n==> QEMU runtime test: %s via %s\n' "$artifact" "$emulator"
   (
     cd "$repository_root"
-    go test -count=1 -timeout=2m -exec "$emulator" ./...
+    # User-mode QEMU occasionally returns transient EBADF or stalls a local
+    # httptest socket while translating a foreign Go runtime. Retry the whole
+    # suite, never an individual assertion: a deterministic failure still
+    # fails three complete runs, while an emulator hiccup does not reject an
+    # otherwise working release artifact.
+    attempt=1
+    while ! go test -count=1 -timeout=2m -exec "$emulator" ./...; do
+      if [ "$attempt" -ge 3 ]; then
+        printf 'QEMU suite failed three times for %s.\n' "$artifact" >&2
+        exit 1
+      fi
+      attempt=$((attempt + 1))
+      printf 'Retrying QEMU suite for %s (attempt %s/3).\n' "$artifact" "$attempt" >&2
+    done
     go build -buildvcs=false -trimpath -ldflags='-s -w -X main.version=qemu-test' -o "$output" ./cmd/shell
   )
 

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -12,6 +12,12 @@ export const enum Opcode {
 
 export const MAX_INPUT_CHUNK = 16 * 1024;
 
+export function isSnapshotOpcode(opcode: number): boolean {
+  return opcode === Opcode.Snapshot ||
+    opcode === Opcode.FinalSnapshot ||
+    opcode === Opcode.BroadcastSnapshot;
+}
+
 export function encodeFrame(opcode: Opcode, payload: Uint8Array): Uint8Array<ArrayBuffer> {
   const frame = new Uint8Array(payload.byteLength + 1);
   frame[0] = opcode;

--- a/shared/session-capacity.ts
+++ b/shared/session-capacity.ts
@@ -1,0 +1,20 @@
+export const MAX_SESSION_VIEWERS = 16;
+export const SESSION_FULL_CLOSE_CODE = 4005;
+export const SESSION_FULL_CLOSE_REASON = "session is full";
+
+export type ViewerAdmission =
+  | { accepted: true }
+  | { accepted: false; closeCode: number; reason: string };
+
+export function viewerAdmission(activeViewers: number): ViewerAdmission {
+  if (activeViewers < MAX_SESSION_VIEWERS) return { accepted: true };
+  return {
+    accepted: false,
+    closeCode: SESSION_FULL_CLOSE_CODE,
+    reason: SESSION_FULL_CLOSE_REASON,
+  };
+}
+
+export function isSessionFullClose(code: number): boolean {
+  return code === SESSION_FULL_CLOSE_CODE;
+}

--- a/tests/protocol.test.ts
+++ b/tests/protocol.test.ts
@@ -5,6 +5,7 @@ import {
   encodeFrame,
   encodeLatencyProbe,
   encodeResize,
+  isSnapshotOpcode,
   Opcode,
 } from "../shared/protocol";
 
@@ -25,6 +26,13 @@ describe("terminal wire protocol", () => {
   it("reserves a recovery snapshot opcode distinct from targeted snapshots", () => {
     expect(Opcode.BroadcastSnapshot).toBe(0x08);
     expect(Opcode.BroadcastSnapshot).not.toBe(Opcode.Snapshot);
+  });
+
+  it("treats targeted, final, and recovery frames as full snapshots", () => {
+    expect(isSnapshotOpcode(Opcode.Snapshot)).toBe(true);
+    expect(isSnapshotOpcode(Opcode.FinalSnapshot)).toBe(true);
+    expect(isSnapshotOpcode(Opcode.BroadcastSnapshot)).toBe(true);
+    expect(isSnapshotOpcode(Opcode.Output)).toBe(false);
   });
 
   it("rejects malformed resize messages", () => {

--- a/tests/session-capacity.test.ts
+++ b/tests/session-capacity.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSessionFullClose,
+  MAX_SESSION_VIEWERS,
+  SESSION_FULL_CLOSE_CODE,
+  SESSION_FULL_CLOSE_REASON,
+  viewerAdmission,
+} from "../shared/session-capacity";
+
+describe("session viewer capacity", () => {
+  it("admits viewers until all slots are occupied", () => {
+    expect(viewerAdmission(MAX_SESSION_VIEWERS - 1)).toEqual({ accepted: true });
+  });
+
+  it("turns a full session into a browser-visible WebSocket close", () => {
+    expect(viewerAdmission(MAX_SESSION_VIEWERS)).toEqual({
+      accepted: false,
+      closeCode: SESSION_FULL_CLOSE_CODE,
+      reason: SESSION_FULL_CLOSE_REASON,
+    });
+    expect(viewerAdmission(MAX_SESSION_VIEWERS + 1).accepted).toBe(false);
+    expect(isSessionFullClose(SESSION_FULL_CLOSE_CODE)).toBe(true);
+    expect(isSessionFullClose(4000)).toBe(false);
+    expect(isSessionFullClose(4004)).toBe(false);
+  });
+});

--- a/web/main.ts
+++ b/web/main.ts
@@ -14,9 +14,14 @@ import {
   decodeLatencyProbe,
   encodeFrame,
   encodeLatencyProbe,
+  isSnapshotOpcode,
   Opcode,
 } from "../shared/protocol";
 import { readOnlyFromControlMessage } from "../shared/session-access";
+import {
+  isSessionFullClose,
+  MAX_SESSION_VIEWERS,
+} from "../shared/session-capacity";
 import { RELEASE_CHECKSUMS_PATH, RELEASE_VERSION } from "../shared/release";
 import {
   formatGitHubStarCount,
@@ -1028,7 +1033,7 @@ function renderTerminal(sessionId: string): void {
           <span id="session-label">terminal</span>
           <span id="session-access" class="session-access" hidden>View only</span>
           <span id="session-encryption" class="session-access encryption" hidden>End-to-end encrypted</span>
-          <span id="session-status" class="status offline"><i></i><b>Offline</b></span>
+          <span id="session-status" class="status offline" role="status" aria-live="polite"><i></i><b>Offline</b></span>
           <span id="typing-status" class="typing-status" hidden></span>
         </div>
         <div class="session-actions">
@@ -1265,6 +1270,7 @@ function renderTerminal(sessionId: string): void {
   let encryptedSession = false;
   let persistentSession = false;
   let waitingForEncryptionKey = false;
+  let waitingForCapacity = false;
   let outgoingFrames = Promise.resolve();
   let incomingFrames = Promise.resolve();
 
@@ -1316,9 +1322,12 @@ function renderTerminal(sessionId: string): void {
     encryptedSession = encrypted;
     encryptionBadge.hidden = false;
     encryptionBadge.classList.toggle("unencrypted", !encrypted);
-    encryptionBadge.textContent = encrypted
+    const fullLabel = encrypted
       ? persistentSession ? "Persistent E2EE" : "End-to-end encrypted"
       : "Transport only";
+    encryptionBadge.textContent = fullLabel;
+    encryptionBadge.setAttribute("aria-label", fullLabel);
+    encryptionBadge.dataset.compactLabel = encrypted ? persistentSession ? "Persistent" : "E2EE" : "Transport";
     renderAccessDescription();
     if (encrypted && !frameCipher && !encryptionDescriptor) {
       showEncryptionGate("This E2EE link is missing its decryption fragment. Ask the sender for the complete URL, including everything after #.", false);
@@ -1505,12 +1514,17 @@ function renderTerminal(sessionId: string): void {
 
   const renderConnectionStatus = (): void => {
     const online = lastStatus === "connected" && latencyMilliseconds !== null;
+    const waitingForSlot = lastStatus === "full";
     statusElement.className = `status ${online ? "connected" : "offline"} state-${lastStatus}`;
     statusElement.setAttribute(
       "aria-label",
-      online ? `${latencyMilliseconds} millisecond round-trip latency to the shared machine` : "Offline",
+      online
+        ? `${latencyMilliseconds} millisecond round-trip latency to the shared machine`
+        : waitingForSlot
+          ? `Session full; waiting for one of ${MAX_SESSION_VIEWERS} viewer slots`
+          : "Offline",
     );
-    if (statusText) statusText.textContent = online ? `${latencyMilliseconds} ms` : "Offline";
+    if (statusText) statusText.textContent = online ? `${latencyMilliseconds} ms` : waitingForSlot ? "Full · waiting" : "Offline";
     renderLatencyGraph();
   };
 
@@ -1679,7 +1693,22 @@ function renderTerminal(sessionId: string): void {
     setStatus("exited");
   };
 
-  const retryOrShowMissing = async (): Promise<void> => {
+  const showSessionFull = (): void => {
+    if (!waitingForCapacity) {
+      waitingForCapacity = true;
+      sessionPage.classList.add("session-full");
+      terminal.options.disableStdin = true;
+      terminal.blur();
+      helperTextarea?.blur();
+      terminalWrites.enqueue(textEncoder.encode(
+        "\x1b[2J\x1b[H\r\n  \x1b[1;37mSession is full.\x1b[0m" +
+        `\r\n  \x1b[90m${MAX_SESSION_VIEWERS} viewers are connected. You will join automatically when a slot opens.\x1b[0m\r\n`,
+      ), true);
+    }
+    setStatus("full");
+  };
+
+  const retryOrShowMissing = async (retryStatus = "disconnected"): Promise<void> => {
     try {
       const response = await fetch(`/api/sessions/${sessionId}`, {
         cache: "no-store",
@@ -1694,7 +1723,7 @@ function renderTerminal(sessionId: string): void {
     }
 
     if (stopped) return;
-    setStatus("disconnected");
+    setStatus(retryStatus);
     const delay = Math.min(10_000, 500 * 2 ** retryAttempt) + Math.random() * 250;
     retryAttempt += 1;
     retryTimer = window.setTimeout(connect, delay);
@@ -1702,16 +1731,15 @@ function renderTerminal(sessionId: string): void {
 
   const connect = (): void => {
     if (stopped) return;
-    setStatus("connecting");
+    setStatus(waitingForCapacity ? "full" : "connecting");
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
     socket = new WebSocket(`${protocol}//${window.location.host}/api/sessions/${sessionId}/ws`);
     socket.binaryType = "arraybuffer";
 
     socket.addEventListener("open", () => {
-      retryAttempt = 0;
       terminalInput.flush();
       scheduleFit();
-      if (!compactSessionQuery.matches && !readOnly) terminal.focus();
+      if (!waitingForCapacity && !compactSessionQuery.matches && !readOnly) terminal.focus();
     });
 
     socket.addEventListener("message", (event: MessageEvent<string | ArrayBuffer>) => {
@@ -1736,7 +1764,7 @@ function renderTerminal(sessionId: string): void {
         }
         if (frame.byteLength === 0) return;
         if (receiveLatencyResponse(frame)) return;
-        if (frame[0] === Opcode.Snapshot || frame[0] === Opcode.FinalSnapshot) {
+        if (isSnapshotOpcode(frame[0])) {
           terminalWrites.enqueue(frame.subarray(1), true);
           snapshotRequestPending = false;
         } else if (frame[0] === Opcode.Output) {
@@ -1764,6 +1792,11 @@ function renderTerminal(sessionId: string): void {
       }
       if (event.code === 4000) {
         showEndedSession();
+        return;
+      }
+      if (isSessionFullClose(event.code)) {
+        showSessionFull();
+        void retryOrShowMissing("full");
         return;
       }
       if (waitingForEncryptionKey || stopped || lastStatus === "exited") return;
@@ -1798,12 +1831,18 @@ function renderTerminal(sessionId: string): void {
       return;
     }
 
+    // Any server message means this retry was admitted. The next snapshot
+    // replaces the capacity notice with the live terminal.
+    retryAttempt = 0;
+    waitingForCapacity = false;
+    sessionPage.classList.remove("session-full");
+
     const messageReadOnly = readOnlyFromControlMessage(message);
     if (messageReadOnly !== null) applyReadOnly(messageReadOnly);
     if (typeof message.encrypted === "boolean") applyEncryptionMode(message.encrypted);
     if (typeof message.persistent === "boolean") {
       persistentSession = message.persistent;
-      if (encryptedSession) encryptionBadge.textContent = persistentSession ? "Persistent E2EE" : "End-to-end encrypted";
+      if (encryptedSession) applyEncryptionMode(true);
     }
 
     if (message.type === "access_denied" && message.reason === "read_only") {

--- a/web/style.css
+++ b/web/style.css
@@ -945,7 +945,15 @@ a {
   .encryption-gate { padding: 14px; }
   .encryption-panel { padding: 25px 21px; border-radius: 15px; }
   .encryption-panel h2 { font-size: 23px; }
-  .session-access.encryption { max-width: 30vw; overflow: hidden; text-overflow: ellipsis; }
+  .session-access.encryption {
+    max-width: none;
+    overflow: visible;
+    font-size: 0;
+  }
+  .session-access.encryption::after {
+    content: attr(data-compact-label);
+    font-size: 9px;
+  }
 }
 
 #session-label {
@@ -994,6 +1002,15 @@ a {
 
 .status.offline {
   color: #7e899d;
+}
+
+.status.state-full {
+  color: #d8b879;
+}
+
+.status.state-full i {
+  background: #d7a84d;
+  box-shadow: 0 0 0 3px rgb(215 168 77 / 14%);
 }
 
 .typing-status {
@@ -1615,6 +1632,15 @@ a {
 
 .session-page.theme-light .status.offline {
   color: #6d778a;
+}
+
+.session-page.theme-light .status.state-full {
+  color: #8a641b;
+}
+
+.session-page.theme-light .status.state-full i {
+  background: #b9811c;
+  box-shadow: 0 0 0 3px rgb(185 129 28 / 12%);
 }
 
 .session-page.theme-light .status i {

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -13,6 +13,10 @@ import { isStatsRange } from "../shared/stats";
 import { RELEASE_VERSION } from "../shared/release";
 import { downloadAssetIsSpaFallback } from "../shared/download-assets";
 import { viewerFrameAction } from "../shared/session-access";
+import {
+  MAX_SESSION_VIEWERS,
+  viewerAdmission,
+} from "../shared/session-capacity";
 import { terminalGridForDevices } from "../shared/terminal-grid";
 import { persistentSessionID } from "../shared/persistent-session";
 import {
@@ -44,7 +48,6 @@ import {
 
 export { StatsStore };
 
-const MAX_VIEWERS = 16;
 const MAX_LIVE_FRAME_BYTES = 64 * 1024;
 const MAX_INPUT_FRAME_BYTES = 16 * 1024 + 1;
 const MAX_SNAPSHOT_BYTES = 512 * 1024;
@@ -151,6 +154,15 @@ interface InitializeSessionBody {
 export default {
   async fetch(request, env, executionContext): Promise<Response> {
     const url = new URL(request.url);
+
+    // Let the Go tool resolve `go install shell.online/cmd/shell@latest`
+    // without redirecting people away from the canonical shell.online URL.
+    if (url.searchParams.get("go-get") === "1") {
+      return new Response(
+        '<!doctype html><meta name="go-import" content="shell.online git https://github.com/TeoSlayer/shell.online">\n',
+        { headers: { "Content-Type": "text/html; charset=utf-8" } },
+      );
+    }
 
     if (url.pathname === "/api/health" && request.method === "GET") {
       return json({ ok: true, service: "shell.online", version: RELEASE_VERSION });
@@ -857,11 +869,20 @@ export class TerminalSession extends DurableObject<Env> {
       role = "host";
     }
 
-    if (
-      role === "viewer" &&
-      this.state.getWebSockets("viewer").filter((socket) => socket.readyState === 1).length >= MAX_VIEWERS
-    ) {
-      return json({ error: "session is full" }, 429);
+    const activeViewerCount = role === "viewer"
+      ? this.state.getWebSockets("viewer").filter((socket) => socket.readyState === 1).length
+      : 0;
+    const admission = viewerAdmission(activeViewerCount);
+    if (role === "viewer" && !admission.accepted) {
+      // Browser WebSockets hide an upgrade rejection's status and body. Finish
+      // the upgrade, then close with a code the viewer can explain and retry.
+      const pair = new WebSocketPair();
+      const client = pair[0];
+      const server = pair[1];
+      server.serializeAttachment({ role: "viewer", id: 0, ended: true } satisfies SocketAttachment);
+      this.state.acceptWebSocket(server, ["rejected"]);
+      safeClose(server, admission.closeCode, admission.reason);
+      return new Response(null, { status: 101, webSocket: client });
     }
 
     if (role === "host") {
@@ -1101,12 +1122,9 @@ export class TerminalSession extends DurableObject<Env> {
           safeClose(socket, 4009, "broadcast snapshot too large");
           return;
         }
-        {
-          const snapshot = new Uint8Array(frame.byteLength);
-          snapshot[0] = Opcode.Snapshot;
-          snapshot.set(frame.subarray(1), 1);
-          this.broadcastBinary(snapshot, "viewer");
-        }
+        // Preserve the opcode: encrypted frames authenticate it as associated
+        // data, and rewriting it makes a valid recovery snapshot undecryptable.
+        this.broadcastBinary(frame, "viewer");
         return;
 
       case Opcode.Pong:
@@ -1431,10 +1449,10 @@ export class TerminalSession extends DurableObject<Env> {
         .map((socket) => readAttachment(socket)?.guestNumber)
         .filter((value): value is number => typeof value === "number"),
     );
-    for (let number = 1; number <= MAX_VIEWERS; number += 1) {
+    for (let number = 1; number <= MAX_SESSION_VIEWERS; number += 1) {
       if (!used.has(number)) return number;
     }
-    return MAX_VIEWERS;
+    return MAX_SESSION_VIEWERS;
   }
 
   private claimInputLease(


### PR DESCRIPTION
## Summary

- keep the background readiness FD out of wrapped processes and make relay dialing signal-aware
- announce sessions only after the relay is connected or the background process has actually started
- honor long auto-close deadlines and refuse duplicate local owners of persistent sessions
- preserve authenticated E2EE recovery snapshots under backpressure
- make mobile encryption labels compact without clipping
- explain full sessions in both browser clients and retry automatically
- publish canonical Go module discovery metadata (the useful portion of #4)
- update all three CodeQL action steps atomically to v4.37.9

## Verification

- `go test -race ./...`
- `go vet ./...`
- `npm run check`
- `npm run build:web`
- `npm --prefix app test`
- `npm --prefix app run build`

Supersedes #46 while retaining its implementation approach. Credits @artemiia for the reports and capacity fix, and @SimonHitzel for the Go discovery contribution.

Closes #44
Closes #47
Closes #48
Closes #49
Closes #50
Closes #52
Closes #53
