### PR TITLE
Release 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,19 @@ All notable user-visible changes are recorded here. Versions follow [Semantic Ve
 
 ## Unreleased
 
+## [0.11.0] — 2026-09-08
+
 ### Added
 
+- Ask on every interactive `shell login` whether the browser may start sessions here, with the previous answer as the default. `--allow-remote-start` remains a shortcut rather than the only way to reach the decision.
+- Show the audit log again: the page, its route and the sidebar entry.
 - Publish Go module discovery metadata so `go install shell.online/cmd/shell@latest` resolves from the canonical domain.
 
 ### Fixed
 
+- Rescue a machine whose daemon can no longer renew its token. Signing in again replaces the running daemon instead of leaving it holding credentials it will never reload, a refused renewal re-reads the credentials file, and repeated refusals back off rather than repeating every two seconds.
+- Read who may type from the session rather than from the tab it was opened in, so a colleague handed a session while watching it can type without reopening.
+- Stop one test closing another test's file descriptor, which failed unrelated tests at random.
 - Keep the background startup pipe private to shell.online so wrapped commands can safely use file descriptor 3.
 - Make foreground relay connection attempts interruptible and print share details only after the relay is connected.
 - Honor long `--auto-close` deadlines instead of silently reducing them to the relay's rolling 12-hour lease.
@@ -17,7 +24,6 @@ All notable user-visible changes are recorded here. Versions follow [Semantic Ve
 - Preserve authenticated E2EE recovery snapshot opcodes during relay backpressure so large output cannot eject viewers to the password screen.
 - Show compact, unclipped encryption badges in narrow mobile headers.
 - Explain when all 16 viewer slots are occupied and keep retrying until a slot opens.
-
 ## [0.10.1] — 2026-09-08
 
 ### Fixed

--- a/Formula/shell-online.rb
+++ b/Formula/shell-online.rb
@@ -1,8 +1,8 @@
 class ShellOnline < Formula
   desc "Turn any terminal process into an interactive or read-only browser link"
   homepage "https://shell.online"
-  url "https://github.com/TeoSlayer/shell.online/archive/refs/tags/v0.8.1.tar.gz"
-  sha256 "4d7cfd000861b5b60c2448d218dad2966a3ce0e3829228d8bfd5eda0b3e53c67"
+  url "https://github.com/TeoSlayer/shell.online/archive/refs/tags/v0.11.0.tar.gz"
+  sha256 "REPLACE_WITH_TAG_TARBALL_SHA256"
   license "MIT"
 
   depends_on "go" => :build

--- a/docs/content.json
+++ b/docs/content.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.10.1",
+  "version": "0.11.0",
   "pages": {
     "docs": {
       "eyebrow": "Documentation",
@@ -513,7 +513,7 @@
       "cards": [
         [
           "Start once",
-          "Pull ghcr.io/teoslayer/shell.online:0.10.1 or run docker compose up --build -d, then docker compose logs shell-online. First launch prints the stable URL and a generated eight-character password. The tagged amd64/arm64 image includes an SBOM and build provenance."
+          "Pull ghcr.io/teoslayer/shell.online:0.11.0 or run docker compose up --build -d, then docker compose logs shell-online. First launch prints the stable URL and a generated eight-character password. The tagged amd64/arm64 image includes an SBOM and build provenance."
         ],
         [
           "Two durable volumes",

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
           },
           "applicationCategory": "DeveloperApplication",
           "operatingSystem": "macOS, Windows, Linux, FreeBSD, OpenBSD, NetBSD, DragonFly BSD, Solaris",
-          "softwareVersion": "0.10.1",
+          "softwareVersion": "0.11.0",
           "softwareRequirements": "A supported architecture, outbound HTTPS and WebSockets, and a PTY or Windows ConPTY",
           "isAccessibleForFree": true,
           "downloadUrl": "https://shell.online/install",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shell-online",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shell-online",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shell-online",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Turn any terminal process into a collaborative browser link.",
   "private": true,
   "license": "MIT",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -24,9 +24,9 @@ The Homebrew formula builds locally: Brew fetches the checksum-pinned tagged sou
 
 The standalone installer uses a checksum-pinned release binary. To compile and run the tagged source outside either installation path:
 
-git clone --depth 1 --branch v0.10.1 https://github.com/TeoSlayer/shell.online.git
+git clone --depth 1 --branch v0.11.0 https://github.com/TeoSlayer/shell.online.git
 cd shell.online
-go build -trimpath -ldflags="-X main.version=0.10.1" -o ./shell ./cmd/shell
+go build -trimpath -ldflags="-X main.version=0.11.0" -o ./shell ./cmd/shell
 ./shell --version
 
 The source-build path requires Go 1.26.8 or newer, except Go 1.27.x is intentionally unsupported on MIPS64 because of go.dev/issue/80978. Keep using ./shell or move it to a directory on PATH.


### PR DESCRIPTION
#66, #68, #69, #70 and #71 are all merged and none of them is in a released
version. Two are the ones people are waiting on:

- a machine whose daemon cannot renew its token recovers when you sign in again
- `shell login` asks about browser-started sessions every time, instead of
  hiding the decision behind `--allow-remote-start`

The second is why this is **0.11.0** and not a patch: an interactive command
answers differently now, and someone who never saw the question will start
seeing it.

## Something I need to flag

The binaries currently served at `shell.online/downloads` are stamped **0.10.1
but were built from `main` after that tag**, so they carry the daemon fix while
the tagged `v0.10.1` does not. Two different sets of bytes under one version
number.

That is my doing. I rebuilt and republished the relay to get the daemon fix out
without bumping the version first, which is exactly the mess this bump exists
to stop. Once this is tagged and published, the artifacts and the tag they name
will agree again.

## After merging

```sh
git tag v0.11.0 && git push origin v0.11.0
curl -fsSL https://github.com/TeoSlayer/shell.online/archive/refs/tags/v0.11.0.tar.gz | shasum -a 256
```

Put that digest in `Formula/shell-online.rb`. `npm test` refuses a placeholder
on a tag build, so forgetting it fails CI rather than `brew install`.

Then the relay redeploy publishes the binaries — that is what actually gets
#66 and #69 onto people's machines.

## Verified

`check-formula` and the landing SEO version check both pass against 0.11.0, so
`package.json`, the formula URL, the structured data and the docs all agree.