### PR TITLE
Fail a build whose configuration is absent, not only empty

### DIFF
--- a/app/scripts/check-bundle.mjs
+++ b/app/scripts/check-bundle.mjs
@@ -72,18 +72,28 @@ const blank = [];
 for await (const path of files(directory)) {
   if (!path.endsWith(".js")) continue;
   const body = await readFile(path, "utf8");
+  if (!body.includes("VITE_")) continue;
   for (const key of REQUIRED) {
-    /* Vite inlines these as `KEY:`value`` in the env object it compiles in. */
-    const match = body.match(new RegExp(`${key}\\s*:\\s*\`([^\`]*)\``, "u"));
-    if (match && match[1].trim() === "") blank.push({ path, key });
+    /*
+     * Vite inlines these into the env object it compiles in, quoted however
+     * the minifier prefers. Absent is a failure as much as empty, and it used
+     * to be the one that got through: a build with no value at all omits the
+     * key, the pattern never matches, and the check passed while the bundle
+     * threw on load and rendered nothing.
+     */
+    const match = body.match(new RegExp(`${key}\\s*:\\s*(["'\`])((?:(?!\\1).)*)\\1`, "u"));
+    if (!match) blank.push({ path, key, why: "absent" });
+    else if (match[2].trim() === "") blank.push({ path, key, why: "empty" });
   }
 }
 
 if (blank.length > 0) {
-  console.error("check-bundle: required values are empty in the production build");
-  for (const { path, key } of blank) console.error(`  ${path}: ${key} is blank`);
-  console.error("  An unset variable overrides .env.production with an empty string.");
-  console.error("  Check the build step's env block against app/.env.production.");
+  console.error("check-bundle: required values are missing from the production build");
+  for (const { path, key, why } of blank) console.error(`  ${path}: ${key} is ${why}`);
+  console.error("  Absent means the build had no value at all: no .env.local on this");
+  console.error("  machine, or no env block in the workflow step. Empty means something");
+  console.error("  passed an empty string and overrode app/.env.production.");
+  console.error("  Either way the page throws on load and renders nothing."); 
   process.exit(1);
 }
 


### PR DESCRIPTION
`check-bundle` refused a bundle carrying a required value as an empty string,
and passed one carrying no value at all. Those are the same failure to anyone
loading the page, and absent is the one that actually happened.

## What it let through

A build from a clean checkout has no `.env.local`, and the Firebase
configuration is not in the repository. Vite emitted **no key** rather than an
empty one, so the pattern the check looks for never appeared and it reported
success. The deployed bundle then threw while still evaluating:

```
Firebase is not configured. Missing VITE_FIREBASE_API_KEY, VITE_FIREBASE_AUTH_DOMAIN,
VITE_FIREBASE_PROJECT_ID, VITE_FIREBASE_APP_ID.
```

React never mounted. The page answered **200 with an empty body**, no failed
requests, and **nothing in the console** — a module that throws during
evaluation does not always surface there. It took re-importing the module in
the page and catching the rejection to see the error at all.

## The change

Absent fails alongside empty, and the message says which it is, because the
remedies differ:

- **absent** — no `.env.local` on this machine, or no `env:` block in the
  workflow step
- **empty** — something passed an empty string and overrode
  `app/.env.production`

The quoting is also no longer assumed to be backticks; the minifier picks, so
the pattern accepts any of the three.

## Verified

- Against the exact bundle that broke production (`index-B2dhPHDJ.js`): now
  refused, exit 1, all four keys named
- Against a correct bundle: still passes
- 564 app tests green