### PR TITLE
Integrate and harden app production fixes

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -46,9 +46,50 @@ jobs:
       - run: npm ci
         working-directory: app
 
+      # Fails here, naming what is missing, rather than somewhere further in
+      # where the symptom no longer resembles the cause. An unset repository
+      # variable is the empty string, and every one of these was empty on the
+      # first run of this workflow.
+      - name: Check the deploy has what it needs
+        env:
+          CLOUD_SQL_INSTANCE: ${{ vars.CLOUD_SQL_INSTANCE }}
+          HYPERDRIVE_ID: ${{ vars.HYPERDRIVE_ID }}
+          MAIL_FROM: ${{ vars.MAIL_FROM }}
+          WEB_ORIGIN: ${{ vars.WEB_ORIGIN }}
+          FIREBASE_PROJECT_ID: ${{ vars.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_API_KEY: ${{ vars.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ vars.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_APP_ID: ${{ vars.VITE_FIREBASE_APP_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          missing=
+          for name in CLOUD_SQL_INSTANCE HYPERDRIVE_ID MAIL_FROM WEB_ORIGIN \
+                      FIREBASE_PROJECT_ID VITE_FIREBASE_API_KEY \
+                      VITE_FIREBASE_AUTH_DOMAIN VITE_FIREBASE_APP_ID \
+                      CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID DATABASE_URL; do
+            eval "value=\${$name}"
+            if [ -z "$value" ]; then missing="$missing $name"; fi
+          done
+          if [ -n "$missing" ]; then
+            echo "Not set:$missing" >&2
+            echo "Repository variables: CLOUD_SQL_INSTANCE HYPERDRIVE_ID MAIL_FROM WEB_ORIGIN VITE_FIREBASE_*" >&2
+            echo "Repository secrets:   CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID DATABASE_URL" >&2
+            exit 1
+          fi
+
       # The Firebase values are compiled into the client, so they are build
-      # inputs rather than runtime configuration. They are not secret, but they
-      # do differ per environment, so they come from the environment's config.
+      # inputs rather than runtime configuration. They are per-environment and
+      # they are not kept in the repository, so they come from here.
+      #
+      # VITE_ACCOUNTS_URL and VITE_RELAY_URL are deliberately absent: they are
+      # plain origins with nothing to protect, app/.env.production holds them,
+      # and passing them from an unset variable is what broke this workflow.
+      # An unset variable arrives as the empty string, overrides
+      # .env.production, and compiles a client that reaches nothing --
+      # VITE_RELAY_URL:`` builds cleanly and opens no session. The preflight
+      # above and check-bundle.mjs both refuse that now.
       - name: Build the client
         run: npm run build
         working-directory: app
@@ -58,8 +99,6 @@ jobs:
           VITE_FIREBASE_PROJECT_ID: ${{ vars.VITE_FIREBASE_PROJECT_ID }}
           VITE_FIREBASE_APP_ID: ${{ vars.VITE_FIREBASE_APP_ID }}
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ vars.VITE_FIREBASE_MESSAGING_SENDER_ID }}
-          VITE_ACCOUNTS_URL: ""
-          VITE_RELAY_URL: ${{ vars.RELAY_URL }}
 
       - id: gcp
         name: Authenticate to Google Cloud

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ bin/
 .env
 .env.*
 !.env.example
+# Build-time values that Vite compiles into a public bundle: an origin and an
+# empty string, no credentials. Ignoring it is what let development values
+# reach production twice, since there was then nothing to override .env.local.
+!app/.env.production
 *.pem
 *.key
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable user-visible changes are recorded here. Versions follow [Semantic Ve
 
 - Route every accounts-app asset response through its Worker security-header wrapper.
 - Treat exhausted Copilot review quota as advisory instead of failing otherwise valid pull requests.
+- Draw a terminal opened in the web app at the size the process is actually running at. The pane sized the emulator to its own pixels instead, so a 120-column session was drawn at around 110 columns and 24 of its 36 rows: every long line wrapped a second time and the bottom third of anything full-screen was missing. It now scales the type to fit the session's grid, the way the standalone viewer already did, and follows that grid when a phone joins or leaves the session.
 
 ## [0.9.0] — 2026-09-08
 

--- a/app/.env.production
+++ b/app/.env.production
@@ -1,0 +1,17 @@
+# Build-time values for `vite build`. Vite loads .env.[mode] after .env.local,
+# so these win over a developer's local overrides -- which is the whole point.
+#
+# Without this file, a production build made on a machine that has .env.local
+# inherits its development values. That shipped twice: a bundle asking every
+# browser for the accounts service on 127.0.0.1:8787, and one refusing to open
+# any session because it believed the relay was on 127.0.0.1:8788.
+#
+# Nothing secret belongs here. These are compiled into a public bundle.
+
+# Empty means same origin. The Worker serves this client and answers /api/*.
+VITE_ACCOUNTS_URL=
+
+# The relay that holds the terminal sockets. Session links point at it, and
+# the app proxies /relay/* there, so the client has to agree with the Worker's
+# RELAY_URL.
+VITE_RELAY_URL=https://shell.online

--- a/app/package.json
+++ b/app/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "build": "tsc -b && vite build && npm run build:server",
+    "build": "tsc -b && vite build && npm run build:server && node scripts/check-bundle.mjs",
     "build:server": "esbuild server/index.ts --bundle --platform=node --target=node22 --format=esm --packages=external --outfile=dist-server/index.js && cp -R server/lib/migrations dist-server/migrations",
     "check:protocol": "node scripts/check-protocol.mjs",
     "db:import": "tsx server/import-json.ts",
@@ -20,7 +20,9 @@
     "test": "vitest run && node scripts/check-protocol.mjs",
     "test:pg": "TEST_DATABASE_URL=${TEST_DATABASE_URL:-postgres://postgres:dev@localhost:5433/shell_online} vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc -b --force"
+    "typecheck": "tsc -b --force",
+    "verify:deploy": "node scripts/verify-deploy.mjs",
+    "verify:bundle": "node scripts/check-bundle.mjs"
   },
   "dependencies": {
     "@phosphor-icons/react": "^2.1.10",

--- a/app/scripts/check-bundle.mjs
+++ b/app/scripts/check-bundle.mjs
@@ -1,0 +1,90 @@
+/**
+ * Refuses a production bundle that points at a developer's machine.
+ *
+ *   node scripts/check-bundle.mjs [dist]
+ *
+ * Vite inlines import.meta.env at build time, and .env.local applies to every
+ * build on the machine that has one. So a production build made anywhere but
+ * CI quietly inherits development values, and the result is a bundle that
+ * loads perfectly and then asks the reader's own computer for the service.
+ *
+ * This has now shipped twice: VITE_ACCOUNTS_URL left at 127.0.0.1:8787, so
+ * every API call failed; and VITE_RELAY_URL left at 127.0.0.1:8788, so no
+ * session would open. Both were invisible in review and obvious in
+ * production, which is the wrong way round.
+ *
+ * Grepping the built output is crude and it is the only check that sees what
+ * was actually compiled rather than what the source intended.
+ */
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const directory = process.argv[2] ?? "dist";
+
+/* Loopback in any form a URL can take. */
+const FORBIDDEN = [/\blocalhost:\d+/gu, /\b127\.0\.0\.1:\d+/gu, /\b0\.0\.0\.0:\d+/gu, /\[::1\]:\d+/gu];
+
+async function* files(dir) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) yield* files(path);
+    else if (/\.(?:js|css|html)$/u.test(entry.name)) yield path;
+  }
+}
+
+const found = [];
+for await (const path of files(directory)) {
+  const body = await readFile(path, "utf8");
+  for (const pattern of FORBIDDEN) {
+    for (const match of body.matchAll(pattern)) {
+      const at = match.index ?? 0;
+      found.push({ path, value: match[0], near: body.slice(Math.max(0, at - 60), at + 30) });
+    }
+  }
+}
+
+if (found.length > 0) {
+  console.error(`check-bundle: ${found.length} loopback reference(s) in the production build`);
+  for (const { path, value, near } of found.slice(0, 10)) {
+    console.error(`  ${path}: ${value}`);
+    console.error(`    ...${near.replace(/\s+/gu, " ")}`);
+  }
+  console.error("  A deployed page cannot reach the reader's own machine.");
+  console.error("  Check .env.production against .env.local, then rebuild.");
+  process.exit(1);
+}
+
+/*
+ * Blank is its own failure. An unset repository variable arrives as the empty
+ * string and overrides .env.production, so the build succeeds and compiles a
+ * client that cannot reach anything: VITE_RELAY_URL:`` shipped exactly that
+ * way, and no session would open.
+ */
+const REQUIRED = [
+  "VITE_RELAY_URL",
+  "VITE_FIREBASE_API_KEY",
+  "VITE_FIREBASE_AUTH_DOMAIN",
+  "VITE_FIREBASE_PROJECT_ID",
+  "VITE_FIREBASE_APP_ID",
+];
+
+const blank = [];
+for await (const path of files(directory)) {
+  if (!path.endsWith(".js")) continue;
+  const body = await readFile(path, "utf8");
+  for (const key of REQUIRED) {
+    /* Vite inlines these as `KEY:`value`` in the env object it compiles in. */
+    const match = body.match(new RegExp(`${key}\\s*:\\s*\`([^\`]*)\``, "u"));
+    if (match && match[1].trim() === "") blank.push({ path, key });
+  }
+}
+
+if (blank.length > 0) {
+  console.error("check-bundle: required values are empty in the production build");
+  for (const { path, key } of blank) console.error(`  ${path}: ${key} is blank`);
+  console.error("  An unset variable overrides .env.production with an empty string.");
+  console.error("  Check the build step's env block against app/.env.production.");
+  process.exit(1);
+}
+
+console.log("check-bundle: no loopback addresses in the production build.");

--- a/app/scripts/check-protocol.mjs
+++ b/app/scripts/check-protocol.mjs
@@ -19,6 +19,8 @@ const upstream = process.env.SHELL_ONLINE_REPO ?? join(here, "..", "..");
 const FILES = [
   { vendored: "src/terminal/protocol.ts", source: "shared/protocol.ts" },
   { vendored: "src/terminal/e2ee.ts", source: "web/e2ee.ts" },
+  { vendored: "src/terminal/terminal-grid.ts", source: "shared/terminal-grid.ts" },
+  { vendored: "src/terminal/terminal-fit.ts", source: "web/terminal-fit.ts" },
 ];
 
 /* Copies kept in step within this repository rather than with shell.online. */

--- a/app/scripts/verify-deploy.mjs
+++ b/app/scripts/verify-deploy.mjs
@@ -1,0 +1,51 @@
+/**
+ * Checks that the deployment is actually serving the build sitting in ./dist.
+ *
+ *   node scripts/verify-deploy.mjs https://app.shell.online
+ *
+ * A Workers deploy can report success and keep serving the previous
+ * index.html: the hashed assets upload, wrangler says "No updated asset files
+ * to upload", and the document that points at them stays behind. The result
+ * is a fix that is live, reachable at its own URL, and invisible, which reads
+ * to everyone as the fix not working.
+ *
+ * Comparing the asset references is enough to catch it. The filenames carry a
+ * content hash, so identical references mean identical bytes.
+ */
+import { readFile } from "node:fs/promises";
+
+const origin = (process.argv[2] ?? "https://app.shell.online").replace(/\/+$/, "");
+const references = (html) => [...html.matchAll(/\/assets\/[A-Za-z0-9._-]+\.(?:js|css)/gu)].map((m) => m[0]);
+
+const local = references(await readFile("dist/index.html", "utf8")).sort();
+if (local.length === 0) {
+  console.error("verify-deploy: dist/index.html references no hashed assets; build first");
+  process.exit(1);
+}
+
+const response = await fetch(`${origin}/?cache-bust=${Date.now()}`, { headers: { "cache-control": "no-cache" } });
+if (!response.ok) {
+  console.error(`verify-deploy: ${origin} answered ${response.status}`);
+  process.exit(1);
+}
+const live = references(await response.text()).sort();
+
+const missing = local.filter((asset) => !live.includes(asset));
+if (missing.length > 0) {
+  console.error(`verify-deploy: ${origin} is serving a different build than ./dist`);
+  console.error(`  built here: ${local.join(", ")}`);
+  console.error(`  served:     ${live.join(", ") || "(none)"}`);
+  console.error("  Deploy again. The assets upload but the document can stay behind.");
+  process.exit(1);
+}
+
+/* Reachable is not the same as referenced, so each one is fetched. */
+for (const asset of local) {
+  const probe = await fetch(`${origin}${asset}`, { method: "HEAD" });
+  if (!probe.ok) {
+    console.error(`verify-deploy: ${asset} is referenced but answers ${probe.status}`);
+    process.exit(1);
+  }
+}
+
+console.log(`verify-deploy: ${origin} is serving this build (${local.length} assets).`);

--- a/app/src/components/NewSessionModal.tsx
+++ b/app/src/components/NewSessionModal.tsx
@@ -165,7 +165,7 @@ export function NewSessionModal({ devices, onClose, onStart }: NewSessionModalPr
               <p className="sheet-note">
                 <Warning size={14} weight="fill" />
                 <span>
-                  These flags come from the published interface for {kind.title}
+                  These flags come from the published interface for {kind.title}{" "}
                   rather than from its own help output, so check the command
                   below before starting.
                 </span>

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -2,7 +2,20 @@ import { auth } from "./firebase";
 
 export { machineOnline } from "./agent";
 
-const BASE = (import.meta.env.VITE_ACCOUNTS_URL ?? "http://127.0.0.1:8787").replace(/\/+$/, "");
+/*
+ * Empty means same origin, which is what a deployment is: the Worker serves
+ * this client and answers /api/* itself.
+ *
+ * The fallback is a development one and must never survive a build. It did
+ * once: an unset VITE_ACCOUNTS_URL left a production bundle asking every
+ * browser for 127.0.0.1:8787, so the app loaded and then failed on its first
+ * request with a message about a service on the user's own machine. Keying
+ * the fallback to DEV means forgetting the variable now costs nothing,
+ * because same origin is already right for every deployment.
+ */
+const BASE = (
+  import.meta.env.VITE_ACCOUNTS_URL ?? (import.meta.env.DEV ? "http://127.0.0.1:8787" : "")
+).replace(/\/+$/, "");
 
 export type Role = "owner" | "admin" | "member";
 

--- a/app/src/routes/Machines.tsx
+++ b/app/src/routes/Machines.tsx
@@ -35,10 +35,19 @@ export function Machines() {
     setUnlinking(device.id);
     try {
       await revokeDevice(device.id);
-      await load();
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : "Could not unlink.");
+      /*
+       * A machine that is already gone is the outcome this was asking for, so
+       * saying "no such machine" and leaving the row on screen is the one
+       * answer that is wrong on both counts. It happened: the list refreshed
+       * only on success, so any error left the unlinked machine sitting there
+       * looking like the button had failed.
+       */
+      const message = caught instanceof Error ? caught.message : "Could not unlink.";
+      if (!/no such machine/i.test(message)) setError(message);
     } finally {
+      /* Reload either way, so the list shows the server's answer, not ours. */
+      await load().catch(() => {});
       setUnlinking("");
     }
   }
@@ -109,6 +118,19 @@ export function Machines() {
                   linked {ago(device.createdAt, now)} · last used{" "}
                   {ago(device.lastSeenAt, now)}
                 </span>
+                {/*
+                 * A machine only polls once it has agreed to browser-started
+                 * sessions, and the default at that prompt is no. So the
+                 * common reason for this badge is a deliberate answer rather
+                 * than anything being wrong, and a bare "Offline" reads as a
+                 * fault and gives nobody the one command that changes it.
+                 */}
+                {!machineOnline(device, now) && (
+                  <span className="session-meta device-offline-hint">
+                    Publish-only until it agrees to browser-started sessions.
+                    Run <code>shell login --allow-remote-start</code> there.
+                  </span>
+                )}
               </div>
               <div className="session-actions">
                 <Button

--- a/app/src/routes/Workspace.tsx
+++ b/app/src/routes/Workspace.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
-import { Copy, Check, X, Terminal as TerminalIcon, List, Plus } from "@phosphor-icons/react";
+import { Copy, Check, X, Terminal as TerminalIcon, List, Plus, CaretRight } from "@phosphor-icons/react";
 import { Link, useSearchParams } from "react-router-dom";
 import { PersonChip } from "../components/Avatar";
 import { PersonPicker } from "../components/PersonPicker";
@@ -463,6 +463,19 @@ function SessionGroup({
   onKill: (session: SessionRecord) => void;
   onAssign: (session: SessionRecord, uid: string) => void;
 }) {
+  /*
+   * Which commands are shown in full. Collapsed by default: an agent command
+   * runs to a few hundred characters, and one of them widens the whole table
+   * and puts every other row behind a horizontal scrollbar.
+   */
+  const [shown, setShown] = useState<ReadonlySet<string>>(() => new Set());
+  const toggleCommand = (id: string) =>
+    setShown((current) => {
+      const next = new Set(current);
+      if (!next.delete(id)) next.add(id);
+      return next;
+    });
+
   return (
     <section className="sessions-group">
       <h2>{heading}</h2>
@@ -494,13 +507,36 @@ function SessionGroup({
                       data-live={live}
                     />
                     <span className="table-name">{session.name || session.command}</span>
-                    {session.name && session.name !== session.command && (
-                      <code className="table-command">{session.command}</code>
-                    )}
                   </Link>
+                  {/*
+                    * Outside the link, because it is a button and a button
+                    * inside an anchor is neither valid nor operable by
+                    * keyboard.
+                    */}
+                  {session.name && session.name !== session.command && (
+                    <>
+                      <button
+                        type="button"
+                        className="table-command-toggle"
+                        aria-expanded={shown.has(session.id)}
+                        aria-controls={`command-${session.id}`}
+                        onClick={() => toggleCommand(session.id)}
+                      >
+                        <CaretRight size={11} weight="bold" data-open={shown.has(session.id)} />
+                        command
+                      </button>
+                      {shown.has(session.id) && (
+                        /* Wraps rather than scrolls: a row should never be the
+                           thing that makes the page scroll sideways. */
+                        <code className="table-command" id={`command-${session.id}`}>
+                          {session.command}
+                        </code>
+                      )}
+                    </>
+                  )}
                 </td>
-                <td><PersonChip person={owner} /></td>
-                <td>
+                <td className="table-person"><PersonChip person={owner} /></td>
+                <td className="table-person">
                   {live && canHandOff(session, you) ? (
                     <PersonPicker
                       people={members}

--- a/app/src/styles/people.css
+++ b/app/src/styles/people.css
@@ -250,6 +250,23 @@
   padding-left: 4px;
 }
 
+/*
+ * The command column absorbs the slack, so every other column can size to
+ * what it holds. Without this the person cells collapse: the chip is built to
+ * truncate, min-width:0 all the way down, and auto table layout reads that as
+ * permission to give the column almost no width at all. An owner rendered as
+ * three letters and an ellipsis was the result.
+ */
+.table td:first-child,
+.table th:first-child {
+  width: 100%;
+}
+
+/* Enough for a first name and surname before the ellipsis earns its place. */
+.table-person {
+  min-width: 152px;
+}
+
 .table-end {
   text-align: right;
 }
@@ -297,13 +314,56 @@
   white-space: nowrap;
 }
 
-.table-command {
-  overflow: hidden;
+/*
+ * The command is behind this rather than beside the name. Agent commands run
+ * to a few hundred characters and one of them used to set the width of the
+ * whole table, putting every other row behind a horizontal scrollbar.
+ */
+.table-command-toggle {
+  display: inline-flex;
+  align-items: center;
+  padding: 0;
+  border: 0;
+  margin-left: 9px;
+  background: none;
   color: var(--faint);
+  cursor: pointer;
   font-family: var(--mono);
   font-size: 11.5px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  gap: 3px;
+}
+
+.table-command-toggle:hover {
+  color: var(--muted);
+}
+
+.table-command-toggle svg {
+  transition: transform 120ms ease;
+}
+
+.table-command-toggle svg[data-open="true"] {
+  transform: rotate(90deg);
+}
+
+/*
+ * Wraps and breaks, so however long the command is the row grows downward.
+ * A table cell that scrolls sideways hides the end of the very thing someone
+ * opened this to read.
+ */
+.table-command {
+  display: block;
+  max-width: 62ch;
+  padding: 6px 8px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-chip);
+  margin-top: 6px;
+  background: var(--paper);
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 11.5px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
 }
 
 .table-quiet {

--- a/app/src/styles/terminal.css
+++ b/app/src/styles/terminal.css
@@ -909,6 +909,27 @@ button.tab {
 }
 
 /*
+ * Sits under the badge rather than beside it: the line is a sentence with a
+ * command in it, and inline it would push the linked/last-used meta off the
+ * row on a narrow window.
+ */
+.device-offline-hint {
+  display: block;
+  margin-top: 3px;
+  color: var(--faint);
+}
+
+.device-offline-hint code {
+  padding: 1px 5px;
+  border-radius: var(--radius-chip);
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 0.94em;
+  white-space: nowrap;
+}
+
+/*
  * Overrides the inline code chip .sessions-empty already sets: a command
  * someone has to copy reads as its own line, not as a word in a sentence.
  */

--- a/app/src/terminal/TerminalPane.tsx
+++ b/app/src/terminal/TerminalPane.tsx
@@ -4,6 +4,8 @@ import { FitAddon } from "@xterm/addon-fit";
 import { ArrowClockwise, LockKey } from "@phosphor-icons/react";
 import "@xterm/xterm/css/xterm.css";
 import { TerminalConnection, type ConnectionStatus } from "./connection";
+import { DESKTOP_TERMINAL_GRID, type TerminalGrid } from "./terminal-grid";
+import { fittedTerminalFontSize } from "./terminal-fit";
 import { encryptionFragment, resolveSessionSocket, sessionIdFromShareUrl } from "./socket-url";
 import { forget, passwordFor } from "../lib/session-passwords";
 import { openSealed } from "../lib/keypair";
@@ -31,6 +33,12 @@ const THEME = {
   selectionBackground: "#3a3f33",
 };
 
+/*
+ * The size the pane would like to draw at when the grid happens to fit. Every
+ * fit scales down from here; nothing scales the grid.
+ */
+const BASE_FONT_SIZE = 13;
+
 export function TerminalPane({
   shareUrl,
   active,
@@ -51,16 +59,52 @@ export function TerminalPane({
   /*
    * Only the visible pane measures itself. A hidden one is still laid out, so
    * it would measure fine here, but refusing to refit it at all means no
-   * future layout change can quietly resize somebody's running terminal.
+   * future layout change can quietly restyle somebody's running terminal.
    */
   const activeRef = useRef(active);
   activeRef.current = active;
 
+  /*
+   * The grid the process is running at, not the grid this pane could fit. The
+   * relay announces it and the CLI opens the PTY at it; a viewer's only say in
+   * the matter is how large to draw it.
+   */
+  const grid = useRef<TerminalGrid>(DESKTOP_TERMINAL_GRID);
+
+  /**
+   * Scales the font so the whole session grid fits this pane, then pins the
+   * terminal to that grid.
+   *
+   * The obvious thing — FitAddon.fit() — is wrong here. It picks the grid that
+   * fills the pane at a fixed font size, so a pane narrower than 120 columns
+   * renders a 120-column process at, say, 94: every long line wraps a second
+   * time and full-screen output loses its bottom rows. Nothing downstream can
+   * repair that, because the PTY is not the size the emulator thinks it is.
+   */
   const refit = useCallback(() => {
-    if (!activeRef.current || !fit.current || !terminal.current) return;
+    const term = terminal.current;
+    const fitAddon = fit.current;
+    if (!activeRef.current || !fitAddon || !term) return;
     try {
-      fit.current.fit();
-      connection.current?.resize(terminal.current.cols, terminal.current.rows);
+      term.options.fontSize = BASE_FONT_SIZE;
+      /* How much fits at the base size; the scale below is derived from it. */
+      const available = fitAddon.proposeDimensions();
+      if (!available) return;
+      const { cols, rows } = grid.current;
+      const fontSize = fittedTerminalFontSize(
+        BASE_FONT_SIZE,
+        available.cols,
+        available.rows,
+        100,
+        cols,
+        rows,
+      );
+      if (term.options.fontSize !== fontSize) term.options.fontSize = fontSize;
+      if (term.cols !== cols || term.rows !== rows) {
+        term.resize(cols, rows);
+      } else {
+        term.refresh(0, term.rows - 1);
+      }
     } catch {
       /* the node can be detached mid-teardown */
     }
@@ -69,6 +113,9 @@ export function TerminalPane({
   useEffect(() => {
     const node = mount.current;
     if (!node) return;
+
+    /* A pane reused for another session starts from the default again. */
+    grid.current = DESKTOP_TERMINAL_GRID;
 
     const resolved = resolveSessionSocket(
       shareUrl,
@@ -84,7 +131,10 @@ export function TerminalPane({
 
     const term = new Terminal({
       fontFamily: 'ui-monospace, "SFMono-Regular", "Menlo", "Consolas", monospace',
-      fontSize: 13,
+      fontSize: BASE_FONT_SIZE,
+      /* Opened at the session grid so the first frames land in the right shape. */
+      cols: grid.current.cols,
+      rows: grid.current.rows,
       lineHeight: 1.35,
       cursorBlink: true,
       convertEol: false,
@@ -124,6 +174,11 @@ export function TerminalPane({
         onReadOnly: (value) => {
           setReadOnly(value);
           term.options.disableStdin = value;
+        },
+        /* A phone joining takes the session to 80x24, and back when it leaves. */
+        onGrid: (next) => {
+          grid.current = next;
+          refit();
         },
       },
     });

--- a/app/src/terminal/connection.test.ts
+++ b/app/src/terminal/connection.test.ts
@@ -219,6 +219,11 @@ describe("session lifecycle", () => {
     await new Promise((resolve) => setTimeout(resolve, 900));
     expect(FakeSocket.created).toBe(2);
     expect(recorded.statuses.at(-1)?.status).toBe("full");
+
+    FakeSocket.last!.opened();
+    expect(recorded.statuses.at(-1)?.status).toBe("full");
+    FakeSocket.last!.control({ type: "welcome" });
+    expect(recorded.statuses.at(-1)?.status).toBe("connected");
   });
 
   it("reports exit from a control message", async () => {

--- a/app/src/terminal/connection.test.ts
+++ b/app/src/terminal/connection.test.ts
@@ -2,6 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TerminalConnection, type ConnectionStatus } from "./connection";
 import { Opcode, encodeFrame } from "./protocol";
 import { BrowserFrameCipher } from "./e2ee";
+import {
+  DESKTOP_TERMINAL_GRID,
+  MOBILE_TERMINAL_GRID,
+  type TerminalGrid,
+} from "./terminal-grid";
 
 /* A WebSocket stand-in that lets a test drive both directions by hand. */
 class FakeSocket {
@@ -61,10 +66,11 @@ interface Recorded {
   statuses: { status: ConnectionStatus; detail?: string }[];
   writes: { text: string; reset: boolean }[];
   readOnly: boolean[];
+  grids: TerminalGrid[];
 }
 
 function connect(fragment = "") {
-  const recorded: Recorded = { statuses: [], writes: [], readOnly: [] };
+  const recorded: Recorded = { statuses: [], writes: [], readOnly: [], grids: [] };
   const connection = new TerminalConnection({
     url: "ws://localhost:5173/relay/api/sessions/x/ws",
     fragment,
@@ -73,6 +79,7 @@ function connect(fragment = "") {
       onStatus: (status, detail) => recorded.statuses.push({ status, detail }),
       onData: (bytes, reset) => recorded.writes.push({ text: new TextDecoder().decode(bytes), reset }),
       onReadOnly: (value) => recorded.readOnly.push(value),
+      onGrid: (grid) => recorded.grids.push(grid),
     },
   });
   return { connection, recorded };
@@ -160,44 +167,22 @@ describe("plaintext session", () => {
     expect(FakeSocket.last!.sent).toHaveLength(0);
   });
 
-  it("sends a resize once and not again for the same size", async () => {
+  it("never asks the relay to resize the shared PTY", async () => {
+    /*
+     * The process keeps one grid for the whole session and every viewer scales
+     * it locally. A viewer that sent its own size would be asking for a size
+     * the relay discards anyway.
+     */
     const { connection } = connect();
     await connection.start();
     FakeSocket.last!.opened();
-    connection.resize(80, 24);
-    connection.resize(80, 24);
+    connection.send("ls\r");
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(FakeSocket.last!.sent).toHaveLength(1);
-    expect(new Uint8Array(FakeSocket.last!.sent[0] as ArrayBuffer)[0]).toBe(Opcode.Resize);
-  });
-
-  it("ignores a nonsense size", async () => {
-    const { connection } = connect();
-    await connection.start();
-    FakeSocket.last!.opened();
-    connection.resize(0, 0);
-    connection.resize(-1, 24);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(FakeSocket.last!.sent).toHaveLength(0);
-  });
-
-  it("re-asserts the size after a reconnect", async () => {
-    /* The PTY follows this viewer, so a fresh socket has to be told again. */
-    const { connection } = connect();
-    await connection.start();
-    FakeSocket.last!.opened();
-    connection.resize(120, 40);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    const first = FakeSocket.last!;
-
-    first.closedWith(1006);
-    await new Promise((resolve) => setTimeout(resolve, 900));
-    FakeSocket.last!.opened();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    expect(FakeSocket.created).toBe(2);
-    expect(new Uint8Array(FakeSocket.last!.sent[0] as ArrayBuffer)[0]).toBe(Opcode.Resize);
+    const opcodes = FakeSocket.last!.sent.map(
+      (payload) => new Uint8Array(payload as ArrayBuffer)[0],
+    );
+    expect(opcodes).not.toContain(Opcode.Resize);
   });
 });
 
@@ -360,7 +345,7 @@ describe("encrypted session", () => {
   });
 });
 
-describe("resize safety", () => {
+describe("the session grid", () => {
   async function connected() {
     const { connection, recorded } = connect();
     await connection.start();
@@ -368,54 +353,53 @@ describe("resize safety", () => {
     return { connection, recorded, socket: FakeSocket.last! };
   }
 
-  function resizes(socket: FakeSocket) {
-    return socket.sent
-      .map((payload) => new Uint8Array(payload as ArrayBuffer))
-      .filter((frame) => frame[0] === Opcode.Resize)
-      .map((frame) => {
-        const view = new DataView(frame.buffer, frame.byteOffset, frame.byteLength);
-        return { cols: view.getUint16(1), rows: view.getUint16(3) };
-      });
-  }
-
-  it("refuses a size a real terminal would never have", async () => {
+  it("starts on the grid the CLI opens a PTY at", async () => {
     /*
-     * A hidden pane used to measure about one column wide. Forwarding that
-     * resized the shared PTY to one column and wrecked anything full-screen.
+     * A viewer that connects before the first announcement still has to draw
+     * something, and desktop is what the process is actually running at.
      */
-    const { connection, socket } = await connected();
-    connection.resize(1, 24);
-    connection.resize(80, 1);
-    connection.resize(2, 2);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    expect(resizes(socket)).toEqual([]);
+    const { connection } = await connected();
+    expect(connection.grid).toEqual(DESKTOP_TERMINAL_GRID);
   });
 
-  it("keeps the last good size when a degenerate one arrives", async () => {
-    const { connection, socket } = await connected();
-    connection.resize(120, 40);
-    connection.resize(1, 1);
-    connection.resize(120, 40);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    /* The second 120x40 is a duplicate of the size still in force, not a
-       recovery from the sliver, so exactly one resize should have gone out. */
-    expect(resizes(socket)).toEqual([{ cols: 120, rows: 40 }]);
+  it("follows the relay onto the mobile grid and back", async () => {
+    const { connection, recorded, socket } = await connected();
+    socket.control({ type: "terminal_size", ...MOBILE_TERMINAL_GRID });
+    expect(connection.grid).toEqual(MOBILE_TERMINAL_GRID);
+    socket.control({ type: "terminal_size", ...DESKTOP_TERMINAL_GRID });
+    expect(connection.grid).toEqual(DESKTOP_TERMINAL_GRID);
+    expect(recorded.grids).toEqual([MOBILE_TERMINAL_GRID, DESKTOP_TERMINAL_GRID]);
   });
 
-  it("still accepts a small but plausible terminal", async () => {
-    const { connection, socket } = await connected();
-    connection.resize(20, 4);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(resizes(socket)).toEqual([{ cols: 20, rows: 4 }]);
+  it("reports a grid change once", async () => {
+    const { recorded, socket } = await connected();
+    socket.control({ type: "terminal_size", ...MOBILE_TERMINAL_GRID });
+    socket.control({ type: "terminal_size", ...MOBILE_TERMINAL_GRID });
+    expect(recorded.grids).toEqual([MOBILE_TERMINAL_GRID]);
   });
 
-  it("ignores a non-finite size rather than sending garbage", async () => {
+  it("refuses a grid the CLI would reject", async () => {
+    /*
+     * cmd/shell/session_unix.go only resizes the PTY to one of the two
+     * canonical grids. Drawing anything else means rendering a shape the
+     * process is not writing, which is the bug this whole model prevents.
+     */
+    const { connection, recorded, socket } = await connected();
+    socket.control({ type: "terminal_size", cols: 94, rows: 28 });
+    socket.control({ type: "terminal_size", cols: 0, rows: 0 });
+    socket.control({ type: "terminal_size", cols: "120", rows: "36" });
+    expect(connection.grid).toEqual(DESKTOP_TERMINAL_GRID);
+    expect(recorded.grids).toEqual([]);
+  });
+
+  it("keeps the grid across a reconnect", async () => {
     const { connection, socket } = await connected();
-    connection.resize(Number.NaN, 24);
-    connection.resize(80, Number.POSITIVE_INFINITY);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(resizes(socket)).toEqual([]);
+    socket.control({ type: "terminal_size", ...MOBILE_TERMINAL_GRID });
+    socket.closedWith(1006);
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    FakeSocket.last!.opened();
+
+    expect(FakeSocket.created).toBe(2);
+    expect(connection.grid).toEqual(MOBILE_TERMINAL_GRID);
   });
 });

--- a/app/src/terminal/connection.ts
+++ b/app/src/terminal/connection.ts
@@ -159,12 +159,17 @@ export class TerminalConnection {
     this.socket = socket;
 
     socket.addEventListener("open", () => {
-      this.waitingForCapacity = false;
-      this.retryAttempt = 0;
-      this.options.events.onStatus("connected");
+      // A deliberately rejected capacity socket still reaches "open" before
+      // its 4005 close. Keep the honest waiting state until the relay sends a
+      // real session message proving this retry was admitted.
+      if (!this.waitingForCapacity) {
+        this.retryAttempt = 0;
+        this.options.events.onStatus("connected");
+      }
     });
 
     socket.addEventListener("message", (event: MessageEvent<string | ArrayBuffer>) => {
+      this.markAdmitted();
       if (typeof event.data === "string") {
         this.handleControl(event.data);
         return;
@@ -200,6 +205,13 @@ export class TerminalConnection {
       this.options.events.onStatus("disconnected");
       this.scheduleRetry();
     });
+  }
+
+  private markAdmitted(): void {
+    if (!this.waitingForCapacity) return;
+    this.waitingForCapacity = false;
+    this.retryAttempt = 0;
+    this.options.events.onStatus("connected");
   }
 
   private async handleFrame(received: Uint8Array): Promise<void> {

--- a/app/src/terminal/connection.ts
+++ b/app/src/terminal/connection.ts
@@ -1,5 +1,10 @@
-import { Opcode, encodeFrame, encodeResize, isSnapshotOpcode } from "./protocol";
+import { Opcode, encodeFrame, isSnapshotOpcode } from "./protocol";
 import { BrowserFrameCipher, parseEncryptionFragment, type EncryptionFragment } from "./e2ee";
+import {
+  DESKTOP_TERMINAL_GRID,
+  MOBILE_TERMINAL_GRID,
+  type TerminalGrid,
+} from "./terminal-grid";
 
 export type ConnectionStatus =
   | "connecting"
@@ -16,6 +21,12 @@ export interface ConnectionEvents {
   /** Terminal bytes to write. `reset` means the screen should be cleared first. */
   onData(bytes: Uint8Array, reset: boolean): void;
   onReadOnly(readOnly: boolean): void;
+  /**
+   * The grid the PTY is running at, announced by the relay. It is a property
+   * of the session rather than of this viewer, and it changes when a phone
+   * joins or leaves.
+   */
+  onGrid(grid: TerminalGrid): void;
 }
 
 export interface ConnectionOptions {
@@ -31,12 +42,6 @@ export interface ConnectionOptions {
 
 const MAX_BACKOFF_MS = 10_000;
 
-/*
- * Below this a terminal is not a terminal, it is a measurement artefact from a
- * pane that is not laid out yet or not on screen.
- */
-const MIN_COLS = 20;
-const MIN_ROWS = 4;
 const CLOSE_ENDED = 4000;
 const CLOSE_MISSING = 4004;
 const CLOSE_DECRYPT_FAILED = 4003;
@@ -60,10 +65,21 @@ export class TerminalConnection {
   private readOnly = false;
   private awaitingPassword = false;
   private waitingForCapacity = false;
-  private lastSize: { cols: number; rows: number } | null = null;
+  private currentGrid: TerminalGrid = DESKTOP_TERMINAL_GRID;
 
   constructor(private readonly options: ConnectionOptions) {
     this.descriptor = parseEncryptionFragment(options.fragment);
+  }
+
+  /**
+   * The grid the PTY is running at.
+   *
+   * Desktop until the relay says otherwise, which is what the CLI opens a PTY
+   * at, so a viewer that connects before the first announcement still renders
+   * at the right size instead of guessing from its own pixels.
+   */
+  get grid(): TerminalGrid {
+    return this.currentGrid;
   }
 
   /** True when the session is encrypted and no working key is held yet. */
@@ -109,24 +125,6 @@ export class TerminalConnection {
     void this.transmit(encodeFrame(Opcode.Input, bytes));
   }
 
-  /**
-   * Reports this viewer's terminal size to the relay, which resizes the shared
-   * PTY to match.
-   *
-   * A degenerate size is refused rather than sent. A hidden pane can measure
-   * as a sliver, and forwarding that would resize the real PTY to a column or
-   * two, destroying the layout of anything full-screen like htop. No terminal
-   * that small is worth honouring, so the last good size stands.
-   */
-  resize(cols: number, rows: number): void {
-    if (!Number.isFinite(cols) || !Number.isFinite(rows)) return;
-    if (cols < MIN_COLS || rows < MIN_ROWS) return;
-    /* The relay resizes the shared PTY, so only send an actual change. */
-    if (this.lastSize?.cols === cols && this.lastSize.rows === rows) return;
-    this.lastSize = { cols, rows };
-    void this.transmit(encodeResize(cols, rows));
-  }
-
   close(): void {
     this.stopped = true;
     if (this.retryTimer !== null) clearTimeout(this.retryTimer);
@@ -164,12 +162,6 @@ export class TerminalConnection {
       this.waitingForCapacity = false;
       this.retryAttempt = 0;
       this.options.events.onStatus("connected");
-      /* The PTY size follows this viewer, so re-assert it on every connect. */
-      if (this.lastSize) {
-        const { cols, rows } = this.lastSize;
-        this.lastSize = null;
-        this.resize(cols, rows);
-      }
     });
 
     socket.addEventListener("message", (event: MessageEvent<string | ArrayBuffer>) => {
@@ -247,7 +239,7 @@ export class TerminalConnection {
   }
 
   private handleControl(raw: string): void {
-    let message: { readOnly?: unknown; status?: unknown };
+    let message: { readOnly?: unknown; status?: unknown; type?: unknown; cols?: unknown; rows?: unknown };
     try {
       message = JSON.parse(raw) as typeof message;
     } catch {
@@ -260,6 +252,26 @@ export class TerminalConnection {
     if (message.status === "exited") {
       this.options.events.onStatus("ended");
     }
+    if (message.type === "terminal_size") {
+      this.adoptGrid(message.cols, message.rows);
+    }
+  }
+
+  /*
+   * Only the two grids the CLI will actually open a PTY at are honoured. It
+   * refuses anything else (`isCanonicalTerminalSize`), so rendering a size it
+   * would have rejected is how a viewer ends up drawing 94 columns of a
+   * 120-column process.
+   */
+  private adoptGrid(cols: unknown, rows: unknown): void {
+    if (typeof cols !== "number" || typeof rows !== "number") return;
+    const grid = [DESKTOP_TERMINAL_GRID, MOBILE_TERMINAL_GRID].find(
+      (candidate) => candidate.cols === cols && candidate.rows === rows,
+    );
+    if (!grid) return;
+    if (grid.cols === this.currentGrid.cols && grid.rows === this.currentGrid.rows) return;
+    this.currentGrid = grid;
+    this.options.events.onGrid(grid);
   }
 
   private scheduleRetry(): void {

--- a/app/src/terminal/terminal-fit.ts
+++ b/app/src/terminal/terminal-fit.ts
@@ -1,0 +1,38 @@
+/*
+ * Vendored verbatim from shell.online: web/terminal-fit.ts
+ *
+ * How a viewer fits the fixed session grid into its own viewport: by scaling
+ * the font, never by changing the number of columns. The standalone viewer
+ * and this app have to agree here, or the same session renders at two
+ * different sizes. Checked by `npm run check:protocol`. Do not edit here.
+ */
+/**
+ * Scale the current session-wide terminal grid into an individual viewport.
+ */
+export function fittedTerminalFontSize(
+  baseFontSize: number,
+  availableColumns: number,
+  availableRows: number,
+  zoomPercent = 100,
+  terminalColumns = 80,
+  terminalRows = 24,
+): number {
+  if (
+    !Number.isFinite(baseFontSize) ||
+    !Number.isFinite(availableColumns) ||
+    !Number.isFinite(availableRows) ||
+    !Number.isFinite(zoomPercent) ||
+    baseFontSize <= 0 ||
+    availableColumns <= 0 ||
+    availableRows <= 0
+  ) {
+    return Math.max(4, baseFontSize || 14);
+  }
+
+  const fitScale = Math.min(
+    availableColumns / terminalColumns,
+    availableRows / terminalRows,
+  );
+  const scaled = baseFontSize * fitScale * (zoomPercent / 100) * 0.985;
+  return Math.min(32, Math.max(4, Math.floor(scaled * 4) / 4));
+}

--- a/app/src/terminal/terminal-grid.ts
+++ b/app/src/terminal/terminal-grid.ts
@@ -1,0 +1,19 @@
+/*
+ * Vendored verbatim from shell.online: shared/terminal-grid.ts
+ *
+ * The session-wide grid the relay picks and the CLI opens the PTY at. It is
+ * copied rather than reimplemented so the app cannot disagree with the relay
+ * about how big a terminal is, and checked by `npm run check:protocol`, which
+ * fails if the upstream file changes. Do not edit here; edit upstream.
+ */
+export interface TerminalGrid {
+  cols: number;
+  rows: number;
+}
+
+export const DESKTOP_TERMINAL_GRID: TerminalGrid = { cols: 120, rows: 36 };
+export const MOBILE_TERMINAL_GRID: TerminalGrid = { cols: 80, rows: 24 };
+
+export function terminalGridForDevices(devices: readonly string[]): TerminalGrid {
+  return devices.includes("mobile") ? MOBILE_TERMINAL_GRID : DESKTOP_TERMINAL_GRID;
+}

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -16,8 +16,19 @@ const authHeaders = {
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
-  const relay = env.VITE_RELAY_URL ?? "http://127.0.0.1:8788";
-  const relayOrigin = new URL(relay).origin;
+  /*
+   * Blank is absent, not a value. `??` only catches undefined, and a
+   * workflow that passes an unset repository variable through supplies the
+   * empty string, so this config took `new URL("")` and the whole build died
+   * on `TypeError: Invalid URL` with no clue which variable was at fault.
+   */
+  const relay = env.VITE_RELAY_URL?.trim() || "http://127.0.0.1:8788";
+  let relayOrigin: string;
+  try {
+    relayOrigin = new URL(relay).origin;
+  } catch {
+    throw new Error(`VITE_RELAY_URL is not a URL: ${JSON.stringify(env.VITE_RELAY_URL)}`);
+  }
 
   return {
     plugins: [react()],

--- a/app/wrangler.jsonc
+++ b/app/wrangler.jsonc
@@ -65,6 +65,20 @@
       // The Cloud SQL instance, reached over a Workers VPC service on a
       // Cloudflare Tunnel. An identifier, not a credential: the database
       // username and password belong to the Hyperdrive configuration.
+      //
+      // QUERY CACHING MUST STAY OFF on this configuration. It is a Hyperdrive
+      // setting rather than a field here, so it cannot be enforced from this
+      // file:
+      //
+      //   wrangler hyperdrive update <id> --caching-disabled true
+      //
+      // It is on by default and it is wrong for this workload. Everything
+      // here is read-after-write by a person who just acted: sign up and the
+      // membership that was written a moment ago reads back missing, so the
+      // request tries to create a second one and fails on the unique index;
+      // unlink a machine and it is still listed; a machine that is polling
+      // still shows as offline. Cached reads turn all of that into an
+      // application that intermittently disagrees with itself.
       "id": "__HYPERDRIVE_ID__",
       // Used only by `wrangler dev`, which connects directly rather than
       // through Hyperdrive. A local Postgres, never the deployed database.

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
           },
           "applicationCategory": "DeveloperApplication",
           "operatingSystem": "macOS, Windows, Linux, FreeBSD, OpenBSD, NetBSD, DragonFly BSD, Solaris",
-          "softwareVersion": "0.9.0",
+          "softwareVersion": "0.10.1",
           "softwareRequirements": "A supported architecture, outbound HTTPS and WebSockets, and a PTY or Windows ConPTY",
           "isAccessibleForFree": true,
           "downloadUrl": "https://shell.online/install",

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
           },
           "applicationCategory": "DeveloperApplication",
           "operatingSystem": "macOS, Windows, Linux, FreeBSD, OpenBSD, NetBSD, DragonFly BSD, Solaris",
-          "softwareVersion": "0.8.1",
+          "softwareVersion": "0.9.0",
           "softwareRequirements": "A supported architecture, outbound HTTPS and WebSockets, and a PTY or Windows ConPTY",
           "isAccessibleForFree": true,
           "downloadUrl": "https://shell.online/install",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test": "vitest run && node --test .github/scripts/moderation.node.mjs && sh ./scripts/test-install.sh && sh ./scripts/test-docker-entrypoint.sh && sh ./scripts/test-deploy-production.sh && sh ./scripts/test-qemu-linux.sh --check && node ./scripts/test-landing-seo.mjs && node ./scripts/test-mobile-controls.mjs && node ./scripts/check-formula.mjs",
     "test:qemu:manifest": "sh ./scripts/test-qemu-linux.sh --check",
     "typecheck": "tsc -p tsconfig.worker.json --noEmit && tsc -p tsconfig.web.json --noEmit",
-    "test:app": "npm --prefix app ci && npm --prefix app test"
+    "test:app": "npm --prefix app ci && npm --prefix app test",
+    "verify:published": "node ./scripts/verify-published.mjs"
   },
   "dependencies": {
     "@xterm/addon-fit": "^0.11.0",

--- a/scripts/test-landing-seo.mjs
+++ b/scripts/test-landing-seo.mjs
@@ -33,6 +33,17 @@ const manifest = JSON.parse(manifestSource);
 const docsContent = JSON.parse(docsSource);
 const packageMetadata = JSON.parse(packageSource);
 
+/*
+ * The structured data names a version, and nothing else on the page does, so
+ * a release that forgets it leaves search engines advertising the previous
+ * one indefinitely. 0.9.0 shipped with 0.8.1 still sitting here.
+ */
+const advertisedVersion = indexHtml.match(/"softwareVersion":\s*"([^"]+)"/u)?.[1];
+check(
+  advertisedVersion === packageMetadata.version,
+  `Structured data advertises ${advertisedVersion} but package.json says ${packageMetadata.version}`,
+);
+
 check(indexHtml.includes('<html lang="en">'), "Document language is missing");
 check(indexHtml.includes('<meta charset="UTF-8"'), "UTF-8 declaration is missing");
 check(indexHtml.includes('<meta name="viewport"'), "Responsive viewport is missing");

--- a/scripts/verify-published.mjs
+++ b/scripts/verify-published.mjs
@@ -1,0 +1,62 @@
+/**
+ * Checks that the install URL is serving the bundle in ./dist/downloads.
+ *
+ *   node ./scripts/verify-published.mjs https://shell.online
+ *
+ * verify-downloads.mjs checks the bundle on this machine. This checks the one
+ * the world gets, which is a different question and the one that went wrong:
+ * a deploy reported success, the manifest at the install URL kept naming the
+ * previous build, and `curl | sh` handed out a binary that was three fixes
+ * behind. Nobody could see it from the version number, because the version
+ * had not changed.
+ *
+ * Compares the manifest rather than downloading 78 binaries, then fetches one
+ * to confirm the manifest is describing what is actually served.
+ */
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+const origin = (process.argv[2] ?? "https://shell.online").replace(/\/+$/, "");
+const local = JSON.parse(await readFile("dist/downloads/release.json", "utf8"));
+
+const fail = (message) => {
+  console.error(`verify-published: ${message}`);
+  process.exit(1);
+};
+
+const response = await fetch(`${origin}/downloads/release.json?cache-bust=${Date.now()}`, {
+  headers: { "cache-control": "no-cache" },
+});
+if (!response.ok) fail(`${origin}/downloads/release.json answered ${response.status}`);
+const published = await response.json();
+
+if (published.version !== local.version) {
+  fail(`${origin} publishes ${published.version}, this bundle is ${local.version}`);
+}
+
+const differing = Object.keys(local.artifacts).filter(
+  (name) => published.artifacts?.[name] !== local.artifacts[name],
+);
+if (differing.length > 0) {
+  fail(
+    `${origin} publishes ${differing.length} artifact(s) that differ from this bundle, ` +
+      `including ${differing.slice(0, 3).join(", ")}. Deploy again.`,
+  );
+}
+
+/*
+ * The manifest agreeing is not the same as the bytes agreeing: both are
+ * uploaded as assets and either can be the stale one.
+ */
+const sample = "shell-darwin-arm64";
+const binary = await fetch(`${origin}/downloads/${sample}?cache-bust=${Date.now()}`);
+if (!binary.ok) fail(`${origin}/downloads/${sample} answered ${binary.status}`);
+const digest = createHash("sha256").update(Buffer.from(await binary.arrayBuffer())).digest("hex");
+if (digest !== local.artifacts[sample]) {
+  fail(`${origin} serves a ${sample} that does not match its own manifest`);
+}
+
+console.log(
+  `verify-published: ${origin} is serving this bundle ` +
+    `(${local.version}, ${Object.keys(local.artifacts).length} artifacts).`,
+);


### PR DESCRIPTION
Integrates the useful production fixes from #58 on top of the reliability work merged in #64, while preserving the corrected session protocol and capacity behavior.

This keeps Alex’s original commit and authorship, then resolves the conflicts and hardens the deployment path.

Highlights:
- validates production configuration and rejects loopback/blank client bundles
- adds exact post-deploy and published-download verification
- fixes fixed-grid terminal rendering, capacity state, unlink refresh, owner display, long commands, and small UI details
- documents and guards the Cloudflare Hyperdrive deployment configuration without committing private identifiers or credentials

Verified locally:
- root: 64 tests, all script/integration guards, production web build
- app: 515 tests passed, 3 skipped; protocol check and production build passed
- deployed to app.shell.online and verified byte-for-byte against the local build

Supersedes #58.