### PR TITLE
Stop one test closing another test's file

### DIFF
--- a/cmd/shell/background_unix_test.go
+++ b/cmd/shell/background_unix_test.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"syscall"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 func TestBackgroundReadyDescriptorIsCloseOnExec(t *testing.T) {
@@ -15,18 +17,44 @@ func TestBackgroundReadyDescriptorIsCloseOnExec(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer reader.Close()
+	defer writer.Close()
+
+	/*
+	 * A duplicate, not writer's own descriptor.
+	 *
+	 * openBackgroundReadyFile wraps whatever number it is given in its own
+	 * *os.File, so handing it writer's would leave two files believing they
+	 * own one descriptor. Closing either frees the number for the next open
+	 * anywhere in the process, and the other one closes it again when the
+	 * garbage collector finalises it -- by which time it belongs to somebody
+	 * else's file.
+	 *
+	 * That is not hypothetical. It surfaced as
+	 * TestPersistentStateRejectsInvalidEncryptionMaterial failing with
+	 * "close .shell-online-state-...: bad file descriptor", in another file,
+	 * on a run that had nothing to do with either test.
+	 *
+	 * dup also clears close-on-exec, which is the state ExtraFiles leaves a
+	 * descriptor in, so this is the condition being tested rather than a
+	 * convenience.
+	 */
+	duplicate, err := unix.Dup(int(writer.Fd()))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	t.Setenv(backgroundChildEnvironment, "1")
 	t.Setenv(backgroundParentEnvironment, strconv.Itoa(os.Getppid()))
-	t.Setenv(backgroundReadyEnvironment, strconv.Itoa(int(writer.Fd())))
+	t.Setenv(backgroundReadyEnvironment, strconv.Itoa(duplicate))
 
 	ready, err := openBackgroundReadyFile()
 	if err != nil {
+		unix.Close(duplicate)
 		t.Fatal(err)
 	}
 	defer ready.Close()
 
-	flags, _, errno := syscall.Syscall(syscall.SYS_FCNTL, writer.Fd(), syscall.F_GETFD, 0)
+	flags, _, errno := syscall.Syscall(syscall.SYS_FCNTL, uintptr(duplicate), syscall.F_GETFD, 0)
 	if errno != 0 {
 		t.Fatalf("read readiness descriptor flags: %v", errno)
 	}


### PR DESCRIPTION
This is what failed PR #69, and it has nothing to do with that branch. It is a
pre-existing bug in `TestBackgroundReadyDescriptorIsCloseOnExec` that lands in
whichever test happens to open a file next.

```
--- FAIL: TestPersistentStateRejectsInvalidEncryptionMaterial
    close .shell-online-state-1730618853: bad file descriptor
```

## What happens

The test makes a pipe and hands the **writer's own descriptor number** to
`openBackgroundReadyFile`, which wraps whatever number it is given in an
`*os.File` of its own. Two files then believe they own one descriptor.

1. `ready.Close()` closes it, freeing the number for the next open anywhere in
   the process
2. `writer` is never closed, so its finalizer closes that number again — by
   which point it belongs to somebody else's file

So the failure surfaces in an unrelated test, in another file, on a run that
touched neither. That is why it reads as a flake in the persistent-state code
and is not one.

## Reproduced

Handing the same descriptor over, closing it, then opening a temporary file:

```
writer fd=6 handed to openBackgroundReadyFile
new file got fd=6          ← the same descriptor, straight back
```

The finalizer closing it after that point is what produces the `EBADF`.

## The fix

The test duplicates the descriptor and hands over the copy, so each file owns
exactly one. `dup` also clears close-on-exec — the state `ExtraFiles` leaves a
descriptor in — so the duplicate is a better model of what this test is about
than the original was.

## Verified

- The two tests together under `GOGC=1` with `-race`, five runs: clean
- `go test -race ./cmd/shell/`: clean
- `go test -race ./...`: clean

Merging this should be enough to make #69 go green on a re-run.