### PR TITLE
Read who may type from the session, not from the tab it was opened in

### DIFF
--- a/app/src/routes/Workspace.tsx
+++ b/app/src/routes/Workspace.tsx
@@ -319,15 +319,29 @@ export function Workspace() {
       */}
       {state.tabs.length > 0 && (
         <div className="panes" hidden={showingList}>
-          {state.tabs.map((tab) => (
-            <TerminalPane
-              key={tab.id}
-              shareUrl={tab.shareUrl}
-              active={state.activeId === tab.id}
-              keyShare={tab.keyShare}
-              canType={tab.canType}
-            />
-          ))}
+          {state.tabs.map((tab) => {
+            /*
+             * Permission is read from the session list on every render, not
+             * from the tab. Whether someone may type is a fact about the
+             * session and the person, and it changes underneath an open tab:
+             * a colleague who opened one to watch, and is then handed the
+             * session, kept the answer taken when the tab was created and
+             * stayed read-only until they closed and reopened it.
+             *
+             * The tab's own copy is the fallback for a session that has left
+             * the list, where the last known answer is the best there is.
+             */
+            const current = sessions?.find((session) => session.id === tab.id);
+            return (
+              <TerminalPane
+                key={tab.id}
+                shareUrl={tab.shareUrl}
+                active={state.activeId === tab.id}
+                keyShare={current?.keyShare ?? tab.keyShare}
+                canType={current ? canEdit(current, you) : tab.canType}
+              />
+            );
+          })}
         </div>
       )}
 

--- a/app/src/terminal/tabs.test.ts
+++ b/app/src/terminal/tabs.test.ts
@@ -149,3 +149,42 @@ describe("select", () => {
     expect(reduce(state, { type: "select", id: "ghost" })).toBe(state);
   });
 });
+
+describe("reopening", () => {
+/*
+ * A session can be handed to someone who already has it open. The tab was a
+ * snapshot taken when it was opened, so they stayed read-only until they
+ * closed and reopened it, which nobody would think to do.
+ */
+it("takes the new answer on whether you may type when a session is reopened", () => {
+  const record = session("s1");
+  const watching = reduce(EMPTY, { type: "open", session: record, canType: false });
+  expect(watching.tabs[0].canType).toBe(false);
+
+  const assigned = reduce(watching, { type: "open", session: record, canType: true });
+  expect(assigned.tabs).toHaveLength(1);
+  expect(assigned.tabs[0].canType).toBe(true);
+  expect(assigned.activeId).toBe("s1");
+});
+
+/* The password a colleague seals to you arrives after the tab is already open. */
+it("picks up a key share that was not there when the tab was opened", () => {
+  const before = reduce(EMPTY, { type: "open", session: session("s1") });
+  expect(before.tabs[0].keyShare).toBeUndefined();
+
+  const share = { senderPublicKey: "pk", sealed: "sealed" };
+  const after = reduce(before, {
+    type: "open",
+    session: { ...session("s1"), keyShare: share },
+  });
+  expect(after.tabs[0].keyShare).toEqual(share);
+});
+
+/* Losing it would silently downgrade a tab that is working. */
+it("keeps a key share when the refreshed session has none", () => {
+  const share = { senderPublicKey: "pk", sealed: "sealed" };
+  const open = reduce(EMPTY, { type: "open", session: { ...session("s1"), keyShare: share } });
+  const again = reduce(open, { type: "open", session: session("s1") });
+  expect(again.tabs[0].keyShare).toEqual(share);
+});
+});

--- a/app/src/terminal/tabs.ts
+++ b/app/src/terminal/tabs.ts
@@ -36,8 +36,29 @@ export function reduce(state: TabState, action: TabAction): TabState {
   switch (action.type) {
     case "open": {
       const { session } = action;
+      /*
+       * Reopening refreshes the tab rather than only selecting it. What it
+       * holds is a copy of the session taken when it was opened, and the
+       * parts that matter change underneath it: a session handed to someone
+       * while they had it open kept the old answer to whether they may type,
+       * and the sealed password they were later given never arrived.
+       */
       const existing = state.tabs.find((tab) => tab.id === session.id);
-      if (existing) return { ...state, activeId: existing.id };
+      if (existing) {
+        const refreshed: Tab = {
+          ...existing,
+          label: session.name?.trim() || session.command,
+          command: session.command,
+          shareUrl: session.shareUrl,
+          readOnly: session.readOnly,
+          keyShare: session.keyShare ?? existing.keyShare,
+          canType: action.canType ?? existing.canType,
+        };
+        return {
+          tabs: state.tabs.map((tab) => (tab.id === existing.id ? refreshed : tab)),
+          activeId: existing.id,
+        };
+      }
 
       const tab: Tab = {
         id: session.id,


### PR DESCRIPTION
Reported as: after assigning a session to a colleague, they still cannot type.
Then narrowed by the reporter — **new sessions are fine**, which is the tell.

## What happens

A tab holds a copy of the session taken when it was opened, and `canType` is
one of the copied fields. That answer changes underneath an open tab:

1. a colleague opens the session to watch — `canType: false`
2. it is assigned to them
3. nothing updates the tab, so they stay read-only

Reopening did not help either. `reduce` treated an already-open session as a
select:

```ts
const existing = state.tabs.find((tab) => tab.id === session.id);
if (existing) return { ...state, activeId: existing.id };
```

New sessions are unaffected because their tab is created after the assignment,
with the right answer baked in — which is exactly why this looked
session-specific rather than like a caching bug.

## The fix

`canType` is read from the session list on every render. Whether someone may
type is a fact about the session and the person, not about when a tab happened
to be created, and the list is already polled. The tab's copy remains the
fallback for a session that has left the list.

Reopening now refreshes the tab too. That matters for the sealed password: a
share made after a tab was opened never reached it. It keeps the share it
already has when the refreshed session carries none, since losing one would
quietly downgrade a working tab.

## Ruled out first

- The relay is not the cause. It reports `read_only:false` for an interactive
  session — checked against a live one on production.
- `canEdit` itself was already right: `ownerUid === you.uid || assigneeUid ===
  you.uid`.
- The fields it needs do arrive. On a live session: `ownerUid` matching
  `you.uid`, `assigneeUid` set, `readOnly:false`.

Three tests cover the answer changing while a tab is open, a share arriving
after it, and a share not being dropped. Typecheck clean, full app suite green.