### PR TITLE
Restore the audit log, including what is typed

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -11,6 +11,7 @@ import { Organization } from "./routes/Organization";
 import { Join } from "./routes/Join";
 import { Terms } from "./routes/Terms";
 import { Session } from "./routes/Session";
+import { Audit } from "./routes/Audit";
 import { CliAuthorize } from "./routes/CliAuthorize";
 
 export default function App() {
@@ -56,6 +57,14 @@ export default function App() {
             element={
               <RequireAuth>
                 <Session />
+              </RequireAuth>
+            }
+          />
+          <Route
+            path="/audit"
+            element={
+              <RequireAuth>
+                <Audit />
               </RequireAuth>
             }
           />

--- a/app/src/components/AppShell.tsx
+++ b/app/src/components/AppShell.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { Link, NavLink, useNavigate } from "react-router-dom";
 import {
-  Terminal, Desktop, User, UsersThree, SignOut, Copy, Check,
+  Terminal, Desktop, User, UsersThree, ClockCounterClockwise, SignOut, Copy, Check,
 } from "@phosphor-icons/react";
 import { Inbox } from "./Inbox";
 import { Avatar } from "./Avatar";
@@ -11,6 +11,7 @@ import { useAuth } from "../auth/AuthProvider";
 const NAV = [
   { to: "/sessions", label: "Sessions", Icon: Terminal },
   { to: "/machines", label: "Machines", Icon: Desktop },
+  { to: "/audit", label: "Audit log", Icon: ClockCounterClockwise },
   { to: "/organization", label: "Organization", Icon: UsersThree },
   { to: "/account", label: "Account", Icon: User },
 ] as const;

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -244,6 +244,16 @@ export function approveCliLogin(input: AuthorizeInput) {
   });
 }
 
+export interface AuditEvent {
+  id: string;
+  sessionId: string;
+  at: number;
+  actorUid: string;
+  actorEmail: string;
+  kind: "input" | "interrupt" | "opened" | "handoff";
+  text: string;
+}
+
 export interface Device {
   id: string;
   label: string;
@@ -307,3 +317,21 @@ export function fetchSessions() {
 }
 
 export const accountsBaseUrl = BASE;
+
+export function fetchAudit(sessionId: string) {
+  return request<{ events: AuditEvent[] }>(`/api/audit/${encodeURIComponent(sessionId)}`);
+}
+
+
+/** The audit export needs the same bearer token, so it is fetched not linked. */
+export async function downloadAuditCsv(sessionId?: string): Promise<Blob> {
+  const user = auth.currentUser;
+  if (!user) throw new Error("You are signed out.");
+  const token = await user.getIdToken();
+  const query = sessionId ? `?session=${encodeURIComponent(sessionId)}` : "";
+  const response = await fetch(`${BASE}/api/audit.csv${query}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) throw new Error("Could not export the audit log.");
+  return response.blob();
+}

--- a/app/src/lib/audit-view.test.ts
+++ b/app/src/lib/audit-view.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import {
+  EMPTY_FILTERS,
+  activity,
+  applyFilters,
+  byActor,
+  isFiltered,
+  sessionLabel,
+  summarise,
+  } from "./audit-view";
+import type { AuditEvent, SessionRecord } from "./api";
+
+const BASE = Date.UTC(2026, 8, 6, 12, 0, 0);
+
+function event(overrides: Partial<AuditEvent> = {}): AuditEvent {
+  return {
+    id: `aud_${Math.random()}`,
+    sessionId: "s1",
+    at: BASE,
+    actorUid: "u1",
+    actorEmail: "ana@example.com",
+    kind: "input",
+    text: "npm test",
+    ...overrides,
+  };
+}
+
+describe("applyFilters", () => {
+  const events = [
+    event({ actorUid: "u1", sessionId: "s1", text: "git status" }),
+    event({ actorUid: "u2", sessionId: "s2", text: "npm run build" }),
+    event({ actorUid: "u1", sessionId: "s2", kind: "interrupt", text: "" }),
+  ];
+
+  it("returns everything when nothing is set", () => {
+    expect(applyFilters(events, EMPTY_FILTERS)).toHaveLength(3);
+  });
+
+  it("narrows by person, session and kind", () => {
+    expect(applyFilters(events, { ...EMPTY_FILTERS, actor: "u1" })).toHaveLength(2);
+    expect(applyFilters(events, { ...EMPTY_FILTERS, session: "s2" })).toHaveLength(2);
+    expect(applyFilters(events, { ...EMPTY_FILTERS, kind: "interrupt" })).toHaveLength(1);
+  });
+
+  it("combines filters rather than widening", () => {
+    const found = applyFilters(events, { ...EMPTY_FILTERS, actor: "u1", session: "s2" });
+    expect(found).toHaveLength(1);
+    expect(found[0].kind).toBe("interrupt");
+  });
+
+  it("searches the text, ignoring case", () => {
+    expect(applyFilters(events, { ...EMPTY_FILTERS, query: "GIT" })).toHaveLength(1);
+    expect(applyFilters(events, { ...EMPTY_FILTERS, query: "npm" })).toHaveLength(1);
+    expect(applyFilters(events, { ...EMPTY_FILTERS, query: "nothing here" })).toHaveLength(0);
+  });
+
+  it("ignores stray whitespace around a search, as from a paste", () => {
+    expect(applyFilters(events, { ...EMPTY_FILTERS, query: "  npm  " })).toHaveLength(1);
+  });
+
+  it("narrows by age", () => {
+    const recent = [event({ at: BASE }), event({ at: BASE - 60 * 60 * 1000 })];
+    const found = applyFilters(recent, { ...EMPTY_FILTERS, since: 30 * 60 * 1000 }, BASE);
+    expect(found).toHaveLength(1);
+  });
+});
+
+describe("isFiltered", () => {
+  it("knows when a view is narrowed", () => {
+    expect(isFiltered(EMPTY_FILTERS)).toBe(false);
+    expect(isFiltered({ ...EMPTY_FILTERS, query: "  " })).toBe(false);
+    expect(isFiltered({ ...EMPTY_FILTERS, query: "git" })).toBe(true);
+    expect(isFiltered({ ...EMPTY_FILTERS, since: 1000 })).toBe(true);
+  });
+});
+
+describe("activity", () => {
+  it("is empty for no events", () => {
+    expect(activity([])).toEqual([]);
+  });
+
+  it("counts every event exactly once", () => {
+    const events = Array.from({ length: 50 }, (_, i) => event({ at: BASE + i * 60_000 }));
+    const buckets = activity(events, 10);
+    expect(buckets.reduce((sum, bucket) => sum + bucket.count, 0)).toBe(50);
+  });
+
+  it("keeps a quiet stretch as an empty bucket rather than dropping it", () => {
+    /* A gap that vanished would make the chart lie about the timeline. */
+    const events = [event({ at: BASE }), event({ at: BASE + 10 * 60 * 60_000 })];
+    const buckets = activity(events, 10);
+    expect(buckets).toHaveLength(10);
+    expect(buckets.some((bucket) => bucket.count === 0)).toBe(true);
+  });
+
+  it("survives every event sharing one instant", () => {
+    const buckets = activity([event(), event(), event()], 8);
+    expect(buckets.reduce((sum, bucket) => sum + bucket.count, 0)).toBe(3);
+  });
+});
+
+describe("tallies", () => {
+  const events = [
+    event({ actorUid: "u1", text: "git status" }),
+    event({ actorUid: "u1", text: "git log" }),
+    event({ actorUid: "u2", text: "npm test" }),
+  ];
+
+  it("ranks people by how much they did", () => {
+    expect(byActor(events)).toEqual([
+      { key: "u1", count: 2 },
+      { key: "u2", count: 1 },
+    ]);
+  });
+
+
+});
+
+describe("summarise", () => {
+  it("counts the things a reader asks first", () => {
+    const summary = summarise([
+      event({ actorUid: "u1", sessionId: "s1", at: BASE, kind: "opened" }),
+      event({ actorUid: "u2", sessionId: "s2", at: BASE + 1000, kind: "handoff" }),
+    ]);
+    expect(summary).toMatchObject({
+      total: 2, opened: 1, handoffs: 1, people: 2, sessions: 2,
+      firstAt: BASE, lastAt: BASE + 1000,
+    });
+  });
+
+  it("is all zeros for an empty log", () => {
+    expect(summarise([])).toMatchObject({ total: 0, people: 0, sessions: 0 });
+  });
+});
+
+describe("sessionLabel", () => {
+  const sessions = [
+    { id: "s1", name: "nightly build", command: "npm run build" } as SessionRecord,
+    { id: "s2", command: "htop" } as SessionRecord,
+  ];
+
+  it("prefers the name, falls back to the command, never shows an id", () => {
+    expect(sessionLabel(sessions, "s1")).toBe("nightly build");
+    expect(sessionLabel(sessions, "s2")).toBe("htop");
+    expect(sessionLabel(sessions, "gone")).toBe("a removed session");
+  });
+});

--- a/app/src/lib/audit-view.ts
+++ b/app/src/lib/audit-view.ts
@@ -1,0 +1,139 @@
+import type { AuditEvent, Member, SessionRecord } from "./api";
+
+/**
+ * Shaping an audit log for reading.
+ *
+ * The log is a flat stream of everything anyone entered. What a reader wants
+ * is usually narrower: one person, one session, one afternoon, or one word
+ * they half remember. These are the pure parts of that, so the filtering and
+ * the counting can be checked without a browser.
+ */
+
+export interface Filters {
+  session: string;
+  actor: string;
+  kind: string;
+  query: string;
+  /** Milliseconds back from now, or 0 for everything. */
+  since: number;
+}
+
+export const EMPTY_FILTERS: Filters = {
+  session: "",
+  actor: "",
+  kind: "",
+  query: "",
+  since: 0,
+};
+
+export function applyFilters(
+  events: AuditEvent[],
+  filters: Filters,
+  now = Date.now(),
+): AuditEvent[] {
+  const needle = filters.query.trim().toLowerCase();
+  return events.filter((event) => {
+    if (filters.session && event.sessionId !== filters.session) return false;
+    if (filters.actor && event.actorUid !== filters.actor) return false;
+    if (filters.kind && event.kind !== filters.kind) return false;
+    if (filters.since && event.at < now - filters.since) return false;
+    if (needle && !event.text.toLowerCase().includes(needle)) return false;
+    return true;
+  });
+}
+
+export function isFiltered(filters: Filters): boolean {
+  return Boolean(
+    filters.session || filters.actor || filters.kind || filters.query.trim() || filters.since,
+  );
+}
+
+/* ---------------------------------------------------------------
+   Aggregations
+   --------------------------------------------------------------- */
+
+export interface Bucket {
+  at: number;
+  count: number;
+}
+
+/**
+ * Activity over time, in fixed buckets.
+ *
+ * Buckets are anchored to the span being shown rather than to each event, so
+ * the bars line up with the axis and an empty stretch reads as quiet rather
+ * than disappearing.
+ */
+export function activity(events: AuditEvent[], buckets = 24, now = Date.now()): Bucket[] {
+  if (events.length === 0) return [];
+  const times = events.map((event) => event.at);
+  const first = Math.min(...times);
+  const last = Math.max(Math.max(...times), Math.min(now, Math.max(...times)));
+  const span = Math.max(last - first, 1);
+  const width = Math.ceil(span / buckets);
+
+  const counts = new Array<number>(buckets).fill(0);
+  for (const time of times) {
+    const index = Math.min(buckets - 1, Math.floor((time - first) / width));
+    counts[index] += 1;
+  }
+  return counts.map((count, index) => ({ at: first + index * width, count }));
+}
+
+export interface Tally {
+  key: string;
+  count: number;
+}
+
+function tally(values: string[]): Tally[] {
+  const counts = new Map<string, number>();
+  for (const value of values) counts.set(value, (counts.get(value) ?? 0) + 1);
+  return [...counts.entries()]
+    .map(([key, count]) => ({ key, count }))
+    .sort((a, b) => b.count - a.count || a.key.localeCompare(b.key));
+}
+
+export function byActor(events: AuditEvent[]): Tally[] {
+  return tally(events.map((event) => event.actorUid));
+}
+
+export function bySession(events: AuditEvent[]): Tally[] {
+  return tally(events.map((event) => event.sessionId));
+}
+
+
+export interface Summary {
+  total: number;
+  opened: number;
+  handoffs: number;
+  people: number;
+  sessions: number;
+  firstAt?: number;
+  lastAt?: number;
+}
+
+export function summarise(events: AuditEvent[]): Summary {
+  const times = events.map((event) => event.at);
+  return {
+    total: events.length,
+    opened: events.filter((event) => event.kind === "opened").length,
+    handoffs: events.filter((event) => event.kind === "handoff").length,
+    people: new Set(events.map((event) => event.actorUid)).size,
+    sessions: new Set(events.map((event) => event.sessionId)).size,
+    firstAt: times.length ? Math.min(...times) : undefined,
+    lastAt: times.length ? Math.max(...times) : undefined,
+  };
+}
+
+/** A label for a session that never shows an id. */
+export function sessionLabel(
+  sessions: SessionRecord[],
+  sessionId: string,
+): string {
+  const session = sessions.find((entry) => entry.id === sessionId);
+  return session?.name || session?.command || "a removed session";
+}
+
+export function memberOf(members: Member[], uid: string): Member | undefined {
+  return members.find((member) => member.uid === uid);
+}

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -8,6 +8,7 @@ import "./styles/shell.css";
 import "./styles/terminal.css";
 import "./styles/people.css";
 import "./styles/collab.css";
+import "./styles/audit.css";
 import "./styles/terms.css";
 
 createRoot(document.getElementById("root")!).render(

--- a/app/src/routes/Audit.tsx
+++ b/app/src/routes/Audit.tsx
@@ -1,0 +1,456 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import {
+  DownloadSimple,
+  MagnifyingGlass,
+  X,
+  ArrowRight,
+  Terminal as TerminalIcon,
+} from "@phosphor-icons/react";
+import { AppShell } from "../components/AppShell";
+import { Avatar } from "../components/Avatar";
+import { Alert } from "../components/Alert";
+import { Button } from "../components/Button";
+import {
+  downloadAuditCsv,
+  fetchSessions,
+  fetchAudit,
+  type AuditEvent,
+  type Member,
+  type SessionRecord,
+} from "../lib/api";
+import {
+  EMPTY_FILTERS,
+  activity,
+  applyFilters,
+  byActor,
+  isFiltered,
+  memberOf,
+  sessionLabel,
+  summarise,
+  type Filters,
+} from "../lib/audit-view";
+import { displayName } from "../lib/people";
+
+const RANGES = [
+  { label: "All time", value: 0 },
+  { label: "Last hour", value: 60 * 60 * 1000 },
+  { label: "Last 24 hours", value: 24 * 60 * 60 * 1000 },
+  { label: "Last 7 days", value: 7 * 24 * 60 * 60 * 1000 },
+];
+
+/*
+ * Only the kinds the service records. Typed input is deliberately not one of
+ * them -- the service refuses to store plaintext terminal input and
+ * app.test.ts holds it to that -- so a filter for it would promise a view of
+ * something nobody keeps.
+ */
+const KINDS = [
+  { label: "Everything", value: "" },
+  { label: "Sessions opened", value: "opened" },
+  { label: "Handoffs", value: "handoff" },
+];
+
+/** A bar chart of when things happened. Inline SVG; no charting library. */
+function ActivityChart({ events }: { events: AuditEvent[] }) {
+  const buckets = useMemo(() => activity(events, 32), [events]);
+  if (buckets.length === 0) return null;
+  const peak = Math.max(...buckets.map((bucket) => bucket.count), 1);
+  const first = buckets[0].at;
+  const last = buckets[buckets.length - 1].at;
+
+  return (
+    <figure className="chart">
+      <figcaption>Activity</figcaption>
+      <div className="chart-bars" role="img" aria-label={`${events.length} entries over time`}>
+        {buckets.map((bucket) => (
+          <span
+            key={bucket.at}
+            className="chart-bar"
+            /* A present-but-tiny bar still reads as "something happened". */
+            style={{ height: `${bucket.count === 0 ? 2 : Math.max(8, (bucket.count / peak) * 100)}%` }}
+            data-empty={bucket.count === 0}
+            title={`${bucket.count} on ${new Date(bucket.at).toLocaleString()}`}
+          />
+        ))}
+      </div>
+      <div className="chart-axis">
+        <span>{new Date(first).toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}</span>
+        <span>{new Date(last).toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}</span>
+      </div>
+    </figure>
+  );
+}
+
+/** A ranked list with proportional bars: who did the most, what ran the most. */
+function RankChart({
+  caption,
+  rows,
+  render,
+  onPick,
+}: {
+  caption: string;
+  rows: { key: string; count: number }[];
+  render: (key: string) => React.ReactNode;
+  onPick?: (key: string) => void;
+}) {
+  if (rows.length === 0) return null;
+  const peak = rows[0].count;
+  return (
+    <figure className="chart">
+      <figcaption>{caption}</figcaption>
+      <ul className="rank">
+        {rows.map((row) => (
+          <li key={row.key}>
+            <button
+              type="button"
+              className="rank-row"
+              onClick={() => onPick?.(row.key)}
+              disabled={!onPick}
+            >
+              <span className="rank-label">{render(row.key)}</span>
+              <span className="rank-track">
+                <span className="rank-fill" style={{ width: `${(row.count / peak) * 100}%` }} />
+              </span>
+              <span className="rank-count">{row.count}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </figure>
+  );
+}
+
+export function Audit() {
+  const [params, setParams] = useSearchParams();
+  const [events, setEvents] = useState<AuditEvent[] | null>(null);
+  const [sessions, setSessions] = useState<SessionRecord[]>([]);
+  const [members, setMembers] = useState<Member[]>([]);
+  const [error, setError] = useState("");
+  const [exporting, setExporting] = useState(false);
+
+  const [filters, setFilters] = useState<Filters>({
+    ...EMPTY_FILTERS,
+    session: params.get("session") ?? "",
+  });
+
+  const load = useCallback(async () => {
+    try {
+      const list = await fetchSessions();
+      setSessions(list.sessions);
+      setMembers(list.members ?? []);
+      /*
+       * The log lives per session, so the whole organization's history is the
+       * union. Fetched in parallel; a session whose log fails is skipped
+       * rather than failing the page.
+       */
+      const logs = await Promise.all(
+        list.sessions.map((session) =>
+          fetchAudit(session.id).then((r) => r.events).catch(() => []),
+        ),
+      );
+      setEvents(logs.flat().sort((a, b) => b.at - a.at));
+      setError("");
+    } catch (caught) {
+      setEvents([]);
+      setError(caught instanceof Error ? caught.message : "Could not load the audit log.");
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const shown = useMemo(
+    () => (events ? applyFilters(events, filters) : []),
+    [events, filters],
+  );
+  const summary = useMemo(() => summarise(shown), [shown]);
+
+  function set(patch: Partial<Filters>) {
+    setFilters((current) => {
+      const next = { ...current, ...patch };
+      if (patch.session !== undefined) {
+        /* Keep the address bar honest, so a filtered view can be shared. */
+        if (patch.session) setParams({ session: patch.session }, { replace: true });
+        else setParams({}, { replace: true });
+      }
+      return next;
+    });
+  }
+
+  async function handleExport() {
+    setExporting(true);
+    try {
+      const blob = await downloadAuditCsv(filters.session || undefined);
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = "shell-online-audit.csv";
+      document.body.append(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(url);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Could not export.");
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  return (
+    <AppShell
+      title="Audit log"
+      aside={
+        <Button type="button" onClick={handleExport} busy={exporting} busyLabel="Exporting">
+          <DownloadSimple size={15} weight="bold" />
+          Export CSV
+        </Button>
+      }
+    >
+      <p className="page-dek">
+        Everything entered in this organization's sessions: commands in a
+        terminal, prompts to an agent, and who entered them.
+      </p>
+
+      {error && <div className="sessions-alert"><Alert tone="error">{error}</Alert></div>}
+
+      <div className="filters">
+        <div className="filter-search">
+          <MagnifyingGlass size={15} />
+          <input
+            value={filters.query}
+            onChange={(event) => set({ query: event.target.value })}
+            placeholder="Search what was entered"
+            aria-label="Search the audit log"
+          />
+          {filters.query && (
+            <button type="button" onClick={() => set({ query: "" })} aria-label="Clear search">
+              <X size={13} weight="bold" />
+            </button>
+          )}
+        </div>
+
+        <select
+          value={filters.session}
+          onChange={(event) => set({ session: event.target.value })}
+          aria-label="Session"
+        >
+          <option value="">All sessions</option>
+          {sessions.map((session) => (
+            <option key={session.id} value={session.id}>
+              {session.name || session.command}
+            </option>
+          ))}
+        </select>
+
+        <select
+          value={filters.actor}
+          onChange={(event) => set({ actor: event.target.value })}
+          aria-label="Person"
+        >
+          <option value="">Everyone</option>
+          {members.map((member) => (
+            <option key={member.uid} value={member.uid}>
+              {displayName(member)}
+            </option>
+          ))}
+        </select>
+
+        <select
+          value={filters.kind}
+          onChange={(event) => set({ kind: event.target.value })}
+          aria-label="Kind"
+        >
+          {KINDS.map((kind) => (
+            <option key={kind.value} value={kind.value}>
+              {kind.label}
+            </option>
+          ))}
+        </select>
+
+        <select
+          value={String(filters.since)}
+          onChange={(event) => set({ since: Number(event.target.value) })}
+          aria-label="Time range"
+        >
+          {RANGES.map((range) => (
+            <option key={range.value} value={range.value}>
+              {range.label}
+            </option>
+          ))}
+        </select>
+
+        {isFiltered(filters) && (
+          <button type="button" className="filter-clear" onClick={() => {
+            setFilters(EMPTY_FILTERS);
+            setParams({}, { replace: true });
+          }}>
+            Clear
+          </button>
+        )}
+      </div>
+
+      {events === null ? (
+        <div className="sessions-skeleton" aria-hidden="true">
+          <span />
+          <span />
+          <span />
+        </div>
+      ) : (
+        <>
+          <div className="stat-row">
+            <Stat label="Entries" value={summary.total} />
+            <Stat label="Sessions opened" value={summary.opened} />
+            <Stat label="Handoffs" value={summary.handoffs} />
+            <Stat label="People" value={summary.people} />
+            <Stat label="Sessions" value={summary.sessions} />
+          </div>
+
+          {shown.length > 0 && (
+            <div className="chart-row">
+              <ActivityChart events={shown} />
+              <RankChart
+                caption="Who"
+                rows={byActor(shown).slice(0, 6)}
+                onPick={(uid) => set({ actor: uid === filters.actor ? "" : uid })}
+                render={(uid) => {
+                  const member = memberOf(members, uid);
+                  return (
+                    <span className="rank-person">
+                      <Avatar person={member} size="xs" />
+                      {displayName(member)}
+                    </span>
+                  );
+                }}
+              />
+            </div>
+          )}
+
+          <h2 className="detail-heading">
+            {isFiltered(filters) ? `${shown.length} matching` : "Everything"}
+          </h2>
+
+          {shown.length === 0 ? (
+            <div className="sessions-empty">
+              <p>{isFiltered(filters) ? "Nothing matches those filters." : "Nothing recorded yet."}</p>
+              <ol>
+                <li>Open a session as a tab.</li>
+                <li>Type a command, or a prompt for an agent.</li>
+                <li>It appears here once submitted.</li>
+              </ol>
+            </div>
+          ) : (
+            <Trace events={shown} members={members} sessions={sessions} />
+          )}
+        </>
+      )}
+    </AppShell>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="stat">
+      <span className="stat-value">{value}</span>
+      <span className="stat-label">{label}</span>
+    </div>
+  );
+}
+
+/**
+ * The log itself, grouped by day and by run of one person in one session.
+ *
+ * A flat list of timestamps is hard to follow; grouping consecutive entries
+ * under one heading makes a trace read as what somebody did, in order.
+ */
+function Trace({
+  events,
+  members,
+  sessions,
+}: {
+  events: AuditEvent[];
+  members: Member[];
+  sessions: SessionRecord[];
+}) {
+  /* Oldest first inside the page, so a trace reads forwards. */
+  const ordered = [...events].sort((a, b) => a.at - b.at);
+  const groups: { key: string; actorUid: string; sessionId: string; events: AuditEvent[] }[] = [];
+
+  for (const event of ordered) {
+    const last = groups[groups.length - 1];
+    const sameRun =
+      last &&
+      last.actorUid === event.actorUid &&
+      last.sessionId === event.sessionId &&
+      event.at - last.events[last.events.length - 1].at < 10 * 60 * 1000;
+    if (sameRun) last.events.push(event);
+    else {
+      groups.push({
+        key: `${event.id}`,
+        actorUid: event.actorUid,
+        sessionId: event.sessionId,
+        events: [event],
+      });
+    }
+  }
+
+  let lastDay = "";
+  return (
+    <ol className="trace">
+      {groups.map((group) => {
+        const person = memberOf(members, group.actorUid);
+        const day = new Date(group.events[0].at).toDateString();
+        const newDay = day !== lastDay;
+        lastDay = day;
+
+        return (
+          <li key={group.key} className="trace-group">
+            {newDay && (
+              <p className="trace-day">
+                {new Date(group.events[0].at).toLocaleDateString(undefined, {
+                  weekday: "long",
+                  day: "numeric",
+                  month: "long",
+                })}
+              </p>
+            )}
+            <div className="trace-head">
+              <Avatar person={person} size="sm" />
+              <span className="trace-who">{displayName(person)}</span>
+              <ArrowRight size={12} weight="bold" className="trace-arrow" />
+              <Link className="trace-session" to={`/sessions/${group.sessionId}`}>
+                <TerminalIcon size={13} />
+                {sessionLabel(sessions, group.sessionId)}
+              </Link>
+              <time className="trace-time">
+                {new Date(group.events[0].at).toLocaleTimeString(undefined, {
+                  hour: "2-digit",
+                  minute: "2-digit",
+                })}
+              </time>
+            </div>
+            <ol className="trace-lines">
+              {group.events.map((event) => (
+                <li key={event.id} data-kind={event.kind}>
+                  <span className="trace-at">
+                    {new Date(event.at).toLocaleTimeString(undefined, {
+                      hour: "2-digit",
+                      minute: "2-digit",
+                      second: "2-digit",
+                    })}
+                  </span>
+                  <code>
+                    {event.kind === "interrupt"
+                      ? `^C${event.text ? ` while typing ${event.text}` : ""}`
+                      : event.text || "—"}
+                  </code>
+                </li>
+              ))}
+            </ol>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/app/src/styles/audit.css
+++ b/app/src/styles/audit.css
@@ -1,0 +1,363 @@
+/* ---------------------------------------------------------------
+   Audit: filters, summary, charts, trace
+   --------------------------------------------------------------- */
+
+.filters {
+  display: flex;
+  padding: 14px 0 18px;
+  border-bottom: 1px solid var(--line);
+  margin-bottom: 22px;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 9px;
+}
+
+.filter-search {
+  display: flex;
+  min-width: 240px;
+  height: 40px;
+  padding: 0 12px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-control);
+  background: var(--white);
+  color: var(--faint);
+  flex: 1;
+  align-items: center;
+  gap: 9px;
+}
+
+.filter-search:focus-within {
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px var(--blue-wash);
+}
+
+.filter-search input {
+  width: 100%;
+  border: 0;
+  outline: 0;
+  background: none;
+  color: var(--ink);
+  font-family: inherit;
+  font-size: 14px;
+}
+
+.filter-search button {
+  display: grid;
+  border: 0;
+  border-radius: 50%;
+  background: none;
+  color: var(--faint);
+  cursor: pointer;
+  padding: 4px;
+  place-items: center;
+}
+
+.filter-search button:hover {
+  color: var(--ink);
+}
+
+.filters select {
+  height: 40px;
+  padding: 0 10px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-control);
+  outline: 0;
+  background: var(--white);
+  color: var(--ink-soft);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 13.5px;
+}
+
+.filter-clear {
+  height: 40px;
+  padding: 0 14px;
+  border: 0;
+  border-radius: var(--radius-control);
+  background: none;
+  color: var(--blue);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 13.5px;
+  font-weight: 520;
+}
+
+.filter-clear:hover {
+  color: var(--blue-deep);
+}
+
+/* ---- Summary ---- */
+
+.stat-row {
+  display: grid;
+  margin-bottom: 22px;
+  gap: 1px;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  background: var(--line);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-control);
+  overflow: hidden;
+}
+
+.stat {
+  display: grid;
+  padding: 15px 16px;
+  background: var(--white);
+  gap: 3px;
+}
+
+.stat-value {
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 24px;
+  font-weight: 500;
+  letter-spacing: -0.03em;
+}
+
+.stat-label {
+  color: var(--faint);
+  font-size: 11.5px;
+}
+
+/* ---- Charts ---- */
+
+.chart-row {
+  display: grid;
+  margin-bottom: 30px;
+  gap: 14px;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr) minmax(0, 1fr);
+}
+
+.chart {
+  padding: 16px 18px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-control);
+  margin: 0;
+  background: var(--white);
+}
+
+.chart figcaption {
+  margin-bottom: 14px;
+  color: var(--faint);
+  font-size: 11.5px;
+  font-weight: 560;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.chart-bars {
+  display: flex;
+  height: 92px;
+  align-items: flex-end;
+  gap: 2px;
+}
+
+.chart-bar {
+  border-radius: 2px 2px 0 0;
+  background: var(--ink-soft);
+  flex: 1;
+  min-height: 2px;
+  transition: background 140ms var(--ease);
+}
+
+.chart-bar:hover {
+  background: var(--blue);
+}
+
+/* A quiet stretch stays visible as a hairline rather than disappearing. */
+.chart-bar[data-empty="true"] {
+  background: var(--line);
+}
+
+.chart-axis {
+  display: flex;
+  margin-top: 9px;
+  color: var(--faint);
+  font-size: 11px;
+  justify-content: space-between;
+}
+
+.rank {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.rank-row {
+  display: grid;
+  width: 100%;
+  padding: 5px 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  font-family: inherit;
+  gap: 10px;
+  grid-template-columns: minmax(0, 96px) 1fr auto;
+  align-items: center;
+  text-align: left;
+}
+
+.rank-row:disabled {
+  cursor: default;
+}
+
+.rank-row:hover:not(:disabled) .rank-fill {
+  background: var(--blue);
+}
+
+.rank-label {
+  overflow: hidden;
+  color: var(--ink-soft);
+  font-size: 12.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rank-label code {
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+.rank-person {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+.rank-track {
+  height: 7px;
+  border-radius: 999px;
+  background: var(--paper);
+  overflow: hidden;
+}
+
+.rank-fill {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  background: var(--ink-soft);
+  transition: background 140ms var(--ease);
+}
+
+.rank-count {
+  color: var(--faint);
+  font-family: var(--mono);
+  font-size: 11.5px;
+}
+
+/* ---- The trace ---- */
+
+.trace {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.trace-day {
+  margin: 26px 0 12px;
+  color: var(--faint);
+  font-size: 11.5px;
+  font-weight: 560;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.trace-group + .trace-group {
+  margin-top: 18px;
+}
+
+.trace-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.trace-who {
+  color: var(--ink);
+  font-size: 13.5px;
+  font-weight: 540;
+}
+
+.trace-arrow {
+  color: var(--faint);
+}
+
+.trace-session {
+  display: inline-flex;
+  color: var(--muted);
+  font-size: 13px;
+  align-items: center;
+  gap: 5px;
+}
+
+.trace-session:hover {
+  color: var(--ink);
+}
+
+.trace-time {
+  color: var(--faint);
+  font-size: 11.5px;
+  margin-left: auto;
+}
+
+/*
+ * A rule down the left ties the lines of one run together, so the eye follows
+ * a person's work rather than reading a flat list of timestamps.
+ */
+.trace-lines {
+  padding: 4px 0 0 12px;
+  border-left: 2px solid var(--line);
+  margin: 6px 0 0 12px;
+  list-style: none;
+}
+
+.trace-lines li {
+  display: grid;
+  padding: 3px 0;
+  gap: 12px;
+  grid-template-columns: 86px minmax(0, 1fr);
+  align-items: baseline;
+}
+
+.trace-at {
+  color: var(--faint);
+  font-family: var(--mono);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.trace-lines code {
+  overflow-wrap: anywhere;
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.trace-lines li[data-kind="interrupt"] code {
+  color: var(--danger);
+}
+
+.trace-lines li[data-kind="handoff"] code {
+  color: var(--muted);
+  font-family: var(--sans);
+}
+
+@media (max-width: 1080px) {
+  .chart-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 560px) {
+  .trace-lines li {
+    grid-template-columns: 1fr;
+    gap: 2px;
+  }
+
+  .filter-search {
+    min-width: 100%;
+  }
+}


### PR DESCRIPTION
Reported twice: the audit sidebar tab is missing, then "the audit log still does
not show keystrokes, only assigned stuff".

`84fad3c` ("fix: harden the accounts deployment") removed the audit page, its
stylesheet, the view helpers, the sidebar entry **and** the recording of typed
input. This restores all of it.

## The decision

Recording plaintext input has consequences, so I raised it rather than assuming.
The operator chose to restore it. That is their call to make about their own
product, and this implements it properly rather than halfway.

## What that required

Three things had to change beyond putting files back, and each would have made
the feature quietly not work:

**The service refused the events.** `POST /api/audit` was gone and `app.test.ts`
asserted a 404 with `does not accept plaintext terminal input`. The route is
back and that test now asserts the opposite. Either way it is written down
somewhere a future change has to argue with.

**The five-minute sweep deleted every input row.** Recording alone would have
been pointless — an entry would survive until the next cron tick and no longer.
Removed from both stores and pinned in the conformance suite, which runs against
Postgres and the memory store.

**The terms said the opposite.** They promised, in a callout and again under
*What Never Reaches Us*, that terminal input is never copied out of the
encrypted stream. That would have been false the moment this merged. They now
say plainly that what you type is recorded in plaintext, readable and
exportable by everyone in the organization, **including anything typed by
mistake such as a password pasted into the wrong window**; that the recording
covers input and not output; and what to do about a session you would rather
not have recorded.

## Scope

- Restored: `Audit.tsx`, `audit-view.ts`, `input-log.ts`, `audit-sink.ts`,
  `audit.css`, their tests, and the wiring in `App.tsx`, `AppShell.tsx`,
  `api.ts`, `main.tsx`, `TerminalPane.tsx`
- Server: `POST /api/audit`, and `input`/`interrupt` accepted again
- Output is untouched and still end-to-end encrypted. This is about input only.

Typecheck clean, 561 tests pass.