### PR TITLE
Record what is typed, and say so in the terms

### DIFF
--- a/app/server/app.test.ts
+++ b/app/server/app.test.ts
@@ -1119,7 +1119,14 @@ describe("audit log", () => {
     return tokens;
   }
 
-  it("does not accept plaintext terminal input", async () => {
+  /*
+   * Terminal input is recorded in plaintext, and the whole organization can
+   * read and export it. That is a deliberate choice rather than an oversight:
+   * it was removed once and put back on the operator's instruction, and the
+   * terms say so. This test is where the choice is written down, so that
+   * removing it again is a decision somebody takes rather than a regression.
+   */
+  it("records what was typed, in plaintext, for the whole organization", async () => {
     await withSession();
     const result = await call("POST", "/api/audit", {
       auth: await idToken(),
@@ -1130,9 +1137,16 @@ describe("audit log", () => {
         ],
       },
     });
-    expect(result.status).toBe(404);
+    expect(result.status).toBe(200);
+    expect(result.body.written).toBe(2);
+
     const log = await call("GET", `/api/audit/${session.id}`, { auth: await idToken() });
-    expect(log.body.events).toEqual([]);
+    expect(log.body.events).toHaveLength(2);
+    expect(log.body.events.map((event: { kind: string }) => event.kind)).toEqual([
+      "input",
+      "interrupt",
+    ]);
+    expect(log.body.events[0].text).toBe("refactor the parser");
   });
 
   it("will not read another organization's log", async () => {

--- a/app/server/app.ts
+++ b/app/server/app.ts
@@ -29,7 +29,7 @@ import {
   notifyInvited,
   revokeInvite,
 } from "./routes/organizations";
-import { assignSession, auditCsv } from "./routes/audit";
+import { recordAudit, assignSession, auditCsv } from "./routes/audit";
 import { addComment, inbox, notifyAssigned, notifySessionStarted } from "./routes/social";
 import { callerAddress, rateLimiter } from "./lib/rate-limit";
 import { logMailer, type Mailer } from "./lib/mail";
@@ -454,6 +454,25 @@ export function createApp(options: AppOptions) {
       }
 
       /* ---- Audit ---- */
+
+      if (route === "POST /api/audit") {
+        const membership = await requireMember(request);
+        if (!membership) return send(response, 401, { error: "sign in first" });
+        const body = (await readBody(request)) as Record<string, unknown>;
+        const entries = Array.isArray(body.entries) ? body.entries : [];
+        const written = [];
+        for (const entry of entries.slice(0, 100)) {
+          const candidate = entry as Record<string, unknown>;
+          const result = await recordAudit(store, membership, {
+            sessionId: String(candidate.session_id ?? ""),
+            kind: String(candidate.kind ?? "input"),
+            text: String(candidate.text ?? ""),
+            at: typeof candidate.at === "number" ? candidate.at : undefined,
+          });
+          if (result.ok) written.push(result.event);
+        }
+        return send(response, 200, { written: written.length });
+      }
 
       const auditRoute = url.pathname.match(/^\/api\/audit\/([A-Za-z0-9_-]{6,64})$/);
       if (request.method === "GET" && auditRoute) {

--- a/app/server/lib/store-conformance.test.ts
+++ b/app/server/lib/store-conformance.test.ts
@@ -509,11 +509,20 @@ for (const implementation of implementations) {
     });
 
     describe("audit", () => {
-      it("purges legacy plaintext input while preserving collaboration metadata", async () => {
-        await store.putAudit(auditEvent({ id: "plain", kind: "input", text: "secret command" }));
+      /*
+       * The five-minute sweep used to delete every input and interrupt row,
+       * which made recording them pointless: an entry survived until the next
+       * cron tick and no longer. Input is retained on purpose now, so the
+       * sweep must leave it alone, and this is where that is written down.
+       */
+      it("keeps recorded input rather than sweeping it away", async () => {
+        await store.putAudit(auditEvent({ id: "typed", kind: "input", text: "secret command" }));
         await store.putAudit(auditEvent({ id: "handoff", kind: "handoff", text: "assigned" }));
         await store.purgeExpired();
-        expect((await store.auditFor("org_1", "s1")).map((entry) => entry.id)).toEqual(["handoff"]);
+        expect((await store.auditFor("org_1", "s1")).map((entry) => entry.id).sort()).toEqual([
+          "handoff",
+          "typed",
+        ]);
       });
 
       it("reads one session's trail in the order it happened", async () => {

--- a/app/server/lib/store-memory.ts
+++ b/app/server/lib/store-memory.ts
@@ -545,20 +545,12 @@ export class MemoryStore implements Store {
   async purgeExpired(now = Date.now()): Promise<void> {
     const before = this.data.codes.length;
     this.data.codes = this.data.codes.filter((entry) => entry.expiresAt > now);
-    const auditBefore = this.data.audit.length;
-    this.data.audit = this.data.audit.filter(
-      (entry) => entry.kind !== "input" && entry.kind !== "interrupt",
-    );
     /* Finished commands are only kept long enough to be reported back. */
     const commandsBefore = this.data.commands.length;
     this.data.commands = this.data.commands.filter(
       (entry) => !entry.doneAt || now - entry.doneAt < 10 * 60_000,
     );
-    if (
-      this.data.codes.length !== before ||
-      this.data.commands.length !== commandsBefore ||
-      this.data.audit.length !== auditBefore
-    ) {
+    if (this.data.codes.length !== before || this.data.commands.length !== commandsBefore) {
       this.flush();
     }
   }

--- a/app/server/lib/store-postgres.ts
+++ b/app/server/lib/store-postgres.ts
@@ -1163,12 +1163,6 @@ export class PostgresStore implements Store {
 
   async purgeExpired(now = Date.now()): Promise<void> {
     await this.pool.query("DELETE FROM auth_codes WHERE expires_at <= $1", [now]);
-    /*
-     * Builds before 0.9.0 briefly captured committed input in plaintext.
-     * E2EE means the control plane should never receive that material, so
-     * remove any legacy rows as part of the normal five-minute sweep.
-     */
-    await this.pool.query("DELETE FROM audit_events WHERE kind IN ('input', 'interrupt')");
     /* Finished commands are only kept long enough to be reported back. */
     await this.pool.query("DELETE FROM agent_commands WHERE done_at IS NOT NULL AND done_at < $1", [
       now - 10 * 60_000,

--- a/app/server/routes/audit.ts
+++ b/app/server/routes/audit.ts
@@ -2,7 +2,7 @@ import type { AuditEvent, SessionRecord, Store } from "../lib/store";
 import { newId, type Membership } from "../lib/orgs";
 
 export const MAX_TEXT = 4100;
-const KINDS = new Set(["opened", "handoff"]);
+const KINDS = new Set(["input", "interrupt", "opened", "handoff"]);
 
 export interface RecordInput {
   sessionId: string;

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -318,6 +318,13 @@ export function fetchSessions() {
 
 export const accountsBaseUrl = BASE;
 
+export function postAudit(entries: { session_id: string; kind: string; text: string; at: number }[]) {
+  return request<{ written: number }>("/api/audit", {
+    method: "POST",
+    body: JSON.stringify({ entries }),
+  });
+}
+
 export function fetchAudit(sessionId: string) {
   return request<{ events: AuditEvent[] }>(`/api/audit/${encodeURIComponent(sessionId)}`);
 }

--- a/app/src/lib/audit-view.test.ts
+++ b/app/src/lib/audit-view.test.ts
@@ -7,7 +7,8 @@ import {
   isFiltered,
   sessionLabel,
   summarise,
-  } from "./audit-view";
+  topCommands,
+} from "./audit-view";
 import type { AuditEvent, SessionRecord } from "./api";
 
 const BASE = Date.UTC(2026, 8, 6, 12, 0, 0);
@@ -113,17 +114,27 @@ describe("tallies", () => {
     ]);
   });
 
+  it("groups commands by the tool, not the whole line", () => {
+    /* Counting whole lines would list near-duplicates and say nothing. */
+    expect(topCommands(events)).toEqual([
+      { key: "git", count: 2 },
+      { key: "npm", count: 1 },
+    ]);
+  });
 
+  it("leaves interrupts out of the command ranking", () => {
+    expect(topCommands([...events, event({ kind: "interrupt", text: "" })])).toHaveLength(2);
+  });
 });
 
 describe("summarise", () => {
   it("counts the things a reader asks first", () => {
     const summary = summarise([
-      event({ actorUid: "u1", sessionId: "s1", at: BASE, kind: "opened" }),
-      event({ actorUid: "u2", sessionId: "s2", at: BASE + 1000, kind: "handoff" }),
+      event({ actorUid: "u1", sessionId: "s1", at: BASE }),
+      event({ actorUid: "u2", sessionId: "s2", at: BASE + 1000, kind: "interrupt" }),
     ]);
     expect(summary).toMatchObject({
-      total: 2, opened: 1, handoffs: 1, people: 2, sessions: 2,
+      total: 2, inputs: 1, interrupts: 1, people: 2, sessions: 2,
       firstAt: BASE, lastAt: BASE + 1000,
     });
   });

--- a/app/src/lib/audit-view.ts
+++ b/app/src/lib/audit-view.ts
@@ -101,11 +101,24 @@ export function bySession(events: AuditEvent[]): Tally[] {
   return tally(events.map((event) => event.sessionId));
 }
 
+/**
+ * The most-used commands.
+ *
+ * Keyed on the first word, because "git status" and "git log" are the same
+ * tool and counting whole lines would produce a list of near-duplicates that
+ * says nothing.
+ */
+export function topCommands(events: AuditEvent[], limit = 8): Tally[] {
+  const words = events
+    .filter((event) => event.kind === "input" && event.text.trim())
+    .map((event) => event.text.trim().split(/\s+/)[0]);
+  return tally(words).slice(0, limit);
+}
 
 export interface Summary {
   total: number;
-  opened: number;
-  handoffs: number;
+  inputs: number;
+  interrupts: number;
   people: number;
   sessions: number;
   firstAt?: number;
@@ -116,8 +129,8 @@ export function summarise(events: AuditEvent[]): Summary {
   const times = events.map((event) => event.at);
   return {
     total: events.length,
-    opened: events.filter((event) => event.kind === "opened").length,
-    handoffs: events.filter((event) => event.kind === "handoff").length,
+    inputs: events.filter((event) => event.kind === "input").length,
+    interrupts: events.filter((event) => event.kind === "interrupt").length,
     people: new Set(events.map((event) => event.actorUid)).size,
     sessions: new Set(events.map((event) => event.sessionId)).size,
     firstAt: times.length ? Math.min(...times) : undefined,

--- a/app/src/lib/input-log.test.ts
+++ b/app/src/lib/input-log.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { InputLog, MAX_ENTRY_LENGTH } from "./input-log";
+
+function feed(chunks: string[]) {
+  const log = new InputLog();
+  return chunks.flatMap((chunk) => log.push(chunk));
+}
+
+describe("submitting a line", () => {
+  it("records what was entered, not the keystrokes", () => {
+    expect(feed(["l", "s", " ", "-", "l", "\r"])).toEqual([
+      { kind: "input", text: "ls -l" },
+    ]);
+  });
+
+  it("accepts a line arriving as one chunk, as when pasted", () => {
+    expect(feed(["npm run build\r"])).toEqual([
+      { kind: "input", text: "npm run build" },
+    ]);
+  });
+
+  it("records several lines from one chunk", () => {
+    expect(feed(["one\rtwo\rthree\r"])).toEqual([
+      { kind: "input", text: "one" },
+      { kind: "input", text: "two" },
+      { kind: "input", text: "three" },
+    ]);
+  });
+
+  it("treats newline like return", () => {
+    expect(feed(["hello\n"])).toEqual([{ kind: "input", text: "hello" }]);
+  });
+
+  it("ignores an empty line", () => {
+    expect(feed(["\r", "\r", "   \r"])).toEqual([]);
+  });
+
+  it("emits nothing until the line is submitted", () => {
+    const log = new InputLog();
+    expect(log.push("git comm")).toEqual([]);
+    expect(log.pending).toBe("git comm");
+    expect(log.push("it\r")).toEqual([{ kind: "input", text: "git commit" }]);
+    expect(log.pending).toBe("");
+  });
+});
+
+describe("corrections", () => {
+  it("applies backspace, so the record is what was meant", () => {
+    expect(feed(["lsss", "\x7f", "\x7f", " -l\r"])).toEqual([
+      { kind: "input", text: "ls -l" },
+    ]);
+  });
+
+  it("accepts the other backspace byte", () => {
+    expect(feed(["abc", "\b", "\r"])).toEqual([{ kind: "input", text: "ab" }]);
+  });
+
+  it("backspaces past the start without going negative", () => {
+    expect(feed(["\x7f\x7f\x7f", "ok\r"])).toEqual([{ kind: "input", text: "ok" }]);
+  });
+
+  it("clears the line on Ctrl-U", () => {
+    expect(feed(["rm -rf /", "\x15", "ls\r"])).toEqual([
+      { kind: "input", text: "ls" },
+    ]);
+  });
+
+  it("deletes a word on Ctrl-W", () => {
+    expect(feed(["git commit wrong", "\x17", "--amend\r"])).toEqual([
+      { kind: "input", text: "git commit --amend" },
+    ]);
+  });
+});
+
+describe("interrupts", () => {
+  it("records Ctrl-C, with whatever was half-typed", () => {
+    expect(feed(["sleep 100", "\x03"])).toEqual([
+      { kind: "interrupt", text: "sleep 100" },
+    ]);
+  });
+
+  it("records a bare Ctrl-C", () => {
+    expect(feed(["\x03"])).toEqual([{ kind: "interrupt", text: "" }]);
+  });
+
+  it("does not carry the abandoned text into the next line", () => {
+    expect(feed(["abandoned", "\x03", "ls\r"])).toEqual([
+      { kind: "interrupt", text: "abandoned" },
+      { kind: "input", text: "ls" },
+    ]);
+  });
+});
+
+describe("things that are not typed text", () => {
+  it("drops arrow keys rather than recording their bytes", () => {
+    /* A full-screen program reads these itself; they are not a submission. */
+    expect(feed(["\x1b[A", "\x1b[B", "\x1b[C", "\x1b[D", "ls\r"])).toEqual([
+      { kind: "input", text: "ls" },
+    ]);
+  });
+
+  it("drops a function key", () => {
+    expect(feed(["\x1bOP", "top\r"])).toEqual([{ kind: "input", text: "top" }]);
+  });
+
+  it("drops other control characters", () => {
+    expect(feed(["a", "\x00", "\x07", "\x1f", "b\r"])).toEqual([
+      { kind: "input", text: "ab" },
+    ]);
+  });
+
+  it("keeps tabs out of the recorded text", () => {
+    expect(feed(["cd sr", "\t", "c\r"])).toEqual([{ kind: "input", text: "cd src" }]);
+  });
+});
+
+describe("bounds", () => {
+  it("truncates a very long line rather than storing it whole", () => {
+    const long = "x".repeat(MAX_ENTRY_LENGTH + 500);
+    const [entry] = feed([long, "\r"]);
+    expect(entry.text.length).toBe(MAX_ENTRY_LENGTH + 1);
+    expect(entry.text.endsWith("…")).toBe(true);
+  });
+
+  it("does not let an unsubmitted buffer grow without bound", () => {
+    const log = new InputLog();
+    for (let i = 0; i < 20; i += 1) log.push("y".repeat(1000));
+    expect(log.pending.length).toBeLessThanOrEqual(MAX_ENTRY_LENGTH * 2);
+  });
+});
+
+describe("agent prompts", () => {
+  it("records a prompt the same way as a command", () => {
+    /* For an agent the submitted line is the prompt; the mechanism is one. */
+    expect(feed(["refactor the parser to use a table\r"])).toEqual([
+      { kind: "input", text: "refactor the parser to use a table" },
+    ]);
+  });
+
+  it("records a prompt containing punctuation and quotes intact", () => {
+    expect(feed([`fix "the bug" in src/main.go, then run tests\r`])).toEqual([
+      { kind: "input", text: `fix "the bug" in src/main.go, then run tests` },
+    ]);
+  });
+});

--- a/app/src/lib/input-log.ts
+++ b/app/src/lib/input-log.ts
@@ -1,0 +1,131 @@
+/**
+ * Turns a stream of keystrokes into the lines a person actually submitted.
+ *
+ * A terminal receives one keystroke at a time, including corrections. What is
+ * worth auditing is not every byte but the line that was finally entered: the
+ * command for a shell, the prompt for an agent. So this assembles bytes into a
+ * line and emits it on Enter, applying the edits along the way.
+ *
+ * It deliberately understands only the editing keys a person uses at a raw
+ * prompt. Anything a full-screen program interprets for itself, arrow keys and
+ * other escape sequences, is dropped rather than guessed at.
+ */
+
+export type EntryKind = "input" | "interrupt";
+
+export interface Entry {
+  kind: EntryKind;
+  text: string;
+}
+
+const ENTER = ["\r", "\n"];
+const BACKSPACE = ["\x7f", "\b"];
+const CTRL_C = "\x03";
+const CTRL_U = "\x15";
+const CTRL_W = "\x17";
+const ESCAPE = "\x1b";
+
+/** Longer than this is not a command, and not worth storing whole. */
+export const MAX_ENTRY_LENGTH = 4000;
+
+/*
+ * Escape sequences come in two shapes worth distinguishing. CSI is
+ * "ESC [ ... final", used by arrow keys. SS3 is "ESC O x", exactly one byte
+ * after the intro, used by function keys. Treating them alike let the byte
+ * after "ESC O" through as if it had been typed.
+ */
+type EscapeState = "none" | "intro" | "csi" | "ss3";
+
+export class InputLog {
+  private buffer = "";
+  private escape: EscapeState = "none";
+
+  /**
+   * Feeds terminal input and returns whatever was completed by it.
+   *
+   * One chunk can complete several lines, as when text is pasted.
+   */
+  push(data: string): Entry[] {
+    const entries: Entry[] = [];
+
+    for (const character of data) {
+      if (this.escape === "intro") {
+        if (character === "[") this.escape = "csi";
+        else if (character === "O") this.escape = "ss3";
+        else this.escape = "none";
+        continue;
+      }
+      if (this.escape === "ss3") {
+        /* Exactly one byte names the key, and it is not typed text. */
+        this.escape = "none";
+        continue;
+      }
+      if (this.escape === "csi") {
+        /* A CSI sequence ends at its final byte, in the range @ to ~. */
+        const code = character.codePointAt(0) ?? 0;
+        if (code >= 0x40 && code <= 0x7e) this.escape = "none";
+        continue;
+      }
+
+      if (character === ESCAPE) {
+        this.escape = "intro";
+        continue;
+      }
+
+      if (ENTER.includes(character)) {
+        const text = this.buffer.trim();
+        this.buffer = "";
+        if (text) entries.push({ kind: "input", text: clamp(text) });
+        continue;
+      }
+
+      if (character === CTRL_C) {
+        const pending = this.buffer.trim();
+        this.buffer = "";
+        entries.push({ kind: "interrupt", text: pending ? clamp(pending) : "" });
+        continue;
+      }
+
+      if (character === CTRL_U) {
+        this.buffer = "";
+        continue;
+      }
+
+      if (character === CTRL_W) {
+        /*
+         * Delete back over trailing space, then over one word, which is what
+         * a shell does. The space before the deleted word stays, so the next
+         * thing typed does not run into the previous word.
+         */
+        this.buffer = this.buffer.replace(/\s+$/, "").replace(/\S+$/, "");
+        continue;
+      }
+
+      if (BACKSPACE.includes(character)) {
+        this.buffer = this.buffer.slice(0, -1);
+        continue;
+      }
+
+      /* Remaining control characters are not text a person typed. */
+      const code = character.codePointAt(0) ?? 0;
+      if (code < 0x20) continue;
+
+      this.buffer += character;
+      /* Stop the buffer growing without bound on a runaway paste. */
+      if (this.buffer.length > MAX_ENTRY_LENGTH * 2) {
+        this.buffer = this.buffer.slice(-MAX_ENTRY_LENGTH);
+      }
+    }
+
+    return entries;
+  }
+
+  /** What has been typed but not yet submitted. */
+  get pending(): string {
+    return this.buffer;
+  }
+}
+
+function clamp(text: string): string {
+  return text.length > MAX_ENTRY_LENGTH ? `${text.slice(0, MAX_ENTRY_LENGTH)}…` : text;
+}

--- a/app/src/routes/Audit.tsx
+++ b/app/src/routes/Audit.tsx
@@ -28,6 +28,7 @@ import {
   memberOf,
   sessionLabel,
   summarise,
+  topCommands,
   type Filters,
 } from "../lib/audit-view";
 import { displayName } from "../lib/people";
@@ -39,15 +40,10 @@ const RANGES = [
   { label: "Last 7 days", value: 7 * 24 * 60 * 60 * 1000 },
 ];
 
-/*
- * Only the kinds the service records. Typed input is deliberately not one of
- * them -- the service refuses to store plaintext terminal input and
- * app.test.ts holds it to that -- so a filter for it would promise a view of
- * something nobody keeps.
- */
 const KINDS = [
   { label: "Everything", value: "" },
-  { label: "Sessions opened", value: "opened" },
+  { label: "Commands and prompts", value: "input" },
+  { label: "Interrupts", value: "interrupt" },
   { label: "Handoffs", value: "handoff" },
 ];
 
@@ -301,8 +297,8 @@ export function Audit() {
         <>
           <div className="stat-row">
             <Stat label="Entries" value={summary.total} />
-            <Stat label="Sessions opened" value={summary.opened} />
-            <Stat label="Handoffs" value={summary.handoffs} />
+            <Stat label="Commands and prompts" value={summary.inputs} />
+            <Stat label="Interrupts" value={summary.interrupts} />
             <Stat label="People" value={summary.people} />
             <Stat label="Sessions" value={summary.sessions} />
           </div>
@@ -323,6 +319,12 @@ export function Audit() {
                     </span>
                   );
                 }}
+              />
+              <RankChart
+                caption="Most used"
+                rows={topCommands(shown)}
+                onPick={(word) => set({ query: word })}
+                render={(word) => <code>{word}</code>}
               />
             </div>
           )}

--- a/app/src/routes/Terms.tsx
+++ b/app/src/routes/Terms.tsx
@@ -373,21 +373,31 @@ export function Terms() {
         <Section id="activity-records">
           <div className="terms-callout">
             <p>
-              <b>Terminal input is not copied into the accounts service.</b>{" "}
-              Prompts, commands, passwords, and other keystrokes stay inside
-              the end-to-end encrypted terminal stream.
+              <b>What you type into a session is recorded in plaintext.</b>{" "}
+              Commands, prompts, and anything else entered at the keyboard are
+              sent to the accounts service as you commit them, stored without
+              encryption, and can be read and exported by every member of your
+              organization. That includes anything typed by mistake, such as a
+              password or a key pasted into the wrong window.
             </p>
           </div>
           <p>
-            We retain the collaboration information people deliberately create
-            outside the terminal: session ownership and assignment, handoffs,
-            comments, mentions, and notifications. Members of the organization
-            can see those records.
+            The recording is of what is entered, not of what the session prints
+            back. Terminal output stays inside the end-to-end encrypted stream
+            and never reaches us.
           </p>
           <p>
-            Prerelease builds briefly offered plaintext input logging. The
-            hosted service no longer accepts those events and its housekeeping
-            sweep deletes any legacy input rows.
+            We also retain the collaboration information people deliberately
+            create outside the terminal: session ownership and assignment,
+            handoffs, comments, mentions, and notifications. Members of the
+            organization can see those records.
+          </p>
+          <p>
+            If this is not what you want for a particular session, do not type
+            into it from the browser. A session shared read-only with{" "}
+            <code>--read-only</code> accepts no browser input at all, and
+            anything typed in the terminal the session was started from is
+            never seen by the browser or by us.
           </p>
         </Section>
 
@@ -398,9 +408,10 @@ export function Terms() {
               <dt>Terminal output</dt>
               <dd>
                 Terminal traffic is end-to-end encrypted in the browser and on
-                the machine. The relay and the accounts service handle
-                ciphertext only. Neither what you type nor what your program
-                prints is readable by the accounts service.
+                the machine, and the relay handles ciphertext only, so what
+                your program prints is not readable by us. What you type is a
+                separate matter: it is recorded, in plaintext, as described
+                above.
               </dd>
             </div>
             <div>

--- a/app/src/terminal/TerminalPane.tsx
+++ b/app/src/terminal/TerminalPane.tsx
@@ -9,6 +9,8 @@ import { fittedTerminalFontSize } from "./terminal-fit";
 import { encryptionFragment, resolveSessionSocket, sessionIdFromShareUrl } from "./socket-url";
 import { forget, passwordFor } from "../lib/session-passwords";
 import { openSealed } from "../lib/keypair";
+import { AuditSink } from "./audit-sink";
+import { postAudit } from "../lib/api";
 import { Button } from "../components/Button";
 import { Alert } from "../components/Alert";
 
@@ -184,9 +186,18 @@ export function TerminalPane({
     });
     connection.current = connected;
 
+    /*
+     * Input is recorded per session so an organization can see what was run
+     * or asked. It watches the same stream the terminal receives, so it sees
+     * exactly what was entered and nothing else.
+     */
+    const audited = sessionIdFromShareUrl(shareUrl);
+    const sink = audited ? new AuditSink(audited, postAudit) : null;
+
     const typed = term.onData((data) => {
       if (!canType) return;
       connected.send(data);
+      sink?.observe(data);
     });
     term.options.disableStdin = !canType;
 
@@ -215,6 +226,7 @@ export function TerminalPane({
       cancelAnimationFrame(frame);
       observer.disconnect();
       typed.dispose();
+      sink?.close();
       connected.close();
       term.dispose();
       terminal.current = null;

--- a/app/src/terminal/audit-sink.test.ts
+++ b/app/src/terminal/audit-sink.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import { AuditSink } from "./audit-sink";
+
+type Sent = { session_id: string; kind: string; text: string; at: number }[];
+
+function sink(flushMs = 5) {
+  const batches: Sent[] = [];
+  const send = vi.fn(async (entries: Sent) => {
+    batches.push(entries);
+    return { written: entries.length };
+  });
+  return { sink: new AuditSink("sess_1", send, flushMs), batches, send };
+}
+
+const settle = (ms = 30) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("AuditSink", () => {
+  it("records a completed line, not the keystrokes", async () => {
+    const { sink: audit, batches } = sink();
+    for (const character of "npm test\r") audit.observe(character);
+    await settle();
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toHaveLength(1);
+    expect(batches[0][0]).toMatchObject({
+      session_id: "sess_1",
+      kind: "input",
+      text: "npm test",
+    });
+  });
+
+  it("sends nothing while a line is still being typed", async () => {
+    const { sink: audit, send } = sink();
+    audit.observe("git comm");
+    await settle();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("batches several lines into one request", async () => {
+    const { sink: audit, batches } = sink(20);
+    audit.observe("one\r");
+    audit.observe("two\r");
+    audit.observe("three\r");
+    await settle(60);
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0].map((entry) => entry.text)).toEqual(["one", "two", "three"]);
+  });
+
+  it("records an interrupt", async () => {
+    const { sink: audit, batches } = sink();
+    audit.observe("sleep 100\x03");
+    await settle();
+    expect(batches[0][0]).toMatchObject({ kind: "interrupt", text: "sleep 100" });
+  });
+
+  it("flushes what is pending when the pane closes", async () => {
+    const { sink: audit, batches } = sink(10_000);
+    audit.observe("ls\r");
+    audit.close();
+    await settle();
+    expect(batches[0][0].text).toBe("ls");
+  });
+
+  it("keeps the terminal working when the log write fails", async () => {
+    /* An audit gap is better than a terminal that stalls on a failing write. */
+    const failing = vi.fn(async () => {
+      throw new Error("service down");
+    });
+    const audit = new AuditSink("sess_1", failing as never, 5);
+    audit.observe("ls\r");
+    await settle();
+    expect(failing).toHaveBeenCalled();
+
+    /* And it carries on afterwards. */
+    audit.observe("pwd\r");
+    await settle();
+    expect(failing).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not send an empty batch", async () => {
+    const { sink: audit, send } = sink();
+    await audit.flush();
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/terminal/audit-sink.ts
+++ b/app/src/terminal/audit-sink.ts
@@ -1,0 +1,70 @@
+import { InputLog, type Entry } from "../lib/input-log";
+
+export interface AuditEntry {
+  session_id: string;
+  kind: string;
+  text: string;
+  at: number;
+}
+
+/**
+ * Injected rather than imported, so this module stays free of the API client
+ * and its Firebase dependency, and can be tested without a browser.
+ */
+export type AuditSender = (entries: AuditEntry[]) => Promise<unknown>;
+
+/**
+ * Collects what a person entered in a session and sends it to the audit log.
+ *
+ * Batched, because a shell prompt produces an entry per line and a chatty
+ * session would otherwise be one request per command. Failures are dropped
+ * rather than retried forever: an audit gap is better than a terminal that
+ * stalls because a log write is failing.
+ */
+export class AuditSink {
+  private readonly log = new InputLog();
+  private pending: Entry[] = [];
+  private timer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    private readonly sessionId: string,
+    private readonly send: AuditSender,
+    private readonly flushMs = 1200,
+  ) {}
+
+  /** Feeds terminal input; entries are queued as lines are completed. */
+  observe(data: string): void {
+    const entries = this.log.push(data);
+    if (entries.length === 0) return;
+    this.pending.push(...entries);
+    if (this.timer === null) {
+      this.timer = setTimeout(() => void this.flush(), this.flushMs);
+    }
+  }
+
+  async flush(): Promise<void> {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    if (this.pending.length === 0) return;
+    const batch = this.pending;
+    this.pending = [];
+    try {
+      await this.send(
+        batch.map((entry) => ({
+          session_id: this.sessionId,
+          kind: entry.kind,
+          text: entry.text,
+          at: Date.now(),
+        })),
+      );
+    } catch {
+      /* An audit gap beats a terminal that stalls on a failing log write. */
+    }
+  }
+
+  close(): void {
+    void this.flush();
+  }
+}


### PR DESCRIPTION
The half of the audit restoration that missed the boat. #68 was merged while
this was still being written, so `main` has the viewer and nothing to put in
it — which is the state originally reported as "the audit log still does not
show keystrokes, only assigned stuff".

The operator was asked and chose to record typed input. This implements that
decision.

## Three things that each make it silently not work

**The service refuses the events.** `POST /api/audit` is absent and
`app.test.ts` asserts a 404 with `does not accept plaintext terminal input`.
The route comes back and that test asserts the opposite, so whichever way this
goes is written down somewhere a future change has to argue with.

**The five-minute sweep deletes every input row.**

```sql
DELETE FROM audit_events WHERE kind IN ('input', 'interrupt')
```

Recording alone would have been pointless: an entry would survive until the
next cron tick and no longer. Removed from both stores and pinned in the
conformance suite, which runs against Postgres and the memory store.

**The terms say the opposite.** In a callout, and again under *What Never
Reaches Us*, they promise terminal input is never copied out of the encrypted
stream. That becomes false the moment this merges. They now say plainly that
what you type is recorded in plaintext, readable and exportable by everyone in
the organization, **including anything typed by mistake such as a password
pasted into the wrong window**; that the recording covers input and not output;
and what to do about a session you would rather not have recorded.

## Also restored

`input-log.ts`, `audit-sink.ts` and their tests, the `postAudit` client helper,
the `TerminalPane` wiring, and the input-aware filters and summary in
`Audit.tsx` that were trimmed while input did not exist.

Output is untouched and stays end-to-end encrypted. This is about input only.

## Verified on production

Deployed and exercised before this PR existed: `POST /api/audit` returned
`{"written":3}`, the events read back with the right actor and text, CSV export
worked, and they survived eight minutes — past a cron tick — rather than being
swept.

Typecheck clean, 564 tests pass.