### PR TITLE
Ask about browser-started sessions on every login, not just the first

### DIFF
--- a/cmd/shell/account.go
+++ b/cmd/shell/account.go
@@ -163,7 +163,7 @@ func runLogin(arguments []string, stdout, stderr io.Writer) int {
 		interactiveTerminal(stderr),
 	)
 	if ask {
-		grant = askRemoteStart(os.Stdin, stderr, credentials.Email)
+		grant = askRemoteStart(os.Stdin, stderr, credentials.Email, alreadyGranted)
 	}
 	credentials.RemoteStart = grant
 

--- a/cmd/shell/daemon.go
+++ b/cmd/shell/daemon.go
@@ -98,7 +98,7 @@ func startDaemonCommand(stdout, stderr io.Writer) int {
 			fmt.Fprintln(stderr, "Run 'shell login --allow-remote-start' to change that.")
 			return 1
 		}
-		if !askRemoteStart(os.Stdin, stderr, credentials.Email) {
+		if !askRemoteStart(os.Stdin, stderr, credentials.Email, credentials.RemoteStart) {
 			fmt.Fprintln(stdout, "Left as publish-only.")
 			return 1
 		}

--- a/cmd/shell/remote_start.go
+++ b/cmd/shell/remote_start.go
@@ -23,30 +23,41 @@ type remoteStartFlags struct {
 // decideRemoteStart returns whether the machine accepts remote starts, and
 // whether the person has to be asked to find out.
 //
-// Agreement is remembered and never re-asked. A refusal is not: someone who
-// said no once may well say yes when they next sign in, and holding them to it
-// silently would be worse than asking again. Without a terminal to ask at,
-// the answer is no -- a script that is not watching cannot consent for anyone.
+// Asked on every interactive login, including when the answer is already yes.
+// The capability is the difference between a machine that appears in a browser
+// and one that does not, and it used to be settable only by remembering a flag
+// nobody had heard of: agreement was remembered and never raised again, so
+// somebody who missed the question once had no way to find it. Asking every
+// time is what makes --allow-remote-start a shortcut rather than the only
+// route, and it is the only moment anyone is in a position to change their
+// mind.
+//
+// The previous answer becomes the default, so returning stays one keystroke
+// and nobody is re-deciding something they already settled.
+//
+// Without a terminal, the answer stands as it was. A script cannot consent for
+// anyone, and it must not revoke on their behalf either: a machine that was
+// reachable before a scripted login should still be reachable after it.
 func decideRemoteStart(alreadyGranted bool, flags remoteStartFlags, interactive bool) (grant, ask bool) {
 	switch {
 	case flags.deny:
 		return false, false
 	case flags.allow:
 		return true, false
-	case alreadyGranted:
-		return true, false
 	case !interactive:
-		return false, false
+		return alreadyGranted, false
 	default:
-		return false, true
+		return alreadyGranted, true
 	}
 }
 
 // askRemoteStart puts the question, and reads one line back.
 //
-// Anything but an explicit yes is a no. A person who hits enter without
-// reading has not agreed to let a browser run commands on their machine.
-func askRemoteStart(input io.Reader, output io.Writer, email string) bool {
+// The current answer is the default, so enter keeps whatever is already true.
+// That is safe in the direction that matters: the default is only yes for a
+// machine that has already agreed, so nobody grants this by hitting enter
+// without reading, and nobody loses a working machine by doing the same.
+func askRemoteStart(input io.Reader, output io.Writer, email string, current bool) bool {
 	color := sessionOutputUsesColor(output)
 	dim := func(text string) string { return styleSessionText(color, "2", text) }
 
@@ -54,15 +65,26 @@ func askRemoteStart(input io.Reader, output io.Writer, email string) bool {
 	fmt.Fprintf(output, "  %s\n", dim("Anyone signed in to "+email+" could start processes on this"))
 	fmt.Fprintf(output, "  %s\n", dim("machine, as you, without touching this terminal."))
 	fmt.Fprintf(output, "  %s\n\n", dim("You can say no and still publish sessions with 'shell <command>'."))
-	fmt.Fprintf(output, "  Allow it? %s ", dim("[y/N]"))
+	choices := "[y/N]"
+	if current {
+		choices = "[Y/n]"
+	}
+	fmt.Fprintf(output, "  Allow it? %s ", dim(choices))
 
 	line, err := bufio.NewReader(input).ReadString('\n')
 	if err != nil && line == "" {
 		fmt.Fprintln(output)
-		return false
+		return current
 	}
-	answer := strings.ToLower(strings.TrimSpace(line))
-	return answer == "y" || answer == "yes"
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return true
+	case "n", "no":
+		return false
+	default:
+		/* Enter, or anything unrecognised, leaves it as it stands. */
+		return current
+	}
 }
 
 // interactiveTerminal reports whether there is a person at both ends to ask.

--- a/cmd/shell/remote_start_test.go
+++ b/cmd/shell/remote_start_test.go
@@ -13,12 +13,20 @@ func TestDecideRemoteStartAsksWhenNothingIsKnown(t *testing.T) {
 	}
 }
 
-// Agreeing is remembered. Being asked every time trains people to say yes
-// without reading, which is the opposite of consent.
-func TestDecideRemoteStartNeverAsksAgainOnceGranted(t *testing.T) {
+// The question is put on every interactive login, including when the answer is
+// already yes.
+//
+// It used to be asked once and never again, which left --allow-remote-start as
+// the only way to reach a decision anyone had already made, and no way at all
+// to find it if they had missed the question. The previous answer is the
+// default, so agreeing again is one keystroke.
+func TestDecideRemoteStartAsksAgainEvenOnceGranted(t *testing.T) {
 	grant, ask := decideRemoteStart(true, remoteStartFlags{}, true)
-	if !grant || ask {
-		t.Fatalf("a granted machine should not be asked again, got grant=%v ask=%v", grant, ask)
+	if !ask {
+		t.Fatal("a machine that already agreed should still be asked")
+	}
+	if !grant {
+		t.Fatal("the standing answer should be the default offered")
 	}
 }
 
@@ -61,14 +69,14 @@ func TestDecideRemoteStartKeepsAGrantWithoutATerminal(t *testing.T) {
 func TestAskRemoteStartAcceptsOnlyAnExplicitYes(t *testing.T) {
 	for _, answer := range []string{"y\n", "Y\n", "yes\n", "YES\n", " y \n"} {
 		var output bytes.Buffer
-		if !askRemoteStart(strings.NewReader(answer), &output, "ana@example.com") {
+		if !askRemoteStart(strings.NewReader(answer), &output, "ana@example.com", false) {
 			t.Fatalf("%q should have been taken as yes", answer)
 		}
 	}
 	// Enter on its own is the common case of not reading the question.
 	for _, answer := range []string{"\n", "n\n", "no\n", "sure\n", "ok\n", ""} {
 		var output bytes.Buffer
-		if askRemoteStart(strings.NewReader(answer), &output, "ana@example.com") {
+		if askRemoteStart(strings.NewReader(answer), &output, "ana@example.com", false) {
 			t.Fatalf("%q should not have been taken as yes", answer)
 		}
 	}
@@ -78,7 +86,7 @@ func TestAskRemoteStartAcceptsOnlyAnExplicitYes(t *testing.T) {
 // access?" would be true and useless.
 func TestAskRemoteStartSaysWhatItGrants(t *testing.T) {
 	var output bytes.Buffer
-	askRemoteStart(strings.NewReader("n\n"), &output, "ana@example.com")
+	askRemoteStart(strings.NewReader("n\n"), &output, "ana@example.com", false)
 	text := output.String()
 	for _, phrase := range []string{"ana@example.com", "start processes", "without touching this terminal"} {
 		if !strings.Contains(text, phrase) {
@@ -101,5 +109,33 @@ func TestWantsDaemonRunning(t *testing.T) {
 	}
 	if wantsDaemonRunning(nil) {
 		t.Fatal("no arguments should not bring the daemon up")
+	}
+}
+
+// Enter keeps whatever is already true, in both directions.
+//
+// A machine that has never agreed must not be granted by somebody pressing
+// enter without reading, and a machine that has agreed must not lose it the
+// same way. That is the whole reason the default follows the current answer
+// rather than being fixed.
+func TestAskRemoteStartTreatsEnterAsLeaveItAlone(t *testing.T) {
+	for _, current := range []bool{false, true} {
+		var output bytes.Buffer
+		if got := askRemoteStart(strings.NewReader("\n"), &output, "ana@example.com", current); got != current {
+			t.Fatalf("enter with current=%v returned %v; it should change nothing", current, got)
+		}
+	}
+}
+
+// The prompt shows which way enter will go.
+func TestAskRemoteStartShowsTheStandingAnswerAsTheDefault(t *testing.T) {
+	var granted, fresh bytes.Buffer
+	askRemoteStart(strings.NewReader("\n"), &granted, "ana@example.com", true)
+	askRemoteStart(strings.NewReader("\n"), &fresh, "ana@example.com", false)
+	if !strings.Contains(granted.String(), "[Y/n]") {
+		t.Fatalf("a machine that agreed should offer [Y/n], got: %s", granted.String())
+	}
+	if !strings.Contains(fresh.String(), "[y/N]") {
+		t.Fatalf("a machine that has not agreed should offer [y/N], got: %s", fresh.String())
 	}
 }


### PR DESCRIPTION
> "`--allow-remote-start` is redundant and people will not know about it."

Agreed, and that is the bug. Agreement was remembered and never raised again,
so the flag was the only way to reach a decision already made — and somebody
who missed the question the first time had no route back to it at all.

This is not a small setting. It decides whether a machine appears in a browser
or does not, which is exactly the difference reported as "machines appear
offline no matter how many times I write `shell login`".

## What changes

The question is put on **every interactive login**, with the previous answer as
the default. Agreeing again is one keystroke. The flag stays as a shortcut for
scripts and for anyone who wants to skip the prompt.

```
  Start sessions from the browser?
  Anyone signed in to you@example.com could start processes on this
  machine, as you, without touching this terminal.
  You can say no and still publish sessions with 'shell <command>'.

  Allow it? [Y/n]        ← [y/N] on a machine that has not agreed
```

## The safety property

Enter keeps whatever is already true, **in both directions**, and that is why
the default follows the current answer rather than being fixed:

- a machine that has never agreed **cannot be granted** by someone pressing
  enter without reading
- a machine that has agreed **does not lose it** the same way

The prompt shows which way enter will go. Two tests pin this.

## One behaviour change worth calling out

Without a terminal the answer now **stands as it was**, where it used to become
no. A script cannot consent for anyone, and it must not revoke on their behalf
either — a machine that was reachable before a scripted login should still be
reachable after one. `TestDecideRemoteStartKeepsAGrantWithoutATerminal` already
covered the granted case and still passes.

`TestDecideRemoteStartNeverAsksAgainOnceGranted` is replaced by
`TestDecideRemoteStartAsksAgainEvenOnceGranted`, since that behaviour is the
thing being removed.

Full Go suite green, `gofmt` and `go vet` clean.