### PR TITLE
Set the Homebrew checksum for v0.11.0

### DIFF
--- a/Formula/shell-online.rb
+++ b/Formula/shell-online.rb
@@ -2,7 +2,7 @@ class ShellOnline < Formula
   desc "Turn any terminal process into an interactive or read-only browser link"
   homepage "https://shell.online"
   url "https://github.com/TeoSlayer/shell.online/archive/refs/tags/v0.11.0.tar.gz"
-  sha256 "REPLACE_WITH_TAG_TARBALL_SHA256"
+  sha256 "753c4815215f024e547a38b77913065282de9b03246715fd178e97a9c67a1c71"
   license "MIT"
 
   depends_on "go" => :build


### PR DESCRIPTION
The digest of the `v0.11.0` tag tarball, which could not be known until the tag
existed:

```
753c4815215f024e547a38b77913065282de9b03246715fd178e97a9c67a1c71
```

`brew install` verifies it, so the placeholder that necessarily sits in the
formula between releases fails for every user while looking like a network
problem.

`check-formula` refuses a placeholder on a tag build and refuses a formula whose
version has drifted from `package.json`. Both pass.