### PR TITLE
Build Codex and Hermes commands from their own interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ All notable user-visible changes are recorded here. Versions follow [Semantic Ve
 ### Added
 
 - Keep the open session tabs across a reload. Refreshing the page put you back at the list with every terminal closed; the tabs that were open come back, on the one that was in front. Only the session ids are remembered, so a restored tab is rebuilt from the session list rather than from a stale copy, and a session that has since ended does not return.
+- Offer GPT Codex's sandbox, approval, resume and web-search options in the new-session form, and Hermes Agent's command, session, model, worktree and approval options, each read from the installed tool rather than from its documentation.
 
 ### Fixed
 
 - Draw a shared terminal at the size of the pane holding it. The font was scaled until the whole grid fitted in one direction, which on a wide pane left about a third of it empty and the text a third smaller than there was room for. The font now comes from the width, where the columns are, and the rows are spread down the full height with the leading that is left over; neither axis may overflow. On a 1440x900 window a 120x36 session goes from 11.5px filling 77% of the pane to 14.75px filling 98%.
 - Remove the box drawn around each column of the session board. It repeated the border and the wash that every card inside it already carries, so three short columns read as three mostly empty containers.
+- Stop building `codex --full-auto`, which current Codex releases reject as an unexpected argument. Starting a full-auto Codex session from the browser failed on the machine it was sent to.
+- Drop the warning that a kind's flags came from a published interface. Every kind now offers only options its own `--help` accepts, so there is nothing left for it to warn about.
 
 ## [0.11.1] — 2026-09-08
 

--- a/app/src/components/NewSessionModal.tsx
+++ b/app/src/components/NewSessionModal.tsx
@@ -161,17 +161,6 @@ export function NewSessionModal({ devices, onClose, onStart }: NewSessionModalPr
               </div>
             ))}
 
-            {kind.flagsFromPublishedInterface && (
-              <p className="sheet-note">
-                <Warning size={14} weight="fill" />
-                <span>
-                  These flags come from the published interface for {kind.title}{" "}
-                  rather than from its own help output, so check the command
-                  below before starting.
-                </span>
-              </p>
-            )}
-
             {devices.length > 1 && (
               <div className="sheet-field">
                 <label htmlFor="f-machine">Machine</label>

--- a/app/src/lib/session-kinds.test.ts
+++ b/app/src/lib/session-kinds.test.ts
@@ -22,16 +22,18 @@ describe("the catalogue", () => {
     }
   });
 
-  it("marks which flag sets came from a published interface rather than --help", () => {
+  it("offers only options each tool's own --help accepts", () => {
     /*
-     * A property of how each builder was written, not of any machine. What a
-     * given machine can actually run is reported by its agent; see
-     * harnessMissing.
+     * Every flag below was read from the installed tool rather than from its
+     * documentation, and rejected flags were removed: codex 0.153.4 answers
+     * `--full-auto` with "unexpected argument", so the launcher no longer
+     * builds it. What a given machine can run is a separate question, reported
+     * by its agent; see harnessMissing.
      */
-    expect(claude.flagsFromPublishedInterface).toBeFalsy();
-    expect(openclaw.flagsFromPublishedInterface).toBeFalsy();
-    expect(codex.flagsFromPublishedInterface).toBe(true);
-    expect(hermes.flagsFromPublishedInterface).toBe(true);
+    const built = SESSION_KINDS.flatMap((kind) =>
+      kind.fields.map((field) => kind.build({ [field.name]: field.kind === "toggle" ? true : "v" })),
+    );
+    expect(built.join(" ")).not.toContain("--full-auto");
   });
 });
 
@@ -72,13 +74,38 @@ describe("Claude Code", () => {
 });
 
 describe("GPT Codex", () => {
-  it("starts fresh, resumes, and goes full auto", () => {
+  it("starts fresh with no options", () => {
     expect(codex.build({})).toBe("codex");
+  });
+
+  it("resumes by id, and by --last only when no id was given", () => {
     expect(codex.build({ sessionId: "s1" })).toBe("codex resume s1");
-    expect(codex.build({ fullAuto: true })).toBe("codex --full-auto");
-    expect(codex.build({ sessionId: "s1", fullAuto: true })).toBe(
-      "codex resume s1 --full-auto",
+    expect(codex.build({ resumeLast: true })).toBe("codex resume --last");
+    /* An id is the more specific request, so it wins over "the last one". */
+    expect(codex.build({ sessionId: "s1", resumeLast: true })).toBe("codex resume s1");
+  });
+
+  it("passes the sandbox and approval choices through", () => {
+    expect(codex.build({ sandbox: "workspace-write" })).toBe(
+      "codex --sandbox workspace-write",
     );
+    expect(codex.build({ approval: "never" })).toBe("codex --ask-for-approval never");
+    expect(codex.build({ search: true })).toBe("codex --search");
+  });
+
+  it("leaves both choices out when neither was made", () => {
+    /* An empty select means "whatever codex defaults to", not a flag. */
+    expect(codex.build({ sandbox: "", approval: "" })).toBe("codex");
+  });
+
+  it("puts options after the resume subcommand, where the CLI takes them", () => {
+    expect(
+      codex.build({ sessionId: "s1", sandbox: "read-only", approval: "never", search: true }),
+    ).toBe("codex resume s1 --sandbox read-only --ask-for-approval never --search");
+  });
+
+  it("quotes a session id that would otherwise split", () => {
+    expect(codex.build({ sessionId: "two words" })).toBe("codex resume 'two words'");
   });
 });
 
@@ -99,9 +126,42 @@ describe("OpenClaw", () => {
 });
 
 describe("Hermes", () => {
-  it("passes arguments through unchanged", () => {
+  it("defaults to the bare command", () => {
     expect(hermes.build({})).toBe("hermes");
-    expect(hermes.build({ args: "run --task build" })).toBe("hermes run --task build");
+  });
+
+  it("puts every option before the subcommand, as the parser requires", () => {
+    /* `hermes sessions --yolo` is an error; only this order parses. */
+    expect(hermes.build({ subcommand: "sessions", yolo: true })).toBe(
+      "hermes --yolo sessions",
+    );
+    expect(hermes.build({ subcommand: "gateway", model: "gpt-5", worktree: true })).toBe(
+      "hermes --model gpt-5 --worktree gateway",
+    );
+  });
+
+  it("resumes a named session", () => {
+    expect(hermes.build({ sessionId: "s1" })).toBe("hermes --resume s1");
+    expect(hermes.build({ sessionId: "two words" })).toBe("hermes --resume 'two words'");
+  });
+
+  it("continues the last session only when nothing could be eaten by it", () => {
+    /*
+     * --continue takes an optional value, so a bare one swallows whatever
+     * follows: `hermes --continue sessions` resumes a session called
+     * "sessions" instead of running the subcommand. It is emitted last, and
+     * only when there is no subcommand and no explicit session to resume.
+     */
+    expect(hermes.build({ continueLast: true })).toBe("hermes --continue");
+    expect(hermes.build({ continueLast: true, subcommand: "sessions" })).toBe(
+      "hermes sessions",
+    );
+    expect(hermes.build({ continueLast: true, sessionId: "s1" })).toBe("hermes --resume s1");
+    expect(hermes.build({ continueLast: true, yolo: true })).toBe("hermes --yolo --continue");
+  });
+
+  it("does not let the session name reach the command line", () => {
+    expect(hermes.build({ name: "my run" })).toBe("hermes");
   });
 });
 

--- a/app/src/lib/session-kinds.ts
+++ b/app/src/lib/session-kinds.ts
@@ -28,15 +28,6 @@ export interface SessionKind {
   /** Shown under the form so the command is never a surprise. */
   build(values: FieldValues): string;
   fields: Field[];
-  /**
-   * True when this flag set was taken from the tool's published interface
-   * rather than read from its own --help.
-   *
-   * A fact about how the builder above was written, fixed when it was written.
-   * It says nothing about any machine: whether a machine can run the tool is
-   * reported by the agent on it, and read through harnessMissing.
-   */
-  flagsFromPublishedInterface?: boolean;
 }
 
 function text(values: FieldValues, name: string): string {
@@ -96,28 +87,66 @@ export const SESSION_KINDS: SessionKind[] = [
     title: "GPT Codex",
     blurb: "OpenAI's coding agent.",
     icon: "/icons/codex.webp",
-    flagsFromPublishedInterface: true,
     fields: [
       {
         name: "sessionId",
         label: "Resume session ID",
         kind: "text",
         placeholder: "leave empty to start fresh",
-        help: "Runs codex resume <id>.",
+        help: "Runs codex resume <id>. Accepts a session UUID or a session name.",
       },
       {
-        name: "fullAuto",
-        label: "Full auto",
+        name: "resumeLast",
+        label: "Resume the most recent session",
         kind: "toggle",
-        help: "Adds --full-auto, so it works without stopping to ask.",
+        help: "Runs codex resume --last. Ignored when a session ID is given.",
+      },
+      {
+        name: "sandbox",
+        label: "Sandbox",
+        kind: "select",
+        help: "Passed to --sandbox, bounding what generated commands may touch.",
+        options: [
+          { value: "", label: "codex default" },
+          { value: "read-only", label: "read-only" },
+          { value: "workspace-write", label: "workspace-write" },
+          { value: "danger-full-access", label: "danger-full-access" },
+        ],
+      },
+      {
+        name: "approval",
+        label: "Approvals",
+        kind: "select",
+        help: "Passed to --ask-for-approval. never runs without stopping to ask.",
+        options: [
+          { value: "", label: "codex default" },
+          { value: "on-request", label: "on-request" },
+          { value: "never", label: "never" },
+        ],
+      },
+      {
+        name: "search",
+        label: "Web search",
+        kind: "toggle",
+        help: "Adds --search, giving the model the native web_search tool.",
       },
       { name: "name", label: "Session name", kind: "text", placeholder: "optional" },
     ],
+    /*
+     * Options follow `resume <id>`, which is where the CLI accepts them: the
+     * subcommand takes the same --sandbox, --ask-for-approval and --search as
+     * the root command, so one order works for both a fresh and a resumed run.
+     */
     build(values) {
       const parts = ["codex"];
       const id = text(values, "sessionId");
       if (id) parts.push("resume", quote(id));
-      if (on(values, "fullAuto")) parts.push("--full-auto");
+      else if (on(values, "resumeLast")) parts.push("resume", "--last");
+      const sandbox = text(values, "sandbox");
+      if (sandbox) parts.push("--sandbox", sandbox);
+      const approval = text(values, "approval");
+      if (approval) parts.push("--ask-for-approval", approval);
+      if (on(values, "search")) parts.push("--search");
       return parts.join(" ");
     },
   },
@@ -126,22 +155,77 @@ export const SESSION_KINDS: SessionKind[] = [
     title: "Hermes Agent",
     blurb: "Your Hermes agent, wrapped in a shareable terminal.",
     icon: "/icons/hermes.png",
-    // The builder stays a pass-through rather than inventing a flag set that
-    // was never read from the tool.
-    flagsFromPublishedInterface: true,
     fields: [
       {
-        name: "args",
-        label: "Arguments",
+        name: "subcommand",
+        label: "Command",
+        kind: "select",
+        options: [
+          { value: "", label: "hermes (interactive chat)" },
+          { value: "chat", label: "chat" },
+          { value: "gateway", label: "gateway" },
+          { value: "sessions", label: "sessions" },
+          { value: "dashboard", label: "dashboard" },
+          { value: "status", label: "status" },
+          { value: "doctor", label: "doctor" },
+          { value: "acp", label: "acp" },
+        ],
+      },
+      {
+        name: "sessionId",
+        label: "Resume session",
         kind: "text",
-        placeholder: "run --task build",
-        help: "Appended to hermes as written.",
+        placeholder: "leave empty to start fresh",
+        help: "Passed to --resume. Accepts a session ID or title.",
+      },
+      {
+        name: "continueLast",
+        label: "Continue the most recent session",
+        kind: "toggle",
+        help: "Adds --continue. Ignored when a command or a session is chosen.",
+      },
+      {
+        name: "model",
+        label: "Model",
+        kind: "text",
+        placeholder: "anthropic/claude-sonnet-4.6",
+        help: "Passed to --model for this run only.",
+      },
+      {
+        name: "worktree",
+        label: "Isolated git worktree",
+        kind: "toggle",
+        help: "Adds --worktree, so parallel agents do not share a checkout.",
+      },
+      {
+        name: "yolo",
+        label: "Skip approval prompts",
+        kind: "toggle",
+        help: "Adds --yolo. The agent will not ask before running a command.",
       },
       { name: "name", label: "Session name", kind: "text", placeholder: "optional" },
     ],
+    /*
+     * Every option here belongs to the top-level parser, so all of them go
+     * before the subcommand; `hermes sessions --yolo` is an error where
+     * `hermes --yolo sessions` is not.
+     *
+     * --continue takes an optional value, which makes a bare one greedy: in
+     * `hermes --continue sessions` the subcommand is read as the session name
+     * to resume. So it is emitted last and only when nothing follows it.
+     */
     build(values) {
-      const args = text(values, "args");
-      return args ? `hermes ${args}` : "hermes";
+      const parts = ["hermes"];
+      const model = text(values, "model");
+      if (model) parts.push("--model", quote(model));
+      if (on(values, "worktree")) parts.push("--worktree");
+      if (on(values, "yolo")) parts.push("--yolo");
+      const id = text(values, "sessionId");
+      if (id) parts.push("--resume", quote(id));
+      const subcommand = text(values, "subcommand");
+      if (subcommand) parts.push(subcommand);
+      else if (!id && on(values, "continueLast")) parts.push("--continue");
+      return parts.join(" ");
     },
   },
   {


### PR DESCRIPTION
## What this changes

The new-session form carried a warning on GPT Codex and Hermes Agent: *"These flags come from the published interface for … rather than from its own help output, so check the command below before starting."*

The warning was accurate. `codex --full-auto` is not a flag in current Codex:

```
$ codex --full-auto --help
error: unexpected argument '--full-auto' found
```

So the one non-default option the form offered for Codex built a command that could only fail on the machine it was sent to, after the round trip through `POST /api/commands` and the agent poll.

Rather than keep the warning, I installed both tools, read their real interfaces, and rebuilt the two kinds so there is nothing left to warn about. Codex and Hermes now sit at the same bar as Claude Code and OpenClaw.

## Verified against

| tool | version | install |
|---|---|---|
| `codex` | 0.153.4 | `npm i -g @openai/codex` |
| `hermes` | 0.19.0 | `uv tool install hermes-agent` |

Every option offered by the two builders parses against the installed binary. All 17 command shapes the builders can produce were generated from the shipped `build()` functions and run against the real CLIs: 17/17 accepted.

## Codex

Dropped `--full-auto`. Added, all read from `codex --help` and `codex resume --help`:

- resume by id, or `--last`
- `--sandbox` — `read-only` / `workspace-write` / `danger-full-access`
- `--ask-for-approval` — `on-request` / `never`
- `--search`

Options follow `resume <id>`, which is where the subcommand accepts them, so one order works for a fresh and a resumed run.

## Hermes

Replaced the free-text argument box with real controls: a subcommand picker, `--resume`, `--continue`, `--model`, `--worktree`, `--yolo`.

Two ordering rules the parser imposes are encoded and tested:

1. Every option belongs to the top-level parser, so all of them precede the subcommand. `hermes sessions --yolo` is `error: unrecognized arguments: --yolo`; `hermes --yolo sessions` is fine.
2. A bare `--continue` takes an optional value, so it is greedy — in `hermes --continue sessions` the subcommand is read as the session name to resume. It is emitted last, and only when no subcommand and no explicit session could be eaten by it.

## Discovery

Unchanged, and already correct: `codex` and `hermes` were present in `cmd/shell/harness.go`, in `KNOWN_HARNESSES` in `app/server/app.ts`, and in `DETECTED_HARNESSES` in `app/src/lib/harnesses.ts`. Confirmed end to end on a machine with all four installed — `installedHarnesses()` returns `[claude-code codex hermes openclaw]`, and the "not found on this machine" note still renders for a machine that reports without them.

## Tests

`session-kinds.test.ts` covers both builders: resume precedence, empty selects meaning "no flag", option ordering, and the `--continue` guard. The catalogue test that asserted which kinds were built from a published interface is replaced by one asserting no builder can emit `--full-auto`.

- `npm run check` (root) — pass
- `npm test` in `app/` — 616 passed, 3 skipped
- `npm run typecheck`, `oxlint` — clean, no new warnings
- `go test -race ./...`, `go vet ./...`, `gofmt -l` — clean
- `npm run build:web` — builds

The modal was also driven in a browser to confirm the live command preview matches the builders and the warning is gone.

Note: `npm run build` in `app/` fails at `check-bundle` for want of `VITE_FIREBASE_*`. That reproduces on `main` on a machine with no `.env.local` and is unrelated to this change.
