### PR TITLE
Let signing in again rescue a machine whose daemon cannot renew

### DIFF
--- a/cmd/shell/account.go
+++ b/cmd/shell/account.go
@@ -175,7 +175,12 @@ func runLogin(arguments []string, stdout, stderr io.Writer) int {
 	// The daemon is what makes the answer mean anything, so it starts here
 	// rather than waiting for the next command.
 	if grant {
-		ensureDaemon()
+		/*
+		 * Restart rather than ensure. The credentials just written are new,
+		 * and a daemon that is already running is holding the previous ones
+		 * in memory where nothing will ever replace them.
+		 */
+		restartDaemon()
 	} else {
 		stopDaemon()
 	}

--- a/cmd/shell/agent_loop.go
+++ b/cmd/shell/agent_loop.go
@@ -16,6 +16,11 @@ import (
 // agentPollInterval is how often the machine asks for queued work.
 const agentPollInterval = 2 * time.Second
 
+// maxRefreshBackoff caps the wait between refusals to renew this machine's
+// token. Long enough that a revoked token is not a stream of requests, short
+// enough that a machine comes back within a minute of being fixed.
+const maxRefreshBackoff = 60 * time.Second
+
 // agentLoop asks the accounts service for work and carries it out.
 //
 // Two things run this: the daemon, which is how a signed-in machine is
@@ -51,6 +56,9 @@ func (loop *agentLoop) run(ctx context.Context) error {
 	// granularity the agent key above already has.
 	harnesses := installedHarnesses()
 
+	/* Grows while renewal keeps being refused, so a dead token is quiet. */
+	refreshBackoff := agentPollInterval
+
 	for {
 		if loop.credentials.Expired(time.Now()) {
 			refreshed, refreshErr := client.Refresh(ctx, loop.credentials)
@@ -58,12 +66,33 @@ func (loop *agentLoop) run(ctx context.Context) error {
 				if ctx.Err() != nil {
 					return nil
 				}
+				/*
+				 * A refusal is not a blip. The token is revoked or unknown
+				 * and asking again in two seconds will be refused in exactly
+				 * the same way, so retrying at the poll interval is a request
+				 * every two seconds for as long as the machine is up. That
+				 * earns a rate limit, which then hides any real recovery
+				 * behind a second failure.
+				 *
+				 * Two things break the loop instead. Credentials are re-read
+				 * from disk first, because a login in another terminal has
+				 * written working ones and this process would otherwise never
+				 * look. Failing that, the wait grows.
+				 */
+				if reloaded, loadErr := account.Load(loop.credentialsPath); loadErr == nil &&
+					reloaded.RefreshToken != loop.credentials.RefreshToken {
+					loop.credentials = reloaded
+					refreshBackoff = agentPollInterval
+					continue
+				}
 				fmt.Fprintf(loop.report, "shell: could not renew this machine's token: %v\n", refreshErr)
-				if !sleepOrDone(ctx, agentPollInterval) {
+				if !sleepOrDone(ctx, refreshBackoff) {
 					return nil
 				}
+				refreshBackoff = min(refreshBackoff*2, maxRefreshBackoff)
 				continue
 			}
+			refreshBackoff = agentPollInterval
 			loop.credentials = refreshed
 			if saveErr := account.Save(loop.credentialsPath, loop.credentials); saveErr != nil {
 				fmt.Fprintf(loop.report, "shell: could not store the renewed token: %v\n", saveErr)

--- a/cmd/shell/daemon.go
+++ b/cmd/shell/daemon.go
@@ -329,3 +329,39 @@ func ensureDaemon() {
 	}
 	startDetachedDaemon(self)
 }
+
+// restartDaemon replaces a running daemon, and starts one if none is running.
+//
+// For after a login, and only after a login. A daemon holds the credentials it
+// started with in memory and never reads the file again, so a fresh login
+// leaves the running one stale by definition: it goes on presenting the tokens
+// it already had, and once those stop working it presents them every couple of
+// seconds for as long as the machine is up.
+//
+// That is what "shell login does nothing" looks like from outside. The login
+// succeeds, writes working credentials, and the machine still reports itself
+// offline because the process doing the polling never looks at them. Found on
+// a machine that had been refusing to renew for eight and a half hours across
+// several logins.
+//
+// ensureDaemon above deliberately does not do this. It runs on every ordinary
+// command, and restarting there would re-key the agent on each one, which
+// throws away the key a browser has already sealed a session password to.
+func restartDaemon() {
+	path, err := account.DefaultPath()
+	if err != nil {
+		return
+	}
+	credentials, err := account.Load(path)
+	if err != nil || !credentials.RemoteStart {
+		return
+	}
+	if daemonAnswering() {
+		stopDaemon()
+	}
+	self, err := os.Executable()
+	if err != nil {
+		return
+	}
+	startDetachedDaemon(self)
+}

--- a/cmd/shell/daemon_unix_test.go
+++ b/cmd/shell/daemon_unix_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -212,4 +213,45 @@ func TestAnOrdinaryCommandStartsNoDaemonWithoutConsent(t *testing.T) {
 	if daemonCommand(t, binary, configPath, runtime, "daemon", "status").Run() == nil {
 		t.Fatal("a machine that did not agree should have no daemon")
 	}
+}
+
+// An ordinary command must leave a running daemon alone.
+//
+// ensureDaemon runs on every command, and restarting there would re-key the
+// agent each time. A browser seals a session password to the key the daemon
+// published, so throwing it away mid-session makes work already queued
+// impossible to open. Only `shell login` replaces a daemon, because only a
+// login produces credentials the running one cannot know about.
+func TestAnOrdinaryCommandLeavesTheDaemonAlone(t *testing.T) {
+	binary := buildShell(t)
+	configPath, runtime := linkedMachine(t, true)
+
+	first := daemonCommand(t, binary, configPath, runtime, "daemon")
+	if err := first.Start(); err != nil {
+		t.Fatalf("start the daemon: %v", err)
+	}
+	defer func() {
+		_ = first.Process.Kill()
+		_, _ = first.Process.Wait()
+	}()
+	waitForDaemon(t, binary, configPath, runtime, true)
+	original := first.Process.Pid
+
+	ordinary := daemonCommand(t, binary, configPath, runtime, "true")
+	if output, err := ordinary.CombinedOutput(); err != nil {
+		t.Fatalf("run an ordinary command: %v: %s", err, output)
+	}
+
+	if !processAlive(original) {
+		t.Fatalf("daemon %d was replaced by an ordinary command; that re-keys the agent", original)
+	}
+}
+
+// processAlive reports whether a pid still names a live process.
+func processAlive(pid int) bool {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return process.Signal(syscall.Signal(0)) == nil
 }


### PR DESCRIPTION
Reported as "machines appear offline no matter how many times I write
`shell login`". It is reproducible and it never recovers on its own.

## What happens

A daemon holds the credentials it started with, in memory, and never reads the
file again. `ensureDaemon` returned early whenever one was already answering,
so a fresh login wrote working credentials to a file the running process would
never look at.

Meanwhile that process polled with a token the service had stopped accepting,
tried to renew, was refused, and tried again at the poll interval — every two
seconds, for as long as the machine was up.

Found on a machine that had been doing it for eight and a half hours. In 40
seconds of Worker logs: 27 renewals from `shell/0.9.0`, 7 refused outright and
11 rate-limited. The account showed the machine offline the whole time, and
every `shell login` reported success.

## Three changes

**Login restarts the daemon** instead of leaving it. That is `restartDaemon`,
kept separate from `ensureDaemon`, because `ensureDaemon` runs on every
ordinary command and restarting there would re-key the agent each time. A
browser seals a session password to the key the daemon published, so discarding
it mid-session makes queued work impossible to open. `TestAnOrdinaryCommandLeavesTheDaemonAlone`
pins that distinction — I broke it first and the test is why it did not ship.

**A refused renewal re-reads the credentials file** before believing itself. A
login in another terminal has already written working ones, so a running daemon
can now recover without being restarted at all.

**A refusal backs off** to a minute. A revoked token is refused identically
however fast it is presented; asking every two seconds only earns a rate limit,
which then hides the recovery behind a second failure.

## Verified

Built and installed on the affected machine. Two consecutive logins replace the
daemon (pid `30662` → `30699`) and the machine reports online with `agentSeenAt`
2–4s across repeated checks. Full Go suite green, `gofmt` and `go vet` clean.