### PR TITLE
Release 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-visible changes are recorded here. Versions follow [Semantic Ve
 
 ## Unreleased
 
+## [0.11.1] — 2026-09-08
+
 ### Added
 
 - Read the session list as a board as well as a table. A toggle above the list switches between them and the choice is remembered; the board's three columns carry the action each one affords, and a search box matches a session's name or its command.

--- a/Formula/shell-online.rb
+++ b/Formula/shell-online.rb
@@ -1,8 +1,8 @@
 class ShellOnline < Formula
   desc "Turn any terminal process into an interactive or read-only browser link"
   homepage "https://shell.online"
-  url "https://github.com/TeoSlayer/shell.online/archive/refs/tags/v0.11.0.tar.gz"
-  sha256 "753c4815215f024e547a38b77913065282de9b03246715fd178e97a9c67a1c71"
+  url "https://github.com/TeoSlayer/shell.online/archive/refs/tags/v0.11.1.tar.gz"
+  sha256 "REPLACE_WITH_TAG_TARBALL_SHA256"
   license "MIT"
 
   depends_on "go" => :build

--- a/docs/content.json
+++ b/docs/content.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.11.0",
+  "version": "0.11.1",
   "pages": {
     "docs": {
       "eyebrow": "Documentation",
@@ -513,7 +513,7 @@
       "cards": [
         [
           "Start once",
-          "Pull ghcr.io/teoslayer/shell.online:0.11.0 or run docker compose up --build -d, then docker compose logs shell-online. First launch prints the stable URL and a generated eight-character password. The tagged amd64/arm64 image includes an SBOM and build provenance."
+          "Pull ghcr.io/teoslayer/shell.online:0.11.1 or run docker compose up --build -d, then docker compose logs shell-online. First launch prints the stable URL and a generated eight-character password. The tagged amd64/arm64 image includes an SBOM and build provenance."
         ],
         [
           "Two durable volumes",

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
           },
           "applicationCategory": "DeveloperApplication",
           "operatingSystem": "macOS, Windows, Linux, FreeBSD, OpenBSD, NetBSD, DragonFly BSD, Solaris",
-          "softwareVersion": "0.11.0",
+          "softwareVersion": "0.11.1",
           "softwareRequirements": "A supported architecture, outbound HTTPS and WebSockets, and a PTY or Windows ConPTY",
           "isAccessibleForFree": true,
           "downloadUrl": "https://shell.online/install",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shell-online",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shell-online",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shell-online",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Turn any terminal process into a collaborative browser link.",
   "private": true,
   "license": "MIT",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -24,9 +24,9 @@ The Homebrew formula builds locally: Brew fetches the checksum-pinned tagged sou
 
 The standalone installer uses a checksum-pinned release binary. To compile and run the tagged source outside either installation path:
 
-git clone --depth 1 --branch v0.11.0 https://github.com/TeoSlayer/shell.online.git
+git clone --depth 1 --branch v0.11.1 https://github.com/TeoSlayer/shell.online.git
 cd shell.online
-go build -trimpath -ldflags="-X main.version=0.11.0" -o ./shell ./cmd/shell
+go build -trimpath -ldflags="-X main.version=0.11.1" -o ./shell ./cmd/shell
 ./shell --version
 
 The source-build path requires Go 1.26.8 or newer, except Go 1.27.x is intentionally unsupported on MIPS64 because of go.dev/issue/80978. Keep using ./shell or move it to a directory on PATH.


### PR DESCRIPTION
A patch, not a minor: nothing about how an existing command behaves changes.
What it carries is one fix that needs a published binary to reach anyone.

A session started from the browser was handed to `sh -c`, so the machine
recorded the shell and not the program. Every browser-started session arrived
in the list wearing a terminal icon, whatever was running in it. The web side
of that shipped already and reads existing rows correctly; the recording
happens in the CLI, so it is only fixed for new sessions once this is out.

The Homebrew checksum stays a placeholder until the tag exists; npm test
refuses a placeholder on a tag build.