### PR TITLE
Draw the terminal at the size of the pane it is in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable user-visible changes are recorded here. Versions follow [Semantic Ve
 
 ## Unreleased
 
+### Added
+
+- Keep the open session tabs across a reload. Refreshing the page put you back at the list with every terminal closed; the tabs that were open come back, on the one that was in front. Only the session ids are remembered, so a restored tab is rebuilt from the session list rather than from a stale copy, and a session that has since ended does not return.
+
+### Fixed
+
+- Draw a shared terminal at the size of the pane holding it. The font was scaled until the whole grid fitted in one direction, which on a wide pane left about a third of it empty and the text a third smaller than there was room for. The font now comes from the width, where the columns are, and the rows are spread down the full height with the leading that is left over; neither axis may overflow. On a 1440x900 window a 120x36 session goes from 11.5px filling 77% of the pane to 14.75px filling 98%.
+- Remove the box drawn around each column of the session board. It repeated the border and the wash that every card inside it already carries, so three short columns read as three mostly empty containers.
+
 ## [0.11.1] — 2026-09-08
 
 ### Added

--- a/app/scripts/check-protocol.mjs
+++ b/app/scripts/check-protocol.mjs
@@ -21,6 +21,7 @@ const FILES = [
   { vendored: "src/terminal/e2ee.ts", source: "web/e2ee.ts" },
   { vendored: "src/terminal/terminal-grid.ts", source: "shared/terminal-grid.ts" },
   { vendored: "src/terminal/terminal-fit.ts", source: "web/terminal-fit.ts" },
+  { vendored: "src/terminal/terminal-metrics.ts", source: "web/terminal-metrics.ts" },
 ];
 
 /* Copies kept in step within this repository rather than with shell.online. */

--- a/app/src/routes/Workspace.tsx
+++ b/app/src/routes/Workspace.tsx
@@ -11,9 +11,11 @@ import { SessionBoard } from "../components/SessionBoard";
 import { SessionClipboard } from "../components/SessionClipboard";
 import { SignedInModal } from "../components/SignedInModal";
 import { AppShell } from "../components/AppShell";
+import { useAuth } from "../auth/AuthProvider";
 import { Alert } from "../components/Alert";
 import { TerminalPane } from "../terminal/TerminalPane";
-import { EMPTY, reduce } from "../terminal/tabs";
+import { EMPTY, reduce, tabFor } from "../terminal/tabs";
+import { readOpenTabs, writeOpenTabs } from "../terminal/tab-store";
 import {
   assignSession,
   deleteSession,
@@ -113,6 +115,7 @@ function writeViewMode(mode: ViewMode): void {
 
 export function Workspace() {
   usePageTitle("Sessions");
+  const { user } = useAuth();
   const [state, dispatch] = useReducer(reduce, EMPTY);
   const [sessions, setSessions] = useState<SessionRecord[] | null>(null);
   const [devices, setDevices] = useState<Device[]>([]);
@@ -133,6 +136,8 @@ export function Workspace() {
   const [search, setSearch] = useSearchParams();
   const [justLinked, setJustLinked] = useState(() => wasJustLinked(search));
   const loadedOnce = useRef(false);
+  /* Tabs are put back once, from the first session list a reload receives. */
+  const restoredTabs = useRef(false);
   /* Passwords waiting for their session to appear so they can be shared. */
   const pendingShares = useRef(new Map<string, string>());
   /* Who each session has already been shared with, so polling is not chatty. */
@@ -174,6 +179,34 @@ export function Workspace() {
       window.clearInterval(tick);
     };
   }, [load]);
+
+  /*
+   * The tabs that were open before the last reload, rebuilt from the session
+   * list rather than from what was stored: only the ids were kept. A session
+   * that has since ended or been removed does not come back, because a pane on
+   * a dead session is a card saying so, which is not worth a tab.
+   */
+  useEffect(() => {
+    if (restoredTabs.current || sessions === null) return;
+    restoredTabs.current = true;
+    const remembered = readOpenTabs(user?.uid ?? "");
+    if (remembered.ids.length === 0) return;
+    const byId = new Map(sessions.map((session) => [session.id, session]));
+    const tabs = remembered.ids
+      .map((id) => byId.get(id))
+      .filter((session): session is SessionRecord => session !== undefined && !session.closedAt)
+      .map((session) => tabFor(session, canEdit(session, you)));
+    dispatch({ type: "restore", tabs, activeId: remembered.activeId });
+  }, [sessions, you, user]);
+
+  /* Written only after the restore, so an empty first render cannot erase it. */
+  useEffect(() => {
+    if (!restoredTabs.current) return;
+    writeOpenTabs(user?.uid ?? "", {
+      ids: state.tabs.map((tab) => tab.id),
+      activeId: state.activeId,
+    });
+  }, [state, user]);
 
   /*
    * Publishing this browser's key makes it a possible recipient of a session

--- a/app/src/styles/auth.css
+++ b/app/src/styles/auth.css
@@ -1255,12 +1255,14 @@
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
+/*
+ * A column is a heading and the cards under it, with nothing drawn around it.
+ * The box it used to sit in repeated the border and the wash each card already
+ * carries, which read as a panel inside a panel and made three short columns
+ * look like three empty containers.
+ */
 .board-column {
   display: flex;
-  padding: 12px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-control);
-  background: color-mix(in srgb, var(--ink) 2%, transparent);
   flex-direction: column;
   gap: 2px;
 }

--- a/app/src/styles/terminal.css
+++ b/app/src/styles/terminal.css
@@ -139,9 +139,21 @@ button.tab {
   pointer-events: none;
 }
 
+/*
+ * The grid is drawn as large as it fits, and what the fit could not use is
+ * split between the two sides rather than left as a gap down one of them.
+ */
 .pane-screen {
+  display: flex;
   width: 100%;
   height: 100%;
+  align-items: center;
+  justify-content: center;
+}
+
+/* The emulator sizes itself; it must not be shrunk to the flex line. */
+.pane-screen > .xterm {
+  flex: none;
 }
 
 .pane-screen .xterm .xterm-viewport {

--- a/app/src/terminal/TerminalPane.tsx
+++ b/app/src/terminal/TerminalPane.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useRef, useState, type FormEvent, useMemo } from "react";
 import { Terminal } from "@xterm/xterm";
-import { FitAddon } from "@xterm/addon-fit";
 import { ArrowClockwise, LockKey } from "@phosphor-icons/react";
 import "@xterm/xterm/css/xterm.css";
 import { TerminalConnection, type ConnectionStatus } from "./connection";
 import { DESKTOP_TERMINAL_GRID, type TerminalGrid } from "./terminal-grid";
-import { fittedTerminalFontSize } from "./terminal-fit";
+import { fittedTerminal, type TerminalCell } from "./terminal-fit";
+import { cellMeasurer, terminalBox } from "./terminal-metrics";
 import { encryptionFragment, resolveSessionSocket, sessionIdFromShareUrl } from "./socket-url";
 import { forget, passwordFor } from "../lib/session-passwords";
 import { openSealed } from "../lib/keypair";
@@ -35,11 +35,17 @@ const THEME = {
   selectionBackground: "#3a3f33",
 };
 
-/*
- * The size the pane would like to draw at when the grid happens to fit. Every
- * fit scales down from here; nothing scales the grid.
- */
+const FONT_FAMILY = 'ui-monospace, "SFMono-Regular", "Menlo", "Consolas", monospace';
+
+/* Only until the first fit, which is one frame later. Nothing else reads it. */
 const BASE_FONT_SIZE = 13;
+
+/*
+ * The loosest the rows are ever drawn. A pane with height to spare uses it; a
+ * pane that is short for the grid tightens towards the font's own line box,
+ * which is what buys the columns a larger font.
+ */
+const BASE_LINE_HEIGHT = 1.35;
 
 export function TerminalPane({
   shareUrl,
@@ -49,7 +55,7 @@ export function TerminalPane({
 }: TerminalPaneProps) {
   const mount = useRef<HTMLDivElement>(null);
   const terminal = useRef<Terminal | null>(null);
-  const fit = useRef<FitAddon | null>(null);
+  const measure = useRef<((fontSize: number) => TerminalCell) | null>(null);
   const connection = useRef<TerminalConnection | null>(null);
 
   const [status, setStatus] = useState<ConnectionStatus>("connecting");
@@ -74,7 +80,7 @@ export function TerminalPane({
   const grid = useRef<TerminalGrid>(DESKTOP_TERMINAL_GRID);
 
   /**
-   * Scales the font so the whole session grid fits this pane, then pins the
+   * Draws the whole session grid as large as this pane allows, then pins the
    * terminal to that grid.
    *
    * The obvious thing — FitAddon.fit() — is wrong here. It picks the grid that
@@ -82,26 +88,26 @@ export function TerminalPane({
    * renders a 120-column process at, say, 94: every long line wraps a second
    * time and full-screen output loses its bottom rows. Nothing downstream can
    * repair that, because the PTY is not the size the emulator thinks it is.
+   * What the pane may choose is the font and the leading, which is what the
+   * fit returns.
    */
   const refit = useCallback(() => {
     const term = terminal.current;
-    const fitAddon = fit.current;
-    if (!activeRef.current || !fitAddon || !term) return;
+    const node = mount.current;
+    const measureCell = measure.current;
+    if (!activeRef.current || !term || !node || !measureCell) return;
     try {
-      term.options.fontSize = BASE_FONT_SIZE;
-      /* How much fits at the base size; the scale below is derived from it. */
-      const available = fitAddon.proposeDimensions();
-      if (!available) return;
+      const box = terminalBox(node);
+      if (box.width === 0 || box.height === 0) return;
       const { cols, rows } = grid.current;
-      const fontSize = fittedTerminalFontSize(
-        BASE_FONT_SIZE,
-        available.cols,
-        available.rows,
-        100,
-        cols,
-        rows,
-      );
-      if (term.options.fontSize !== fontSize) term.options.fontSize = fontSize;
+      const fitted = fittedTerminal(box, { cols, rows }, measureCell, {
+        pixelRatio: window.devicePixelRatio,
+        maxLineHeight: BASE_LINE_HEIGHT,
+      });
+      if (term.options.fontSize !== fitted.fontSize) term.options.fontSize = fitted.fontSize;
+      if (term.options.lineHeight !== fitted.lineHeight) {
+        term.options.lineHeight = fitted.lineHeight;
+      }
       if (term.cols !== cols || term.rows !== rows) {
         term.resize(cols, rows);
       } else {
@@ -149,23 +155,21 @@ export function TerminalPane({
     const target = resolved.target;
 
     const term = new Terminal({
-      fontFamily: 'ui-monospace, "SFMono-Regular", "Menlo", "Consolas", monospace',
+      fontFamily: FONT_FAMILY,
       fontSize: BASE_FONT_SIZE,
       /* Opened at the session grid so the first frames land in the right shape. */
       cols: grid.current.cols,
       rows: grid.current.rows,
-      lineHeight: 1.35,
+      lineHeight: BASE_LINE_HEIGHT,
       cursorBlink: true,
       convertEol: false,
       allowProposedApi: true,
       scrollback: 5000,
       theme: THEME,
     });
-    const fitAddon = new FitAddon();
-    term.loadAddon(fitAddon);
     term.open(node);
     terminal.current = term;
-    fit.current = fitAddon;
+    measure.current = cellMeasurer(FONT_FAMILY);
 
     const connected = new TerminalConnection({
       url: target.url,
@@ -247,7 +251,7 @@ export function TerminalPane({
       connected.close();
       term.dispose();
       terminal.current = null;
-      fit.current = null;
+      measure.current = null;
       connection.current = null;
     };
   }, [shareUrl, refit, canType, stableShare]);

--- a/app/src/terminal/tab-store.test.ts
+++ b/app/src/terminal/tab-store.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { readOpenTabs, writeOpenTabs } from "./tab-store";
+
+function fakeStorage() {
+  const map = new Map<string, string>();
+  return {
+    getItem: (key: string) => map.get(key) ?? null,
+    setItem: (key: string, value: string) => void map.set(key, value),
+    removeItem: (key: string) => void map.delete(key),
+    clear: () => map.clear(),
+    key: () => null,
+    length: 0,
+  } as unknown as Storage;
+}
+
+beforeEach(() => {
+  vi.stubGlobal("window", { localStorage: fakeStorage() });
+});
+
+describe("the tabs a reload finds", () => {
+  it("returns what was open, and which one was in front", () => {
+    writeOpenTabs("uid-1", { ids: ["a", "b"], activeId: "b" });
+    expect(readOpenTabs("uid-1")).toEqual({ ids: ["a", "b"], activeId: "b" });
+  });
+
+  it("hands nothing to another account on the same computer", () => {
+    writeOpenTabs("uid-1", { ids: ["a"], activeId: "a" });
+    expect(readOpenTabs("uid-2")).toEqual({ ids: [], activeId: null });
+  });
+
+  it("drops an active id that is not among the tabs", () => {
+    writeOpenTabs("uid-1", { ids: ["a"], activeId: "gone" });
+    expect(readOpenTabs("uid-1").activeId).toBeNull();
+  });
+
+  it("reads nothing rather than throwing on damaged storage", () => {
+    window.localStorage.setItem("shell.online:sessions:tabs:v1", "{not json");
+    expect(readOpenTabs("uid-1")).toEqual({ ids: [], activeId: null });
+  });
+
+  it("survives storage being unavailable", () => {
+    vi.stubGlobal("window", {
+      get localStorage(): Storage {
+        throw new Error("blocked");
+      },
+    });
+    expect(() => writeOpenTabs("uid-1", { ids: ["a"], activeId: "a" })).not.toThrow();
+    expect(readOpenTabs("uid-1")).toEqual({ ids: [], activeId: null });
+  });
+});

--- a/app/src/terminal/tab-store.ts
+++ b/app/src/terminal/tab-store.ts
@@ -1,0 +1,47 @@
+/**
+ * Which sessions were open, so that reloading the page does not close them.
+ *
+ * A reload is not a decision to stop watching a build; it is a reload. What is
+ * remembered is only the ids and which one was in front. Everything else a tab
+ * holds — its label, the command, the share link, the password sealed to this
+ * browser — is read back from the session list on the next load, so a restored
+ * tab is never a stale copy of a session, and nothing is written to this
+ * computer that the list would not hand over anyway.
+ *
+ * Scoped to the account, like the passwords beside it: signing in as somebody
+ * else on the same computer must not reopen the previous person's terminals.
+ */
+
+const KEY = "shell.online:sessions:tabs:v1";
+
+export interface OpenTabs {
+  ids: string[];
+  activeId: string | null;
+}
+
+const NONE: OpenTabs = { ids: [], activeId: null };
+
+export function readOpenTabs(uid: string): OpenTabs {
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    if (!raw) return NONE;
+    const held = JSON.parse(raw) as Partial<OpenTabs> & { uid?: string };
+    if (held.uid !== uid) return NONE;
+    const ids = Array.isArray(held.ids) ? held.ids.filter((id) => typeof id === "string") : [];
+    const activeId = typeof held.activeId === "string" && ids.includes(held.activeId)
+      ? held.activeId
+      : null;
+    return { ids, activeId };
+  } catch {
+    /* private windows, blocked storage, and anything hand-edited land here */
+    return NONE;
+  }
+}
+
+export function writeOpenTabs(uid: string, open: OpenTabs): void {
+  try {
+    window.localStorage.setItem(KEY, JSON.stringify({ uid, ...open }));
+  } catch {
+    /* nothing to do; the tabs simply will not come back */
+  }
+}

--- a/app/src/terminal/tabs.test.ts
+++ b/app/src/terminal/tabs.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { EMPTY, MAX_TABS, reduce, type TabState } from "./tabs";
+import { EMPTY, MAX_TABS, reduce, tabFor, type TabState } from "./tabs";
 import type { SessionRecord } from "../lib/api";
 
 function session(id: string, command = "top"): SessionRecord {
@@ -187,4 +187,39 @@ it("keeps a key share when the refreshed session has none", () => {
   const again = reduce(open, { type: "open", session: session("s1") });
   expect(again.tabs[0].keyShare).toEqual(share);
 });
+});
+
+describe("restore", () => {
+  const restored = (state: TabState, ids: string[], activeId: string | null) =>
+    reduce(state, {
+      type: "restore",
+      tabs: ids.map((id) => tabFor(session(id), true)),
+      activeId,
+    });
+
+  it("puts back the tabs a reload found, on the one that was in front", () => {
+    const state = restored(EMPTY, ["a", "b"], "b");
+    expect(state.tabs.map((t) => t.id)).toEqual(["a", "b"]);
+    expect(state.activeId).toBe("b");
+  });
+
+  /* The list arrives after the page, and a click in between is deliberate. */
+  it("leaves a tab opened before the list arrived alone", () => {
+    const opened = open(EMPTY, "live");
+    expect(restored(opened, ["a", "b"], "b")).toBe(opened);
+  });
+
+  it("shows the list when the session that was in front has gone", () => {
+    /* Its id is not among the tabs the list could rebuild. */
+    const state = restored(EMPTY, ["a"], "b");
+    expect(state.tabs.map((t) => t.id)).toEqual(["a"]);
+    expect(state.activeId).toBeNull();
+  });
+
+  it("keeps no more tabs than may be open at once", () => {
+    const ids = Array.from({ length: MAX_TABS + 3 }, (_, index) => `s${index}`);
+    const state = restored(EMPTY, ids, null);
+    expect(state.tabs).toHaveLength(MAX_TABS);
+    expect(state.tabs.map((t) => t.id)).toEqual(ids.slice(-MAX_TABS));
+  });
 });

--- a/app/src/terminal/tabs.ts
+++ b/app/src/terminal/tabs.ts
@@ -24,7 +24,21 @@ export const MAX_TABS = 8;
 export type TabAction =
   | { type: "open"; session: SessionRecord; canType?: boolean }
   | { type: "close"; id: string }
-  | { type: "select"; id: string | null };
+  | { type: "select"; id: string | null }
+  | { type: "restore"; tabs: Tab[]; activeId: string | null };
+
+/** What a tab holds about the session it was opened from. */
+export function tabFor(session: SessionRecord, canType: boolean): Tab {
+  return {
+    id: session.id,
+    label: session.name?.trim() || session.command,
+    command: session.command,
+    shareUrl: session.shareUrl,
+    readOnly: session.readOnly,
+    keyShare: session.keyShare,
+    canType,
+  };
+}
 
 /**
  * Tab bookkeeping, kept apart from React so the rules are testable.
@@ -60,15 +74,7 @@ export function reduce(state: TabState, action: TabAction): TabState {
         };
       }
 
-      const tab: Tab = {
-        id: session.id,
-        label: session.name?.trim() || session.command,
-        command: session.command,
-        shareUrl: session.shareUrl,
-        readOnly: session.readOnly,
-        keyShare: session.keyShare,
-        canType: action.canType ?? true,
-      };
+      const tab = tabFor(session, action.canType ?? true);
       /* Oldest goes when the cap is reached, and never the one being opened. */
       const tabs = [...state.tabs, tab].slice(-MAX_TABS);
       return { tabs, activeId: tab.id };
@@ -84,6 +90,18 @@ export function reduce(state: TabState, action: TabAction): TabState {
       /* Closing the active tab lands on its neighbour, not back at the list. */
       const neighbour = tabs[index] ?? tabs[index - 1] ?? null;
       return { tabs, activeId: neighbour?.id ?? null };
+    }
+
+    /*
+     * The tabs a reload found, rebuilt from the session list. It loses to
+     * anything already open: the list arrives a moment after the page does, and
+     * a session opened in that moment is a deliberate act, not a leftover.
+     */
+    case "restore": {
+      if (state.tabs.length > 0) return state;
+      const tabs = action.tabs.slice(-MAX_TABS);
+      const active = tabs.some((tab) => tab.id === action.activeId) ? action.activeId : null;
+      return { tabs, activeId: active };
     }
 
     case "select":

--- a/app/src/terminal/terminal-fit.ts
+++ b/app/src/terminal/terminal-fit.ts
@@ -2,37 +2,165 @@
  * Vendored verbatim from shell.online: web/terminal-fit.ts
  *
  * How a viewer fits the fixed session grid into its own viewport: by scaling
- * the font, never by changing the number of columns. The standalone viewer
+ * what it draws, never by changing the number of columns. The standalone viewer
  * and this app have to agree here, or the same session renders at two
  * different sizes. Checked by `npm run check:protocol`. Do not edit here.
  */
 /**
  * Scale the current session-wide terminal grid into an individual viewport.
+ *
+ * How many columns and rows there are is not a viewer's decision: the relay
+ * picks the grid and the CLI opens the PTY at it. What a viewer chooses is how
+ * large to draw that grid, and there are two knobs for it rather than one — the
+ * font size, and the leading between rows.
+ *
+ * Two, because a pane is almost never the shape of the grid. Scaling the font
+ * alone fits the grid into the pane the way an image fits a frame: as soon as
+ * one edge is reached the other stops growing, and a wide pane showing a 120x36
+ * session was left with a third of its width empty and its text a third smaller
+ * than the room allowed. So the font is taken from the width, where the columns
+ * are, and the rows are then spread down the full height with whatever leading
+ * that leaves. Neither axis is allowed to overflow: everything a viewer is
+ * drawing is inside the box it was given.
  */
-export function fittedTerminalFontSize(
-  baseFontSize: number,
-  availableColumns: number,
-  availableRows: number,
-  zoomPercent = 100,
-  terminalColumns = 80,
-  terminalRows = 24,
-): number {
-  if (
-    !Number.isFinite(baseFontSize) ||
-    !Number.isFinite(availableColumns) ||
-    !Number.isFinite(availableRows) ||
-    !Number.isFinite(zoomPercent) ||
-    baseFontSize <= 0 ||
-    availableColumns <= 0 ||
-    availableRows <= 0
-  ) {
-    return Math.max(4, baseFontSize || 14);
+
+export interface TerminalBox {
+  width: number;
+  height: number;
+}
+
+export interface TerminalGridSize {
+  cols: number;
+  rows: number;
+}
+
+/** One character, in CSS pixels, as the emulator itself measures it. */
+export interface TerminalCell {
+  width: number;
+  height: number;
+}
+
+export interface FittedTerminal {
+  fontSize: number;
+  lineHeight: number;
+}
+
+export interface TerminalFitOptions {
+  /** Personal zoom, as a percentage. Above 100 it may deliberately overflow. */
+  zoomPercent?: number;
+  /** Cells are rounded to whole device pixels, so the ratio changes the fit. */
+  pixelRatio?: number;
+  /** The leading to use when the height is not the binding constraint. */
+  maxLineHeight?: number;
+}
+
+/** Below this a terminal is unreadable, above it the grid is a poster. */
+const MIN_FONT_SIZE = 4;
+const MAX_FONT_SIZE = 32;
+/** Quarter-pixel steps: fine enough to fill a pane, coarse enough to settle. */
+const FONT_STEP = 0.25;
+/** A row is never drawn tighter than the font's own line box. */
+const MIN_LINE_HEIGHT = 1;
+const DEFAULT_MAX_LINE_HEIGHT = 1.35;
+/** Big enough to measure accurately, and only ever used as a ratio. */
+const REFERENCE_FONT_SIZE = 16;
+/** Used only when there is nothing to measure, e.g. a detached pane. */
+const FALLBACK_FONT_SIZE = 14;
+
+/**
+ * The largest font, and the leading to go with it, that draws the whole grid
+ * inside the box.
+ *
+ * `measure` reports what one character occupies at a given font size, which is
+ * a question only the browser can answer and only for the font in use.
+ */
+export function fittedTerminal(
+  box: TerminalBox,
+  grid: TerminalGridSize,
+  measure: (fontSize: number) => TerminalCell,
+  options: TerminalFitOptions = {},
+): FittedTerminal {
+  const maxLineHeight = Math.max(
+    MIN_LINE_HEIGHT,
+    positive(options.maxLineHeight) ? options.maxLineHeight : DEFAULT_MAX_LINE_HEIGHT,
+  );
+  const pixelRatio = positive(options.pixelRatio) ? options.pixelRatio : 1;
+  const zoom = positive(options.zoomPercent) ? options.zoomPercent / 100 : 1;
+
+  if (!positive(box.width) || !positive(box.height)) {
+    return { fontSize: FALLBACK_FONT_SIZE, lineHeight: maxLineHeight };
+  }
+  if (!positive(grid.cols) || !positive(grid.rows)) {
+    return { fontSize: FALLBACK_FONT_SIZE, lineHeight: maxLineHeight };
   }
 
-  const fitScale = Math.min(
-    availableColumns / terminalColumns,
-    availableRows / terminalRows,
+  const reference = measure(REFERENCE_FONT_SIZE);
+  if (!positive(reference.width) || !positive(reference.height)) {
+    return { fontSize: FALLBACK_FONT_SIZE, lineHeight: maxLineHeight };
+  }
+
+  /* Character metrics scale with the font, so one measurement sizes them all. */
+  const widthPerPixel = reference.width / REFERENCE_FONT_SIZE;
+  const heightPerPixel = reference.height / REFERENCE_FONT_SIZE;
+  const fromWidth = box.width / (grid.cols * widthPerPixel);
+  const fromHeight = box.height / (grid.rows * heightPerPixel * MIN_LINE_HEIGHT);
+
+  let fontSize = clamp(step(Math.min(fromWidth, fromHeight) * zoom), MIN_FONT_SIZE, MAX_FONT_SIZE);
+  let cell = measure(fontSize);
+
+  /*
+   * Metrics are not exactly linear — hinting rounds them — so the size derived
+   * from the reference can be a step too large. Asking what it really measures
+   * costs one measurement per step, and there is rarely more than one. Zoom
+   * above 100% is a request for text larger than fits, so it skips this.
+   */
+  while (zoom <= 1 && fontSize > MIN_FONT_SIZE && overflows(cell, box, grid, pixelRatio)) {
+    fontSize = step(fontSize - FONT_STEP);
+    cell = measure(fontSize);
+  }
+
+  /* Whatever height the rows did not need becomes the space between them. */
+  const lineHeight = clamp(
+    rowBudget(box.height, grid.rows, pixelRatio) / deviceHeight(cell.height, pixelRatio),
+    MIN_LINE_HEIGHT,
+    maxLineHeight,
   );
-  const scaled = baseFontSize * fitScale * (zoomPercent / 100) * 0.985;
-  return Math.min(32, Math.max(4, Math.floor(scaled * 4) / 4));
+
+  return { fontSize, lineHeight };
+}
+
+/**
+ * Whether the grid drawn at this cell size would spill out of the box, judged
+ * the way the emulator lays it out: columns rounded to whole CSS pixels, rows
+ * to whole device pixels at the tightest leading available.
+ */
+function overflows(
+  cell: TerminalCell,
+  box: TerminalBox,
+  grid: TerminalGridSize,
+  pixelRatio: number,
+): boolean {
+  if (Math.round(cell.width * grid.cols) > box.width) return true;
+  const rows = Math.floor(deviceHeight(cell.height, pixelRatio) * MIN_LINE_HEIGHT) * grid.rows;
+  return rows > box.height * pixelRatio;
+}
+
+function deviceHeight(height: number, pixelRatio: number): number {
+  return Math.ceil(height * pixelRatio);
+}
+
+function rowBudget(height: number, rows: number, pixelRatio: number): number {
+  return Math.floor((height * pixelRatio) / rows);
+}
+
+function step(value: number): number {
+  return Math.floor(value / FONT_STEP) * FONT_STEP;
+}
+
+function clamp(value: number, low: number, high: number): number {
+  return Math.min(high, Math.max(low, value));
+}
+
+function positive(value: number | undefined): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
 }

--- a/app/src/terminal/terminal-metrics.ts
+++ b/app/src/terminal/terminal-metrics.ts
@@ -1,0 +1,91 @@
+/*
+ * Vendored verbatim from shell.online: web/terminal-metrics.ts
+ *
+ * The browser measurements terminal-fit.ts is given. They travel with it: a
+ * viewer that measured a character differently would choose a different size
+ * for the same session. Checked by `npm run check:protocol`. Do not edit here.
+ */
+/**
+ * The two browser measurements a viewer needs before it can size a terminal:
+ * what one character occupies, and how much room there is to draw in.
+ *
+ * The emulator measures its own cells from the font's metrics, so a viewer
+ * choosing a font size has to ask the same question the same way, or the size
+ * it picks is not the size that reaches the screen. That is the advance width
+ * of a capital W and the font's bounding box for its height, which is what
+ * xterm asks a canvas for; the element fallback below is the one xterm falls
+ * back to, for a browser that does not report bounding-box metrics.
+ */
+
+import type { TerminalBox, TerminalCell } from "./terminal-fit";
+
+/** What xterm reserves for a scrollbar before it has drawn one. */
+const ASSUMED_SCROLLBAR_WIDTH = 14;
+/** Enough repeats that a fractional advance width survives being rounded. */
+const MEASURE_REPEATS = 32;
+
+/**
+ * A cached measurer for one font family. Sizes repeat constantly — every refit
+ * asks about the same handful — and measuring is a layout, so it is worth
+ * keeping the answers.
+ */
+export function cellMeasurer(fontFamily: string): (fontSize: number) => TerminalCell {
+  const measured = new Map<number, TerminalCell>();
+  return (fontSize) => {
+    const held = measured.get(fontSize);
+    if (held) return held;
+    const cell = measureCell(fontFamily, fontSize);
+    if (cell.width > 0 && cell.height > 0) measured.set(fontSize, cell);
+    return cell;
+  };
+}
+
+/**
+ * The room a terminal has, in CSS pixels.
+ *
+ * A classic scrollbar takes its width from the columns, an overlay scrollbar
+ * takes none, and which one is on this computer is not something to guess at:
+ * the viewport reports it. Before the emulator has drawn a viewport, the
+ * pessimistic figure keeps the last column off the scrollbar either way.
+ */
+export function terminalBox(element: HTMLElement): TerminalBox {
+  const viewport = element.querySelector<HTMLElement>(".xterm-viewport");
+  const scrollbar = viewport
+    ? Math.max(0, viewport.offsetWidth - viewport.clientWidth)
+    : ASSUMED_SCROLLBAR_WIDTH;
+  return {
+    width: Math.max(0, element.clientWidth - scrollbar),
+    height: Math.max(0, element.clientHeight),
+  };
+}
+
+let context: CanvasRenderingContext2D | null | undefined;
+
+function measureCell(fontFamily: string, fontSize: number): TerminalCell {
+  if (context === undefined) context = document.createElement("canvas").getContext("2d");
+  if (context) {
+    context.font = `${fontSize}px ${fontFamily}`;
+    const metrics = context.measureText("W");
+    const height = metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent;
+    if (metrics.width > 0 && Number.isFinite(height) && height > 0) {
+      return { width: metrics.width, height };
+    }
+  }
+  return measureElement(fontFamily, fontSize);
+}
+
+/* A span of Ws, laid out and read back, for browsers without font metrics. */
+function measureElement(fontFamily: string, fontSize: number): TerminalCell {
+  const span = document.createElement("span");
+  span.style.position = "absolute";
+  span.style.top = "-9999px";
+  span.style.whiteSpace = "pre";
+  span.style.fontKerning = "none";
+  span.style.fontFamily = fontFamily;
+  span.style.fontSize = `${fontSize}px`;
+  span.textContent = "W".repeat(MEASURE_REPEATS);
+  document.body.appendChild(span);
+  const cell = { width: span.offsetWidth / MEASURE_REPEATS, height: span.offsetHeight };
+  span.remove();
+  return cell;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
-        "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0"
       },
       "devDependencies": {
@@ -2015,12 +2014,6 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
-    },
-    "node_modules/@xterm/addon-fit": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
-      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
-      "license": "MIT"
     },
     "node_modules/@xterm/xterm": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "verify:published": "node ./scripts/verify-published.mjs"
   },
   "dependencies": {
-    "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0"
   },
   "devDependencies": {

--- a/tests/terminal-fit.test.ts
+++ b/tests/terminal-fit.test.ts
@@ -1,8 +1,26 @@
 import { describe, expect, it } from "vitest";
-import {
-  fittedTerminalFontSize,
-} from "../web/terminal-fit";
+import { fittedTerminal, type TerminalCell } from "../web/terminal-fit";
 import { DESKTOP_TERMINAL_GRID, MOBILE_TERMINAL_GRID, terminalGridForDevices } from "../shared/terminal-grid";
+
+/*
+ * A monospaced font measured the way the browser measures one: an advance
+ * width and a bounding box, both proportional to the size asked for.
+ */
+const font = (width = 0.6, height = 1.16) =>
+  (fontSize: number): TerminalCell => ({ width: fontSize * width, height: fontSize * height });
+
+/** What the emulator will draw at the size the fit chose. */
+function drawn(
+  cell: TerminalCell,
+  lineHeight: number,
+  grid: { cols: number; rows: number },
+  pixelRatio = 2,
+) {
+  return {
+    width: Math.round(cell.width * grid.cols),
+    height: (Math.floor(Math.ceil(cell.height * pixelRatio) * lineHeight) * grid.rows) / pixelRatio,
+  };
+}
 
 describe("viewer-local terminal fitting", () => {
   it("uses compatibility sizing only while a phone is connected", () => {
@@ -11,19 +29,91 @@ describe("viewer-local terminal fitting", () => {
     expect(terminalGridForDevices(["desktop", "mobile"])).toEqual(MOBILE_TERMINAL_GRID);
   });
 
-  it("fits each canonical grid to its viewer", () => {
-    const phone = fittedTerminalFontSize(13, 46, 50, 100, 80, 24);
-    const desktop = fittedTerminalFontSize(14, 170, 52, 100, 120, 36);
+  it("fills a pane wider than the grid instead of leaving it empty", () => {
+    const box = { width: 1069, height: 668 };
+    const measure = font();
+    const fitted = fittedTerminal(box, DESKTOP_TERMINAL_GRID, measure, { pixelRatio: 2 });
+    const size = drawn(measure(fitted.fontSize), fitted.lineHeight, DESKTOP_TERMINAL_GRID);
 
-    expect(phone).toBeGreaterThanOrEqual(7);
-    expect(phone).toBeLessThan(10);
-    expect(desktop).toBeGreaterThan(16);
-    expect(desktop).toBeLessThanOrEqual(24);
+    /* Both axes used, neither exceeded. */
+    expect(size.width).toBeLessThanOrEqual(box.width);
+    expect(size.height).toBeLessThanOrEqual(box.height);
+    expect(size.width / box.width).toBeGreaterThan(0.97);
+    expect(size.height / box.height).toBeGreaterThan(0.97);
+  });
+
+  it("never overflows the box it was given", () => {
+    for (const width of [320, 480, 720, 1069, 1400, 2189, 3400]) {
+      for (const height of [240, 400, 588, 668, 848, 1208]) {
+        for (const ratio of [1, 2, 3]) {
+          const box = { width, height };
+          const measure = font();
+          const fitted = fittedTerminal(box, DESKTOP_TERMINAL_GRID, measure, { pixelRatio: ratio });
+          const size = drawn(measure(fitted.fontSize), fitted.lineHeight, DESKTOP_TERMINAL_GRID, ratio);
+          expect(size.width).toBeLessThanOrEqual(box.width);
+          expect(size.height).toBeLessThanOrEqual(box.height);
+        }
+      }
+    }
+  });
+
+  it("keeps the leading it was given when the height is not the constraint", () => {
+    /* Tall and narrow: the columns run out first, so the rows have room. */
+    const fitted = fittedTerminal({ width: 700, height: 1400 }, DESKTOP_TERMINAL_GRID, font(), {
+      maxLineHeight: 1.35,
+      pixelRatio: 2,
+    });
+    expect(fitted.lineHeight).toBe(1.35);
+  });
+
+  it("tightens the leading rather than shrinking the font", () => {
+    const short = fittedTerminal({ width: 1069, height: 588 }, DESKTOP_TERMINAL_GRID, font(), {
+      maxLineHeight: 1.35,
+      pixelRatio: 2,
+    });
+    expect(short.lineHeight).toBeLessThan(1.35);
+    expect(short.lineHeight).toBeGreaterThanOrEqual(1);
+  });
+
+  it("fits each canonical grid to its viewer", () => {
+    const phone = fittedTerminal({ width: 380, height: 620 }, MOBILE_TERMINAL_GRID, font(), {
+      pixelRatio: 3,
+    });
+    const desktop = fittedTerminal({ width: 1400, height: 900 }, DESKTOP_TERMINAL_GRID, font(), {
+      pixelRatio: 2,
+    });
+
+    expect(phone.fontSize).toBeGreaterThanOrEqual(7);
+    expect(phone.fontSize).toBeLessThan(10);
+    expect(desktop.fontSize).toBeGreaterThan(16);
+    expect(desktop.fontSize).toBeLessThanOrEqual(24);
   });
 
   it("applies personal zoom without changing terminal dimensions", () => {
-    const normal = fittedTerminalFontSize(13, 80, 24, 100, 80, 24);
-    expect(fittedTerminalFontSize(13, 80, 24, 50, 80, 24)).toBeLessThan(normal);
-    expect(fittedTerminalFontSize(13, 80, 24, 150, 80, 24)).toBeGreaterThan(normal);
+    const box = { width: 1069, height: 668 };
+    const normal = fittedTerminal(box, DESKTOP_TERMINAL_GRID, font(), { pixelRatio: 2 });
+    const small = fittedTerminal(box, DESKTOP_TERMINAL_GRID, font(), {
+      zoomPercent: 50,
+      pixelRatio: 2,
+    });
+    const large = fittedTerminal(box, DESKTOP_TERMINAL_GRID, font(), {
+      zoomPercent: 150,
+      pixelRatio: 2,
+    });
+
+    expect(small.fontSize).toBeLessThan(normal.fontSize);
+    expect(large.fontSize).toBeGreaterThan(normal.fontSize);
+  });
+
+  it("falls back rather than dividing by a pane that has no size yet", () => {
+    const detached = fittedTerminal({ width: 0, height: 0 }, DESKTOP_TERMINAL_GRID, font());
+    expect(detached.fontSize).toBeGreaterThan(0);
+    expect(detached.lineHeight).toBeGreaterThanOrEqual(1);
+
+    const unmeasurable = fittedTerminal({ width: 800, height: 600 }, DESKTOP_TERMINAL_GRID, () => ({
+      width: 0,
+      height: 0,
+    }));
+    expect(unmeasurable.fontSize).toBeGreaterThan(0);
   });
 });

--- a/web/main.ts
+++ b/web/main.ts
@@ -1,4 +1,3 @@
-import { FitAddon } from "@xterm/addon-fit";
 import { Terminal, type ITheme } from "@xterm/xterm";
 import {
   CLAUDE_CODE_PATH,
@@ -42,9 +41,8 @@ import {
   type LatencySample,
 } from "./latency-history";
 import { MobileViewportTracker, terminalTypography } from "./mobile-viewport";
-import {
-  fittedTerminalFontSize,
-} from "./terminal-fit";
+import { fittedTerminal } from "./terminal-fit";
+import { cellMeasurer, terminalBox } from "./terminal-metrics";
 import { DESKTOP_TERMINAL_GRID } from "../shared/terminal-grid";
 import { renderStatsDashboard } from "./stats";
 import {
@@ -1216,8 +1214,7 @@ function renderTerminal(sessionId: string): void {
     allowTransparency: false,
     theme: terminalThemes[colorMode],
   });
-  const fit = new FitAddon();
-  terminal.loadAddon(fit);
+  const measureCell = cellMeasurer(terminal.options.fontFamily ?? "monospace");
   terminal.open(terminalElement);
   const helperTextarea = terminalElement.querySelector<HTMLTextAreaElement>(".xterm-helper-textarea");
   if (helperTextarea) {
@@ -1577,8 +1574,9 @@ function renderTerminal(sessionId: string): void {
   };
 
   const fitTerminal = (): void => {
-    if (terminalWrap.clientWidth === 0 || terminalWrap.clientHeight === 0) return;
     try {
+      const box = terminalBox(terminalElement);
+      if (box.width === 0 || box.height === 0) return;
       const current = readViewport();
       const typography = terminalTypography(
         compactSessionQuery.matches,
@@ -1586,20 +1584,25 @@ function renderTerminal(sessionId: string): void {
         current.width,
         current.height,
       );
-      terminal.options.fontSize = typography.fontSize;
-      terminal.options.lineHeight = typography.lineHeight;
-      const available = fit.proposeDimensions();
-      if (!available) return;
-      const scaledFontSize = fittedTerminalFontSize(
-        typography.fontSize,
-        available.cols,
-        available.rows,
-        terminalZoomPercent,
-        terminalColumns,
-        terminalRows,
+      /*
+       * The typography for this device is the loosest the rows are drawn at;
+       * the fit tightens the leading from there when that buys a larger font.
+       */
+      const fitted = fittedTerminal(
+        box,
+        { cols: terminalColumns, rows: terminalRows },
+        measureCell,
+        {
+          zoomPercent: terminalZoomPercent,
+          pixelRatio: window.devicePixelRatio,
+          maxLineHeight: typography.lineHeight,
+        },
       );
-      if (terminal.options.fontSize !== scaledFontSize) {
-        terminal.options.fontSize = scaledFontSize;
+      if (terminal.options.fontSize !== fitted.fontSize) {
+        terminal.options.fontSize = fitted.fontSize;
+      }
+      if (terminal.options.lineHeight !== fitted.lineHeight) {
+        terminal.options.lineHeight = fitted.lineHeight;
       }
       if (terminal.cols !== terminalColumns || terminal.rows !== terminalRows) {
         terminal.resize(terminalColumns, terminalRows);

--- a/web/terminal-fit.ts
+++ b/web/terminal-fit.ts
@@ -1,30 +1,158 @@
 /**
  * Scale the current session-wide terminal grid into an individual viewport.
+ *
+ * How many columns and rows there are is not a viewer's decision: the relay
+ * picks the grid and the CLI opens the PTY at it. What a viewer chooses is how
+ * large to draw that grid, and there are two knobs for it rather than one — the
+ * font size, and the leading between rows.
+ *
+ * Two, because a pane is almost never the shape of the grid. Scaling the font
+ * alone fits the grid into the pane the way an image fits a frame: as soon as
+ * one edge is reached the other stops growing, and a wide pane showing a 120x36
+ * session was left with a third of its width empty and its text a third smaller
+ * than the room allowed. So the font is taken from the width, where the columns
+ * are, and the rows are then spread down the full height with whatever leading
+ * that leaves. Neither axis is allowed to overflow: everything a viewer is
+ * drawing is inside the box it was given.
  */
-export function fittedTerminalFontSize(
-  baseFontSize: number,
-  availableColumns: number,
-  availableRows: number,
-  zoomPercent = 100,
-  terminalColumns = 80,
-  terminalRows = 24,
-): number {
-  if (
-    !Number.isFinite(baseFontSize) ||
-    !Number.isFinite(availableColumns) ||
-    !Number.isFinite(availableRows) ||
-    !Number.isFinite(zoomPercent) ||
-    baseFontSize <= 0 ||
-    availableColumns <= 0 ||
-    availableRows <= 0
-  ) {
-    return Math.max(4, baseFontSize || 14);
+
+export interface TerminalBox {
+  width: number;
+  height: number;
+}
+
+export interface TerminalGridSize {
+  cols: number;
+  rows: number;
+}
+
+/** One character, in CSS pixels, as the emulator itself measures it. */
+export interface TerminalCell {
+  width: number;
+  height: number;
+}
+
+export interface FittedTerminal {
+  fontSize: number;
+  lineHeight: number;
+}
+
+export interface TerminalFitOptions {
+  /** Personal zoom, as a percentage. Above 100 it may deliberately overflow. */
+  zoomPercent?: number;
+  /** Cells are rounded to whole device pixels, so the ratio changes the fit. */
+  pixelRatio?: number;
+  /** The leading to use when the height is not the binding constraint. */
+  maxLineHeight?: number;
+}
+
+/** Below this a terminal is unreadable, above it the grid is a poster. */
+const MIN_FONT_SIZE = 4;
+const MAX_FONT_SIZE = 32;
+/** Quarter-pixel steps: fine enough to fill a pane, coarse enough to settle. */
+const FONT_STEP = 0.25;
+/** A row is never drawn tighter than the font's own line box. */
+const MIN_LINE_HEIGHT = 1;
+const DEFAULT_MAX_LINE_HEIGHT = 1.35;
+/** Big enough to measure accurately, and only ever used as a ratio. */
+const REFERENCE_FONT_SIZE = 16;
+/** Used only when there is nothing to measure, e.g. a detached pane. */
+const FALLBACK_FONT_SIZE = 14;
+
+/**
+ * The largest font, and the leading to go with it, that draws the whole grid
+ * inside the box.
+ *
+ * `measure` reports what one character occupies at a given font size, which is
+ * a question only the browser can answer and only for the font in use.
+ */
+export function fittedTerminal(
+  box: TerminalBox,
+  grid: TerminalGridSize,
+  measure: (fontSize: number) => TerminalCell,
+  options: TerminalFitOptions = {},
+): FittedTerminal {
+  const maxLineHeight = Math.max(
+    MIN_LINE_HEIGHT,
+    positive(options.maxLineHeight) ? options.maxLineHeight : DEFAULT_MAX_LINE_HEIGHT,
+  );
+  const pixelRatio = positive(options.pixelRatio) ? options.pixelRatio : 1;
+  const zoom = positive(options.zoomPercent) ? options.zoomPercent / 100 : 1;
+
+  if (!positive(box.width) || !positive(box.height)) {
+    return { fontSize: FALLBACK_FONT_SIZE, lineHeight: maxLineHeight };
+  }
+  if (!positive(grid.cols) || !positive(grid.rows)) {
+    return { fontSize: FALLBACK_FONT_SIZE, lineHeight: maxLineHeight };
   }
 
-  const fitScale = Math.min(
-    availableColumns / terminalColumns,
-    availableRows / terminalRows,
+  const reference = measure(REFERENCE_FONT_SIZE);
+  if (!positive(reference.width) || !positive(reference.height)) {
+    return { fontSize: FALLBACK_FONT_SIZE, lineHeight: maxLineHeight };
+  }
+
+  /* Character metrics scale with the font, so one measurement sizes them all. */
+  const widthPerPixel = reference.width / REFERENCE_FONT_SIZE;
+  const heightPerPixel = reference.height / REFERENCE_FONT_SIZE;
+  const fromWidth = box.width / (grid.cols * widthPerPixel);
+  const fromHeight = box.height / (grid.rows * heightPerPixel * MIN_LINE_HEIGHT);
+
+  let fontSize = clamp(step(Math.min(fromWidth, fromHeight) * zoom), MIN_FONT_SIZE, MAX_FONT_SIZE);
+  let cell = measure(fontSize);
+
+  /*
+   * Metrics are not exactly linear — hinting rounds them — so the size derived
+   * from the reference can be a step too large. Asking what it really measures
+   * costs one measurement per step, and there is rarely more than one. Zoom
+   * above 100% is a request for text larger than fits, so it skips this.
+   */
+  while (zoom <= 1 && fontSize > MIN_FONT_SIZE && overflows(cell, box, grid, pixelRatio)) {
+    fontSize = step(fontSize - FONT_STEP);
+    cell = measure(fontSize);
+  }
+
+  /* Whatever height the rows did not need becomes the space between them. */
+  const lineHeight = clamp(
+    rowBudget(box.height, grid.rows, pixelRatio) / deviceHeight(cell.height, pixelRatio),
+    MIN_LINE_HEIGHT,
+    maxLineHeight,
   );
-  const scaled = baseFontSize * fitScale * (zoomPercent / 100) * 0.985;
-  return Math.min(32, Math.max(4, Math.floor(scaled * 4) / 4));
+
+  return { fontSize, lineHeight };
+}
+
+/**
+ * Whether the grid drawn at this cell size would spill out of the box, judged
+ * the way the emulator lays it out: columns rounded to whole CSS pixels, rows
+ * to whole device pixels at the tightest leading available.
+ */
+function overflows(
+  cell: TerminalCell,
+  box: TerminalBox,
+  grid: TerminalGridSize,
+  pixelRatio: number,
+): boolean {
+  if (Math.round(cell.width * grid.cols) > box.width) return true;
+  const rows = Math.floor(deviceHeight(cell.height, pixelRatio) * MIN_LINE_HEIGHT) * grid.rows;
+  return rows > box.height * pixelRatio;
+}
+
+function deviceHeight(height: number, pixelRatio: number): number {
+  return Math.ceil(height * pixelRatio);
+}
+
+function rowBudget(height: number, rows: number, pixelRatio: number): number {
+  return Math.floor((height * pixelRatio) / rows);
+}
+
+function step(value: number): number {
+  return Math.floor(value / FONT_STEP) * FONT_STEP;
+}
+
+function clamp(value: number, low: number, high: number): number {
+  return Math.min(high, Math.max(low, value));
+}
+
+function positive(value: number | undefined): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
 }

--- a/web/terminal-metrics.ts
+++ b/web/terminal-metrics.ts
@@ -1,0 +1,84 @@
+/**
+ * The two browser measurements a viewer needs before it can size a terminal:
+ * what one character occupies, and how much room there is to draw in.
+ *
+ * The emulator measures its own cells from the font's metrics, so a viewer
+ * choosing a font size has to ask the same question the same way, or the size
+ * it picks is not the size that reaches the screen. That is the advance width
+ * of a capital W and the font's bounding box for its height, which is what
+ * xterm asks a canvas for; the element fallback below is the one xterm falls
+ * back to, for a browser that does not report bounding-box metrics.
+ */
+
+import type { TerminalBox, TerminalCell } from "./terminal-fit";
+
+/** What xterm reserves for a scrollbar before it has drawn one. */
+const ASSUMED_SCROLLBAR_WIDTH = 14;
+/** Enough repeats that a fractional advance width survives being rounded. */
+const MEASURE_REPEATS = 32;
+
+/**
+ * A cached measurer for one font family. Sizes repeat constantly — every refit
+ * asks about the same handful — and measuring is a layout, so it is worth
+ * keeping the answers.
+ */
+export function cellMeasurer(fontFamily: string): (fontSize: number) => TerminalCell {
+  const measured = new Map<number, TerminalCell>();
+  return (fontSize) => {
+    const held = measured.get(fontSize);
+    if (held) return held;
+    const cell = measureCell(fontFamily, fontSize);
+    if (cell.width > 0 && cell.height > 0) measured.set(fontSize, cell);
+    return cell;
+  };
+}
+
+/**
+ * The room a terminal has, in CSS pixels.
+ *
+ * A classic scrollbar takes its width from the columns, an overlay scrollbar
+ * takes none, and which one is on this computer is not something to guess at:
+ * the viewport reports it. Before the emulator has drawn a viewport, the
+ * pessimistic figure keeps the last column off the scrollbar either way.
+ */
+export function terminalBox(element: HTMLElement): TerminalBox {
+  const viewport = element.querySelector<HTMLElement>(".xterm-viewport");
+  const scrollbar = viewport
+    ? Math.max(0, viewport.offsetWidth - viewport.clientWidth)
+    : ASSUMED_SCROLLBAR_WIDTH;
+  return {
+    width: Math.max(0, element.clientWidth - scrollbar),
+    height: Math.max(0, element.clientHeight),
+  };
+}
+
+let context: CanvasRenderingContext2D | null | undefined;
+
+function measureCell(fontFamily: string, fontSize: number): TerminalCell {
+  if (context === undefined) context = document.createElement("canvas").getContext("2d");
+  if (context) {
+    context.font = `${fontSize}px ${fontFamily}`;
+    const metrics = context.measureText("W");
+    const height = metrics.fontBoundingBoxAscent + metrics.fontBoundingBoxDescent;
+    if (metrics.width > 0 && Number.isFinite(height) && height > 0) {
+      return { width: metrics.width, height };
+    }
+  }
+  return measureElement(fontFamily, fontSize);
+}
+
+/* A span of Ws, laid out and read back, for browsers without font metrics. */
+function measureElement(fontFamily: string, fontSize: number): TerminalCell {
+  const span = document.createElement("span");
+  span.style.position = "absolute";
+  span.style.top = "-9999px";
+  span.style.whiteSpace = "pre";
+  span.style.fontKerning = "none";
+  span.style.fontFamily = fontFamily;
+  span.style.fontSize = `${fontSize}px`;
+  span.textContent = "W".repeat(MEASURE_REPEATS);
+  document.body.appendChild(span);
+  const cell = { width: span.offsetWidth / MEASURE_REPEATS, height: span.offsetHeight };
+  span.remove();
+  return cell;
+}


### PR DESCRIPTION
## The terminal did not fill its pane

A viewer never changes how many columns and rows a session has — the relay picks the grid, the CLI opens the PTY at it. What a viewer chooses is how large to draw them, and that was a single knob: the font size, scaled until the grid fitted in whichever direction ran out first.

A pane is almost never the shape of a 120x36 grid, so on a wide one the columns stopped growing the moment the rows reached the bottom. Measured in a real layout at four window sizes, the grid used only 68–77% of the pane's width, and the text was a third smaller than there was room for.

| window | before | after |
| --- | --- | --- |
| 1440x900 | 11.5px, 77% of the width | 14.75px, 98% |
| 1728x1000 | 13.5px, 71% | 17.75px, 94% |
| 1920x1080 | 14.75px, 68% | 19.75px, 91% |
| 2560x1440 | 21.25px, 70% | 28.25px, 93% |

## What changed

`fittedTerminal` replaces `fittedTerminalFontSize` and returns two things instead of one:

- The **font** comes from the width, where the columns are.
- The **rows** are then spread down the full height with whatever leading is left over, between the font's own line box and the leading the surface asked for (1.35 in the app, the device's typography in the standalone viewer). A pane with height to spare keeps the leading it had.

Neither axis may overflow. The size is derived from what the browser says a character measures, then checked against what the emulator will actually lay out — columns rounded to whole CSS pixels, rows to whole device pixels at the ratio the screen will round to — and stepped down if it would not fit. A test sweeps 126 box/ratio combinations and asserts the drawn grid never exceeds the box.

All of it is client-side: no session, no relay and no PTY sees any of this.

Supporting changes:

- `web/terminal-metrics.ts`, vendored into the app beside the fit and covered by `npm run check:protocol`, holds the two browser measurements — what a character occupies (the way xterm measures it, so the chosen size is the size that lands) and how much room the pane has, minus a scrollbar only where the platform actually takes one.
- What the fit cannot use is now split between both sides of the pane instead of left down one of them.
- Measuring directly retires `FitAddon` in the viewer, where `proposeDimensions` was the only thing it was used for. The app still ships it for the sign-in page's animated preview, which genuinely wants a grid that fills its box.

## Also in here

**The open tabs survive a reload.** Refreshing put you back at the list with every terminal closed. The ids of the open tabs and the one in front are now remembered per account, and put back from the first session list the page receives — rebuilt from that list rather than from what was stored, so a restored tab is never a stale copy of a session, and one that has since ended does not come back. Nothing is written to the browser that the session list would not hand over anyway.

**The board columns lose their box.** Each column drew a border and a wash around cards that already carry both, so three short columns read as three mostly empty containers.

## Checks

`npm run typecheck`, `npx vitest run` (20 files) and `npm run build:web` at the root; `npm run typecheck`, `npm test` (616 tests) and `check:protocol` in `app/`. The app's `npm run build` stops at `check-bundle` on this machine for want of Firebase values in `.env.local`, which is unrelated to the diff.