### PR TITLE
Fix what production found: the inbox, passwords, mobile, and the audit order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable user-visible changes are recorded here. Versions follow [Semantic Ve
 
 ### Added
 
+- Choose who can open a session when you start it. The password is generated and sealed to each person ticked, so nothing is typed and nobody is told a secret; people can be added afterwards from the session page.
+- Offer the session you just started as soon as the machine publishes it, instead of leaving you to find its row.
+- Pick a model for Claude Code and Codex sessions.
+- Copy a session's link, password or attach command from the session page, not only from the list.
+
+### Fixed
+
+- Stop "Mark all read" blanking the inbox. The reply left out the roster the list is drawn from.
+- Keep a session password that was typed once, so opening the same session again does not ask for it.
+- Seal a session's password only to the people chosen for it. It went to the whole team, so every colleague could open every session and the choice was never offered.
+- Say which person is the owner and which is the assignee on a phone, where the table stacks and its header is gone.
+- Keep the terminal above the on-screen keyboard rather than behind it.
+- Fix the top bar on a home-screen install, where the status bar inset was eaten out of the bar instead of added to it, and carry the wordmark and the account menu there.
+- Read the audit log newest first, and call its chart "By user".
+- Stop re-deriving every session's password on every poll, which is most of what the session list was doing on a phone.
+
+### Added
+
 - Keep the open session tabs across a reload. Refreshing the page put you back at the list with every terminal closed; the tabs that were open come back, on the one that was in front. Only the session ids are remembered, so a restored tab is rebuilt from the session list rather than from a stale copy, and a session that has since ended does not return.
 - Offer GPT Codex's sandbox, approval, resume and web-search options in the new-session form, and Hermes Agent's command, session, model, worktree and approval options, each read from the installed tool rather than from its documentation.
 

--- a/app/server/app.test.ts
+++ b/app/server/app.test.ts
@@ -1434,6 +1434,29 @@ describe("being told a colleague started a session", () => {
     });
     expect(stranger.body.notifications).toEqual([]);
   });
+
+  /*
+   * The client draws each notification as a person doing something, so a reply
+   * without the roster is a reply it cannot render. Marking everything read
+   * returned one without it, and the page went blank.
+   */
+  it("carries the roster on every reply, not only on the read", async () => {
+    const { tokens, colleague } = await orgWithColleague();
+    await call("POST", "/api/sessions", { auth: tokens.access_token, body: session });
+
+    const listed = await call("GET", "/api/notifications", { auth: colleague });
+    expect(listed.body.members.length).toBeGreaterThan(0);
+
+    const one = await call("POST", "/api/notifications/read", {
+      auth: colleague,
+      body: { id: listed.body.notifications[0].id },
+    });
+    expect(one.body.members).toEqual(listed.body.members);
+
+    const all = await call("POST", "/api/notifications/read", { auth: colleague, body: {} });
+    expect(all.body.members).toEqual(listed.body.members);
+    expect(all.body.unread).toBe(0);
+  });
 });
 
 describe("guarding the service itself", () => {

--- a/app/server/app.ts
+++ b/app/server/app.ts
@@ -964,8 +964,7 @@ export function createApp(options: AppOptions) {
       if (route === "GET /api/notifications") {
         const membership = await requireMember(request);
         if (!membership) return send(response, 401, { error: "sign in first" });
-        const view = await inbox(store, membership);
-        return send(response, 200, { ...view, members: await store.members(membership.orgId) });
+        return send(response, 200, await inbox(store, membership));
       }
 
       if (route === "POST /api/notifications/read") {

--- a/app/server/routes/social.ts
+++ b/app/server/routes/social.ts
@@ -111,12 +111,27 @@ export async function notifySessionStarted(
   }
 }
 
+/*
+ * The whole inbox, roster included.
+ *
+ * The roster is part of the view rather than something each route remembers to
+ * add: a notification is rendered as a person doing something, so a reply
+ * without members is a reply the client cannot draw. One route added them and
+ * the other did not, and marking everything read returned the incomplete one,
+ * which blanked the page.
+ */
 export async function inbox(
   store: Store,
   membership: Membership,
-): Promise<{ notifications: Notification[]; unread: number; unreadAssignments: number }> {
+): Promise<{
+  notifications: Notification[];
+  unread: number;
+  unreadAssignments: number;
+  members: Awaited<ReturnType<Store["members"]>>;
+}> {
   const notifications = await store.notificationsFor(membership.uid);
   return {
+    members: await store.members(membership.orgId),
     notifications,
     unread: notifications.filter((entry) => !entry.readAt).length,
     /* Counted apart, because an assignment deserves more attention than a

--- a/app/src/components/AppShell.tsx
+++ b/app/src/components/AppShell.tsx
@@ -152,10 +152,24 @@ export function AppShell({ title, aside, children }: AppShellProps) {
       <div className="shell-main">
         <header className="topbar">
           <div className="topbar-inner">
-            <h1 className="topbar-title">{title}</h1>
+            <div className="topbar-heading">
+              {/* Shown only where the rail is not: see .topbar-mark. */}
+              <Link to="/sessions" className="topbar-mark" aria-label="shell.online">
+                <Wordmark />
+              </Link>
+              <h1 className="topbar-title">{title}</h1>
+            </div>
             <div className="topbar-right">
               {aside}
               <Inbox />
+              {/*
+                * On a phone the rail is a strip of destinations along the
+                * bottom and its foot is gone, taking the account menu with it.
+                * Signing out was then only reachable from the Account page.
+                */}
+              <span className="topbar-account">
+                <AccountMenu />
+              </span>
             </div>
           </div>
         </header>

--- a/app/src/components/Inbox.tsx
+++ b/app/src/components/Inbox.tsx
@@ -101,7 +101,8 @@ export function Inbox() {
           ) : (
             <ul className="inbox-list">
               {view.notifications.map((notification) => {
-                const actor = findPerson(view.members, notification.actorUid);
+                /* A reply without a roster costs a name, not the page. */
+                const actor = findPerson(view.members ?? [], notification.actorUid);
                 const assigned = notification.kind === "assigned";
                 const shared = notification.kind === "shared";
                 return (

--- a/app/src/components/LaunchPrompt.tsx
+++ b/app/src/components/LaunchPrompt.tsx
@@ -1,0 +1,61 @@
+import { createPortal } from "react-dom";
+import { Terminal as TerminalIcon, X } from "@phosphor-icons/react";
+import { Button } from "./Button";
+import { kindForCommand } from "../lib/session-kinds";
+import type { SessionRecord } from "../lib/api";
+
+/**
+ * Offers the session that was just started.
+ *
+ * Starting one used to end in a line of text saying it would turn up, which
+ * left the person who asked for it scanning a list for a row that was not
+ * there yet. The machine has to poll, launch and publish first, so the wait is
+ * real; what was missing was anything at the end of it.
+ */
+export function LaunchPrompt({
+  session,
+  onOpen,
+  onClose,
+}: {
+  session: SessionRecord;
+  onOpen(): void;
+  onClose(): void;
+}) {
+  const kind = kindForCommand(session.command);
+  return createPortal(
+    <div
+      className="scrim"
+      onMouseDown={(event) => event.target === event.currentTarget && onClose()}
+    >
+      <div className="sheet is-compact" role="dialog" aria-modal="true" aria-label="Session started">
+        <header className="sheet-head">
+          <h2>Session started</h2>
+          <button type="button" className="sheet-close" onClick={onClose} aria-label="Close">
+            <X size={17} weight="bold" />
+          </button>
+        </header>
+
+        <div className="sheet-body">
+          <div className="launch-subject">
+            <img src={kind.icon} alt="" className="launch-icon" />
+            <span className="launch-text">
+              <b>{session.name || session.command}</b>
+              <em>{session.host ? `Running on ${session.host}` : "Running"}</em>
+            </span>
+          </div>
+
+          <div className="sheet-actions">
+            <Button type="button" variant="ghost" onClick={onClose}>
+              Not now
+            </Button>
+            <Button type="button" onClick={onOpen}>
+              <TerminalIcon size={15} weight="bold" />
+              Open the session
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/app/src/components/NewSessionModal.tsx
+++ b/app/src/components/NewSessionModal.tsx
@@ -9,23 +9,51 @@ import {
   type FieldValues,
   type SessionKind,
 } from "../lib/session-kinds";
-import type { Device } from "../lib/api";
+import type { Device, Member } from "../lib/api";
+import { Avatar } from "./Avatar";
+import { displayName } from "../lib/people";
+import { shareCandidates } from "../lib/session-share";
 import { machineOnline } from "../lib/agent";
 import { harnessMissing } from "../lib/harnesses";
 
 interface NewSessionModalProps {
   devices: Device[];
+  /** The team, so the password can be sealed to the people chosen here. */
+  members: Member[];
+  you: Member | null;
   onClose(): void;
-  onStart(input: { deviceId: string; command: string; name: string }): Promise<void>;
+  onStart(input: {
+    deviceId: string;
+    command: string;
+    name: string;
+    share: string[];
+  }): Promise<void>;
 }
 
-export function NewSessionModal({ devices, onClose, onStart }: NewSessionModalProps) {
+export function NewSessionModal({
+  devices,
+  members,
+  you,
+  onClose,
+  onStart,
+}: NewSessionModalProps) {
   const [kind, setKind] = useState<SessionKind>(SESSION_KINDS[0]);
   const [values, setValues] = useState<FieldValues>({});
   const [machine, setMachine] = useState(devices[0]?.id ?? "");
+  const [share, setShare] = useState<ReadonlySet<string>>(() => new Set<string>());
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
   const firstField = useRef<HTMLInputElement | HTMLSelectElement>(null);
+
+  /*
+   * Nobody, until somebody is ticked.
+   *
+   * The password used to be sealed to the whole team the moment a session
+   * started, so every colleague could open every session and nobody was asked.
+   * Starting from nobody makes the answer something chosen rather than
+   * something discovered later.
+   */
+  const { reachable: colleagues, unreachable } = shareCandidates(members, you);
 
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
@@ -68,7 +96,12 @@ export function NewSessionModal({ devices, onClose, onStart }: NewSessionModalPr
     setBusy(true);
     setError("");
     try {
-      await onStart({ deviceId: machine, command, name: sessionName(values, command) });
+      await onStart({
+        deviceId: machine,
+        command,
+        name: sessionName(values, command),
+        share: [...share],
+      });
       onClose();
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : "Could not start that session.");
@@ -209,6 +242,52 @@ export function NewSessionModal({ devices, onClose, onStart }: NewSessionModalPr
                   <b>{chosenMachine.label}</b> is not reachable. Sign in there
                   with <code>shell login</code> and allow browser-started
                   sessions, and this will light up.
+                </span>
+              </p>
+            )}
+
+            {/*
+              * Who gets the password. Nothing is typed: the password is
+              * generated here and sealed to each person ticked, so the choice
+              * is a list of colleagues rather than a secret to invent and pass
+              * around by hand.
+              */}
+            {colleagues.length > 0 && (
+              <fieldset className="share-list">
+                <legend>Who can open it</legend>
+                {colleagues.map((member) => (
+                  <label key={member.uid} className="share-person">
+                    <input
+                      type="checkbox"
+                      checked={share.has(member.uid)}
+                      onChange={(event) =>
+                        setShare((current) => {
+                          const next = new Set(current);
+                          if (event.target.checked) next.add(member.uid);
+                          else next.delete(member.uid);
+                          return next;
+                        })
+                      }
+                    />
+                    <Avatar person={member} size="xs" />
+                    <span className="share-name">{displayName(member)}</span>
+                  </label>
+                ))}
+                <p className="sheet-help">
+                  {share.size === 0
+                    ? "Only you will be able to open this session. You can add people to it afterwards."
+                    : "They can open it without being told anything. You can add more people afterwards."}
+                </p>
+              </fieldset>
+            )}
+
+            {unreachable.length > 0 && (
+              <p className="sheet-note">
+                <Warning size={14} weight="fill" />
+                <span>
+                  {unreachable.length === 1
+                    ? `${displayName(unreachable[0])} has not opened the app in a browser yet, so there is nowhere to send a password. They will appear here once they have.`
+                    : `${unreachable.length} people have not opened the app in a browser yet, so there is nowhere to send them a password.`}
                 </span>
               </p>
             )}

--- a/app/src/components/SessionAudience.tsx
+++ b/app/src/components/SessionAudience.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from "react";
+import { UserPlus } from "@phosphor-icons/react";
+import { Avatar } from "./Avatar";
+import { PersonPicker } from "./PersonPicker";
+import { shareSessionKeys, type Member, type SessionRecord } from "../lib/api";
+import { openSealed, sealForMembers } from "../lib/keypair";
+import { addToAudience, audienceFor, passwordFor } from "../lib/session-passwords";
+import { displayName } from "../lib/people";
+
+/**
+ * Who else can open this session.
+ *
+ * The password is sealed once per person, so this list is the whole of the
+ * answer: a colleague who is not on it holds nothing, whatever the session
+ * says about who it is assigned to. Assigning a session to somebody used to
+ * appear to hand it over because the password had already gone to everyone.
+ *
+ * Only ever adds. Removing somebody here would not reach into their browser
+ * and take back the copy they hold, so a control that offered it would be
+ * describing something that did not happen.
+ */
+export function SessionAudience({
+  session,
+  members,
+  you,
+}: {
+  session: SessionRecord;
+  members: Member[];
+  you: Member | null;
+}) {
+  const [audience, setAudience] = useState<string[]>(() => audienceFor(session.id));
+  const [busy, setBusy] = useState("");
+  const [error, setError] = useState("");
+  const [held, setHeld] = useState(false);
+
+  const isOwner = Boolean(you && session.ownerUid === you.uid);
+
+  /* Only somebody holding the password has anything to seal. */
+  useEffect(() => {
+    let live = true;
+    void (async () => {
+      const own = passwordFor(session.id);
+      if (own) return live && setHeld(true);
+      const share = session.keyShare;
+      const opened = share ? await openSealed(share.senderPublicKey, share.sealed) : null;
+      if (live) setHeld(Boolean(opened));
+    })();
+    return () => {
+      live = false;
+    };
+  }, [session]);
+
+  if (!isOwner || !held) return null;
+
+  const shared = members.filter((member) => audience.includes(member.uid));
+  const candidates = members.filter(
+    (member) =>
+      member.uid !== you?.uid && !audience.includes(member.uid) && Boolean(member.publicKey),
+  );
+
+  async function add(uid: string) {
+    const member = members.find((candidate) => candidate.uid === uid);
+    if (!member?.publicKey) return;
+    const password = passwordFor(session.id);
+    if (!password) return setError("This browser no longer holds the password for this session.");
+
+    setBusy(uid);
+    setError("");
+    try {
+      const sealed = await sealForMembers([member], password);
+      await shareSessionKeys(
+        session.id,
+        sealed.map((entry) => ({
+          uid: entry.uid,
+          sender_public_key: entry.senderPublicKey,
+          sealed: entry.sealed,
+        })),
+      );
+      setAudience(addToAudience(session.id, [uid]));
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Could not share the session.");
+    } finally {
+      setBusy("");
+    }
+  }
+
+  return (
+    <section className="audience">
+      <h2 className="detail-heading">Who can open it</h2>
+
+      {shared.length === 0 ? (
+        <p className="detail-empty">Only you. Add someone and they can open it straight away.</p>
+      ) : (
+        <ul className="audience-list">
+          {shared.map((member) => (
+            <li key={member.uid}>
+              <Avatar person={member} size="xs" />
+              {displayName(member)}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {candidates.length > 0 && (
+        <div className="audience-add">
+          <UserPlus size={15} weight="bold" />
+          <PersonPicker
+            people={candidates}
+            value={undefined}
+            label="Add someone to this session"
+            placeholder={busy ? "Sharing" : "Add someone"}
+            onChange={(uid) => void add(uid)}
+          />
+        </div>
+      )}
+
+      {error && <p className="audience-error">{error}</p>}
+    </section>
+  );
+}

--- a/app/src/components/SessionClipboard.tsx
+++ b/app/src/components/SessionClipboard.tsx
@@ -48,6 +48,17 @@ export function SessionClipboard({
   const isOwner = Boolean(you && session.ownerUid === you.uid);
   const attachCommand = `shell attach ${session.id.slice(0, 10)}`;
 
+  /*
+   * Depends on the sealed material, not on the session object.
+   *
+   * The list is re-fetched every few seconds and hands every row a new object
+   * each time, so this ran an ECDH derivation per session per poll to answer a
+   * question whose inputs had not changed. On a phone with several sessions
+   * open that is most of what the page was doing.
+   */
+  const sealed = session.keyShare
+    ? `${session.keyShare.senderPublicKey}:${session.keyShare.sealed}`
+    : "";
   useEffect(() => {
     let live = true;
     void readPassword(session).then((password) => {
@@ -56,7 +67,8 @@ export function SessionClipboard({
     return () => {
       live = false;
     };
-  }, [session]);
+    /* eslint-disable-next-line react-hooks/exhaustive-deps -- see above */
+  }, [session.id, sealed]);
 
   useEffect(() => {
     if (!open) return;

--- a/app/src/lib/audit-view.test.ts
+++ b/app/src/lib/audit-view.test.ts
@@ -8,6 +8,7 @@ import {
   sessionLabel,
   summarise,
   topCommands,
+  traceGroups,
 } from "./audit-view";
 import type { AuditEvent, SessionRecord } from "./api";
 
@@ -154,5 +155,57 @@ describe("sessionLabel", () => {
     expect(sessionLabel(sessions, "s1")).toBe("nightly build");
     expect(sessionLabel(sessions, "s2")).toBe("htop");
     expect(sessionLabel(sessions, "gone")).toBe("a removed session");
+  });
+});
+
+describe("traceGroups", () => {
+  const minute = 60 * 1000;
+
+  it("shows the most recent run first", () => {
+    const groups = traceGroups([
+      event({ id: "a", at: BASE, text: "first" }),
+      event({ id: "b", at: BASE + 60 * minute, text: "second" }),
+      event({ id: "c", at: BASE + 120 * minute, text: "third" }),
+    ]);
+    expect(groups.map((group) => group.events[0].text)).toEqual(["third", "second", "first"]);
+  });
+
+  it("keeps each run reading forwards inside itself", () => {
+    const groups = traceGroups([
+      event({ id: "b", at: BASE + 2 * minute, text: "then" }),
+      event({ id: "a", at: BASE, text: "first" }),
+      event({ id: "c", at: BASE + 4 * minute, text: "last" }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].events.map((entry) => entry.text)).toEqual(["first", "then", "last"]);
+  });
+
+  it("starts a new run for a different person", () => {
+    const groups = traceGroups([
+      event({ id: "a", at: BASE, actorUid: "u1" }),
+      event({ id: "b", at: BASE + minute, actorUid: "u2" }),
+    ]);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].actorUid).toBe("u2");
+  });
+
+  it("starts a new run for a different session", () => {
+    const groups = traceGroups([
+      event({ id: "a", at: BASE, sessionId: "s1" }),
+      event({ id: "b", at: BASE + minute, sessionId: "s2" }),
+    ]);
+    expect(groups).toHaveLength(2);
+  });
+
+  it("starts a new run after a long quiet gap", () => {
+    const groups = traceGroups([
+      event({ id: "a", at: BASE }),
+      event({ id: "b", at: BASE + 11 * minute }),
+    ]);
+    expect(groups).toHaveLength(2);
+  });
+
+  it("has nothing to group in an empty trail", () => {
+    expect(traceGroups([])).toEqual([]);
   });
 });

--- a/app/src/lib/audit-view.ts
+++ b/app/src/lib/audit-view.ts
@@ -150,3 +150,45 @@ export function sessionLabel(
 export function memberOf(members: Member[], uid: string): Member | undefined {
   return members.find((member) => member.uid === uid);
 }
+
+export interface TraceGroup {
+  key: string;
+  actorUid: string;
+  sessionId: string;
+  events: AuditEvent[];
+}
+
+/** How long a gap ends a run, rather than continuing one. */
+const RUN_GAP_MS = 10 * 60 * 1000;
+
+/**
+ * Groups the trail into runs: one person, in one session, without a long gap.
+ *
+ * Each run reads forwards, because that is the order the person did things in.
+ * The runs themselves read backwards, newest first: what somebody ran a few
+ * minutes ago is the reason to open this page, and it was at the bottom.
+ */
+export function traceGroups(events: AuditEvent[]): TraceGroup[] {
+  const ordered = [...events].sort((a, b) => a.at - b.at);
+  const groups: TraceGroup[] = [];
+
+  for (const event of ordered) {
+    const last = groups[groups.length - 1];
+    const sameRun =
+      last &&
+      last.actorUid === event.actorUid &&
+      last.sessionId === event.sessionId &&
+      event.at - last.events[last.events.length - 1].at < RUN_GAP_MS;
+    if (sameRun) last.events.push(event);
+    else {
+      groups.push({
+        key: event.id,
+        actorUid: event.actorUid,
+        sessionId: event.sessionId,
+        events: [event],
+      });
+    }
+  }
+
+  return groups.reverse();
+}

--- a/app/src/lib/session-kinds.test.ts
+++ b/app/src/lib/session-kinds.test.ts
@@ -278,6 +278,28 @@ describe("the kind of a session started from the browser", () => {
    * An older CLI recorded the argv it was given by joining it with spaces, so
    * the quotes that made the wrapped line one argument are gone from the row.
    */
+  it("passes a chosen model through, and says nothing when none is chosen", () => {
+    const claude = SESSION_KINDS.find((kind) => kind.id === "claude-code")!;
+    expect(claude.build({ model: "opus" })).toBe("claude --model opus");
+    expect(claude.build({})).toBe("claude");
+    expect(claude.build({ model: "opus", skipPermissions: true })).toBe(
+      "claude --model opus --dangerously-skip-permissions",
+    );
+
+    const codex = SESSION_KINDS.find((kind) => kind.id === "codex")!;
+    expect(codex.build({ model: "gpt-5-codex" })).toBe("codex --model gpt-5-codex");
+    expect(codex.build({})).toBe("codex");
+    /* The model goes with the other options, after any resume subcommand. */
+    expect(codex.build({ resumeLast: true, model: "gpt-5-codex", search: true })).toBe(
+      "codex resume --last --model gpt-5-codex --search",
+    );
+  });
+
+  it("quotes a model name that would otherwise split", () => {
+    const codex = SESSION_KINDS.find((kind) => kind.id === "codex")!;
+    expect(codex.build({ model: "some model" })).toBe("codex --model 'some model'");
+  });
+
   it("unwraps a shell whose quotes were lost on the way to the record", () => {
     expect(unwrapShell("sh -c claude")).toBe("claude");
     expect(unwrapShell("sh -c claude --dangerously-skip-permissions")).toBe(

--- a/app/src/lib/session-kinds.ts
+++ b/app/src/lib/session-kinds.ts
@@ -67,6 +67,18 @@ export const SESSION_KINDS: SessionKind[] = [
         help: "Passed to --resume.",
       },
       {
+        name: "model",
+        label: "Model",
+        kind: "select",
+        options: [
+          { value: "", label: "Whatever the machine is set to" },
+          { value: "opus", label: "Opus" },
+          { value: "sonnet", label: "Sonnet" },
+          { value: "haiku", label: "Haiku" },
+        ],
+        help: "Passed to --model. Left alone, the machine's own default is used.",
+      },
+      {
         name: "skipPermissions",
         label: "Skip permission checks",
         kind: "toggle",
@@ -78,6 +90,8 @@ export const SESSION_KINDS: SessionKind[] = [
       const parts = ["claude"];
       const id = text(values, "sessionId");
       if (id) parts.push("--resume", quote(id));
+      const model = text(values, "model");
+      if (model) parts.push("--model", quote(model));
       if (on(values, "skipPermissions")) parts.push("--dangerously-skip-permissions");
       return parts.join(" ");
     },
@@ -94,6 +108,13 @@ export const SESSION_KINDS: SessionKind[] = [
         kind: "text",
         placeholder: "leave empty to start fresh",
         help: "Runs codex resume <id>. Accepts a session UUID or a session name.",
+      },
+      {
+        name: "model",
+        label: "Model",
+        kind: "text",
+        placeholder: "leave empty for the codex default",
+        help: "Passed to --model as written.",
       },
       {
         name: "resumeLast",
@@ -142,6 +163,8 @@ export const SESSION_KINDS: SessionKind[] = [
       const id = text(values, "sessionId");
       if (id) parts.push("resume", quote(id));
       else if (on(values, "resumeLast")) parts.push("resume", "--last");
+      const model = text(values, "model");
+      if (model) parts.push("--model", quote(model));
       const sandbox = text(values, "sandbox");
       if (sandbox) parts.push("--sandbox", sandbox);
       const approval = text(values, "approval");

--- a/app/src/lib/session-passwords.test.ts
+++ b/app/src/lib/session-passwords.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  adoptOrigin, forget, forgetAll, passwordFor, rememberForOrigin, setPasswordOwner,
+  addToAudience, adoptOrigin, audienceFor, forget, forgetAll, passwordFor,
+  rememberFor, rememberForOrigin, setPasswordOwner,
 } from "./session-passwords";
 
 function fakeStorage() {
@@ -127,5 +128,65 @@ describe("passwords belong to one account", () => {
     forget("sess_1");
     expect(passwordFor("sess_1")).toBeNull();
     expect(passwordFor("sess_2")).toBe("b");
+  });
+
+  /*
+   * The audience is who this browser has sealed the password to. It travels
+   * with the password because it is the same secret, and because the service
+   * is not the record of who can read a session it cannot read itself.
+   */
+  it("carries the chosen audience from the request to the session", () => {
+    setPasswordOwner("uid-1");
+    rememberForOrigin("cmd_1", "Kw9eHbru", ["uid-2", "uid-3"]);
+    adoptOrigin("cmd_1", "sess_1");
+    expect(passwordFor("sess_1")).toBe("Kw9eHbru");
+    expect(audienceFor("sess_1").sort()).toEqual(["uid-2", "uid-3"]);
+  });
+
+  it("shares with nobody when nobody was chosen", () => {
+    setPasswordOwner("uid-1");
+    rememberForOrigin("cmd_1", "Kw9eHbru");
+    adoptOrigin("cmd_1", "sess_1");
+    expect(audienceFor("sess_1")).toEqual([]);
+  });
+
+  it("adds people afterwards without repeating anyone", () => {
+    setPasswordOwner("uid-1");
+    rememberForOrigin("cmd_1", "Kw9eHbru", ["uid-2"]);
+    adoptOrigin("cmd_1", "sess_1");
+    addToAudience("sess_1", ["uid-3", "uid-2"]);
+    expect(audienceFor("sess_1").sort()).toEqual(["uid-2", "uid-3"]);
+  });
+
+  it("has no audience to add to for a session whose password it does not hold", () => {
+    setPasswordOwner("uid-1");
+    expect(addToAudience("sess_unknown", ["uid-2"])).toEqual([]);
+    expect(audienceFor("sess_unknown")).toEqual([]);
+  });
+
+  /* A password typed at the gate is kept, or the next reload asks again. */
+  it("keeps a password recorded against a session directly", () => {
+    setPasswordOwner("uid-1");
+    rememberFor("sess_1", "typed-in");
+    expect(passwordFor("sess_1")).toBe("typed-in");
+  });
+
+  it("does not lose the audience when the password is recorded again", () => {
+    setPasswordOwner("uid-1");
+    rememberForOrigin("cmd_1", "first", ["uid-2"]);
+    adoptOrigin("cmd_1", "sess_1");
+    rememberFor("sess_1", "second");
+    expect(passwordFor("sess_1")).toBe("second");
+    expect(audienceFor("sess_1")).toEqual(["uid-2"]);
+  });
+
+  it("keeps one account's audience away from another's", () => {
+    setPasswordOwner("uid-1");
+    rememberForOrigin("cmd_1", "mine", ["uid-2"]);
+    adoptOrigin("cmd_1", "sess_1");
+
+    setPasswordOwner("uid-9");
+    expect(passwordFor("sess_1")).toBeNull();
+    expect(audienceFor("sess_1")).toEqual([]);
   });
 });

--- a/app/src/lib/session-passwords.ts
+++ b/app/src/lib/session-passwords.ts
@@ -1,17 +1,28 @@
 /**
- * Passwords for sessions this browser started.
+ * Passwords for sessions this browser knows, and who they were shared with.
  *
  * A session started from here has a password this browser chose, so there is
- * nothing to prompt for. It is kept in localStorage, per origin, and never
- * sent anywhere: the accounts service only ever saw it sealed to the machine.
+ * nothing to prompt for. A password typed into the gate is kept too, so a
+ * session started from a terminal asks once rather than on every reload. It
+ * lives in localStorage, per origin, and is never sent anywhere: the accounts
+ * service only ever saw it sealed to a machine or to a colleague.
  *
- * Sessions started from a terminal are not in here, and still prompt.
+ * The audience is stored with it because it is the same secret: it is the list
+ * of colleagues this browser has sealed the password to. The service is not
+ * asked who that is, because the service is not trusted with the password and
+ * should not be the record of who can read it either.
  */
 
-const KEY = "shell.online:session-passwords:v2";
+const KEY = "shell.online:session-passwords:v3";
 const MAX_ENTRIES = 50;
 
-type Store = Record<string, string>;
+interface Entry {
+  password: string;
+  /** Team members this password has been, or is to be, sealed to. */
+  audience?: string[];
+}
+
+type Store = Record<string, Entry>;
 
 /*
  * Scoped to the signed-in account. Without this, signing out and signing in as
@@ -56,11 +67,11 @@ function write(store: Store): void {
   }
 }
 
-/** Remembers a password against the request that will produce a session. */
-export function rememberForOrigin(origin: string, password: string): void {
+/** Remembers a password, and its audience, against the request that will produce a session. */
+export function rememberForOrigin(origin: string, password: string, audience: string[] = []): void {
   if (!origin || !password) return;
   const store = read();
-  store[scoped(`origin:${origin}`)] = password;
+  store[scoped(`origin:${origin}`)] = { password, audience: [...audience] };
   write(trim(store));
 }
 
@@ -68,23 +79,49 @@ export function rememberForOrigin(origin: string, password: string): void {
 export function adoptOrigin(origin: string | undefined, sessionId: string): void {
   if (!origin || !sessionId) return;
   const store = read();
-  const password = store[scoped(`origin:${origin}`)];
-  if (!password) return;
+  const entry = store[scoped(`origin:${origin}`)];
+  if (!entry) return;
   delete store[scoped(`origin:${origin}`)];
-  store[scoped(`session:${sessionId}`)] = password;
+  store[scoped(`session:${sessionId}`)] = entry;
   write(trim(store));
 }
 
-/** Records a password against a session directly. */
+/** Records a password against a session directly, keeping any audience it has. */
 export function rememberFor(sessionId: string, password: string): void {
   if (!sessionId || !password) return;
   const store = read();
-  store[scoped(`session:${sessionId}`)] = password;
+  const key = scoped(`session:${sessionId}`);
+  store[key] = { password, audience: store[key]?.audience ?? [] };
   write(trim(store));
 }
 
 export function passwordFor(sessionId: string): string | null {
-  return read()[scoped(`session:${sessionId}`)] ?? null;
+  return read()[scoped(`session:${sessionId}`)]?.password ?? null;
+}
+
+/** Who this browser has sealed the password to, besides the person holding it. */
+export function audienceFor(sessionId: string): string[] {
+  return read()[scoped(`session:${sessionId}`)]?.audience ?? [];
+}
+
+/**
+ * Adds people to a session's audience.
+ *
+ * Only ever adds. Taking someone off the list would not take the copy they
+ * already hold out of their browser, so a control that appeared to revoke
+ * would be lying about what it did.
+ */
+export function addToAudience(sessionId: string, uids: string[]): string[] {
+  const store = read();
+  const key = scoped(`session:${sessionId}`);
+  const entry = store[key];
+  if (!entry) return [];
+  const audience = new Set(entry.audience ?? []);
+  for (const uid of uids) if (uid) audience.add(uid);
+  entry.audience = [...audience];
+  store[key] = entry;
+  write(trim(store));
+  return entry.audience;
 }
 
 export function forget(sessionId: string): void {

--- a/app/src/lib/session-share.test.ts
+++ b/app/src/lib/session-share.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { sealTargets, shareCandidates } from "./session-share";
+import type { Member } from "./api";
+
+function member(uid: string, publicKey?: string): Member {
+  return {
+    orgId: "org",
+    uid,
+    email: `${uid}@example.com`,
+    name: uid,
+    role: "member",
+    joinedAt: 0,
+    publicKey,
+  };
+}
+
+const you = member("me", "key-me");
+
+describe("who can be offered a session password", () => {
+  it("leaves you off your own list", () => {
+    const { reachable } = shareCandidates([you, member("a", "key-a")], you);
+    expect(reachable.map((entry) => entry.uid)).toEqual(["a"]);
+  });
+
+  it("separates people with no browser key from people with one", () => {
+    const { reachable, unreachable } = shareCandidates(
+      [you, member("a", "key-a"), member("b")],
+      you,
+    );
+    expect(reachable.map((entry) => entry.uid)).toEqual(["a"]);
+    expect(unreachable.map((entry) => entry.uid)).toEqual(["b"]);
+  });
+
+  it("offers the whole team to somebody who is not in it", () => {
+    const { reachable } = shareCandidates([member("a", "key-a")], null);
+    expect(reachable.map((entry) => entry.uid)).toEqual(["a"]);
+  });
+});
+
+describe("who a session password is sealed to", () => {
+  const team = [you, member("a", "key-a"), member("b", "key-b"), member("c")];
+
+  /* The property that matters: not choosing somebody is not sharing with them. */
+  it("seals to nobody when nobody was chosen", () => {
+    expect(sealTargets({ members: team, you, chosen: [] })).toEqual([]);
+  });
+
+  it("seals only to the people chosen", () => {
+    const targets = sealTargets({ members: team, you, chosen: ["a"] });
+    expect(targets.map((entry) => entry.uid)).toEqual(["a"]);
+  });
+
+  it("never seals to you, even if you are on the list", () => {
+    const targets = sealTargets({ members: team, you, chosen: ["me", "a"] });
+    expect(targets.map((entry) => entry.uid)).toEqual(["a"]);
+  });
+
+  it("skips somebody chosen who has no key to seal to", () => {
+    const targets = sealTargets({ members: team, you, chosen: ["c"] });
+    expect(targets).toEqual([]);
+  });
+
+  it("does not seal twice to the same person", () => {
+    const targets = sealTargets({
+      members: team,
+      you,
+      chosen: ["a", "b"],
+      done: new Set(["a"]),
+    });
+    expect(targets.map((entry) => entry.uid)).toEqual(["b"]);
+  });
+
+  it("ignores a chosen uid that is not in the team", () => {
+    const targets = sealTargets({ members: team, you, chosen: ["nobody"] });
+    expect(targets).toEqual([]);
+  });
+});

--- a/app/src/lib/session-share.ts
+++ b/app/src/lib/session-share.ts
@@ -1,0 +1,51 @@
+import type { Member } from "./api";
+
+/**
+ * Who a session's password goes to.
+ *
+ * This is the whole of the access rule. A colleague who was not sealed to
+ * holds nothing: not a weaker copy, not a copy the service could hand over,
+ * nothing. So the two questions here — who can be offered the password, and
+ * who still needs it sealed to them — are worth having on their own rather
+ * than inside a component where they cannot be tested.
+ */
+
+/**
+ * Splits the team into people a password can reach and people it cannot.
+ *
+ * A member who has never opened the app in a browser has published no public
+ * key, so there is nowhere to send them anything. Offering them a tick box
+ * would be offering something that silently does nothing.
+ */
+export function shareCandidates(
+  members: Member[],
+  you: Member | null,
+): { reachable: Member[]; unreachable: Member[] } {
+  const others = members.filter((member) => member.uid !== you?.uid);
+  return {
+    reachable: others.filter((member) => Boolean(member.publicKey)),
+    unreachable: others.filter((member) => !member.publicKey),
+  };
+}
+
+/**
+ * Who still needs this session's password sealed to them.
+ *
+ * Chosen, reachable, not you, and not already done. The chosen list used to be
+ * missing from this: every session was sealed to the whole team the moment it
+ * started, so everyone could open everything and nobody was ever asked.
+ */
+export function sealTargets(input: {
+  members: Member[];
+  you: Member | null;
+  /** The people picked for this session. */
+  chosen: readonly string[];
+  /** The people already sealed to in this browser's lifetime. */
+  done?: ReadonlySet<string>;
+}): Member[] {
+  const chosen = new Set(input.chosen);
+  const done = input.done ?? new Set<string>();
+  return shareCandidates(input.members, input.you).reachable.filter(
+    (member) => chosen.has(member.uid) && !done.has(member.uid),
+  );
+}

--- a/app/src/routes/Account.tsx
+++ b/app/src/routes/Account.tsx
@@ -35,8 +35,6 @@ export function Account() {
 
   return (
     <AppShell title="Account">
-      <p className="page-dek">Who you are signed in as.</p>
-
       {notice && <div className="sessions-alert"><Alert tone="success">{notice}</Alert></div>}
       {error && <div className="sessions-alert"><Alert tone="error">{error}</Alert></div>}
 

--- a/app/src/routes/Audit.tsx
+++ b/app/src/routes/Audit.tsx
@@ -29,6 +29,7 @@ import {
   sessionLabel,
   summarise,
   topCommands,
+  traceGroups,
   type Filters,
 } from "../lib/audit-view";
 import { usePageTitle } from "../lib/page-title";
@@ -306,7 +307,7 @@ export function Audit() {
             <div className="chart-row">
               <ActivityChart events={shown} />
               <RankChart
-                caption="Who"
+                caption="By user"
                 rows={byActor(shown).slice(0, 6)}
                 onPick={(uid) => set({ actor: uid === filters.actor ? "" : uid })}
                 render={(uid) => {
@@ -374,27 +375,7 @@ function Trace({
   members: Member[];
   sessions: SessionRecord[];
 }) {
-  /* Oldest first inside the page, so a trace reads forwards. */
-  const ordered = [...events].sort((a, b) => a.at - b.at);
-  const groups: { key: string; actorUid: string; sessionId: string; events: AuditEvent[] }[] = [];
-
-  for (const event of ordered) {
-    const last = groups[groups.length - 1];
-    const sameRun =
-      last &&
-      last.actorUid === event.actorUid &&
-      last.sessionId === event.sessionId &&
-      event.at - last.events[last.events.length - 1].at < 10 * 60 * 1000;
-    if (sameRun) last.events.push(event);
-    else {
-      groups.push({
-        key: `${event.id}`,
-        actorUid: event.actorUid,
-        sessionId: event.sessionId,
-        events: [event],
-      });
-    }
-  }
+  const groups = traceGroups(events);
 
   let lastDay = "";
   return (

--- a/app/src/routes/Session.tsx
+++ b/app/src/routes/Session.tsx
@@ -2,8 +2,6 @@ import { useCallback, useEffect, useRef, useState, type FormEvent } from "react"
 import { Link, useParams } from "react-router-dom";
 import {
   ArrowLeft,
-  Copy,
-  Check,
   PaperPlaneTilt,
   Terminal as TerminalIcon,
 } from "@phosphor-icons/react";
@@ -13,6 +11,8 @@ import { PersonPicker } from "../components/PersonPicker";
 import { Button } from "../components/Button";
 import { Alert } from "../components/Alert";
 import { Booting } from "../components/Booting";
+import { SessionClipboard } from "../components/SessionClipboard";
+import { SessionAudience } from "../components/SessionAudience";
 import {
   assignSession,
   fetchSession,
@@ -67,7 +67,6 @@ export function Session() {
   const [error, setError] = useState("");
   const [draft, setDraft] = useState("");
   const [posting, setPosting] = useState(false);
-  const [copied, setCopied] = useState(false);
   const composer = useRef<HTMLTextAreaElement>(null);
 
   const load = useCallback(async () => {
@@ -157,23 +156,15 @@ export function Session() {
                 Open terminal
               </Link>
             )}
-            <button
-              type="button"
-              className="session-action"
-              onClick={async () => {
-                try {
-                  await navigator.clipboard.writeText(session.shareUrl);
-                  setCopied(true);
-                  window.setTimeout(() => setCopied(false), 1600);
-                } catch {
-                  /* clipboard is unavailable outside a secure context */
-                }
-              }}
-            >
-              {copied ? <Check size={15} weight="bold" /> : <Copy size={15} />}
-              {copied ? "Copied" : "Copy link"}
-            </button>
+            {/*
+              * The same menu the list has. A bare "Copy link" here meant the
+              * password was reachable from one screen and not the other, which
+              * on a phone is the screen you are actually on.
+              */}
+            <SessionClipboard session={session} you={you} />
           </div>
+
+          <SessionAudience session={session} members={members} you={you} />
 
           <h2 className="detail-heading">Comments</h2>
 

--- a/app/src/routes/Team.tsx
+++ b/app/src/routes/Team.tsx
@@ -275,12 +275,6 @@ export function Team() {
                   Create invite
                 </Button>
               </form>
-              <p className="sessions-note">
-                Give an address and we email them the link. Leaving it blank
-                creates a link anyone can use, so send that one carefully.
-                Either way it works once and expires in seven days.
-              </p>
-
               <h2 className="invites-heading">Invites</h2>
 
               {view.invites.length > 0 && (

--- a/app/src/routes/Workspace.tsx
+++ b/app/src/routes/Workspace.tsx
@@ -7,6 +7,7 @@ import { findPerson } from "../lib/people";
 import { kindForCommand } from "../lib/session-kinds";
 import { canEdit, canHandOff, canRemove, canStop, matches } from "../lib/session-view";
 import { NewSessionModal } from "../components/NewSessionModal";
+import { LaunchPrompt } from "../components/LaunchPrompt";
 import { SessionBoard } from "../components/SessionBoard";
 import { SessionClipboard } from "../components/SessionClipboard";
 import { SignedInModal } from "../components/SignedInModal";
@@ -29,8 +30,17 @@ import {
 } from "../lib/api";
 import { generatePassword, sealPassword } from "../lib/seal";
 import { publicKey, sealForMembers } from "../lib/keypair";
+import { sealTargets } from "../lib/session-share";
 import { fetchOrg, shareSessionKeys } from "../lib/api";
-import { adoptOrigin, forget, passwordFor, rememberFor, rememberForOrigin } from "../lib/session-passwords";
+import {
+  adoptOrigin,
+  audienceFor,
+  forget,
+  passwordFor,
+  rememberFor,
+  rememberForOrigin,
+} from "../lib/session-passwords";
+import { useKeyboardInset } from "../terminal/keyboard-inset";
 import { elapsed } from "../lib/time";
 import { usePageTitle } from "../lib/page-title";
 import { wasJustLinked, withoutLinkedFlag } from "../lib/linked";
@@ -40,6 +50,8 @@ const POLL_MS = 4000;
 const DEVICE_POLL_MS = 5000;
 /* Long enough for the agent to poll, launch, and for the session to publish. */
 const AFTER_COMMAND_MS = 1500;
+/* How long to wait for a started session before saying so. */
+const LAUNCH_PATIENCE_MS = 45_000;
 
 /*
  * Removes a session from the lists. Asks first, because it cannot be undone
@@ -121,6 +133,10 @@ export function Workspace() {
   const [devices, setDevices] = useState<Device[]>([]);
   const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
+  /* The session being started, from the request until its row turns up. */
+  const [launching, setLaunching] = useState("");
+  /* The one that just turned up, waiting to be opened or dismissed. */
+  const [launched, setLaunched] = useState<SessionRecord | null>(null);
   const [now, setNow] = useState(() => Date.now());
   const [composing, setComposing] = useState(false);
   const [killing, setKilling] = useState("");
@@ -138,6 +154,10 @@ export function Workspace() {
   const loadedOnce = useRef(false);
   /* Tabs are put back once, from the first session list a reload receives. */
   const restoredTabs = useRef(false);
+  /* Sized to the space a phone keyboard leaves; see useKeyboardInset. */
+  const panes = useRef<HTMLDivElement>(null);
+  /* Requests whose session should be offered as soon as it exists: origin -> name. */
+  const awaitingOpen = useRef(new Map<string, string>());
   /* Passwords waiting for their session to appear so they can be shared. */
   const pendingShares = useRef(new Map<string, string>());
   /* Who each session has already been shared with, so polling is not chatty. */
@@ -157,6 +177,22 @@ export function Workspace() {
       const result = await fetchSessions();
       /* A session that came from this browser inherits the password it chose. */
       for (const session of result.sessions) adoptOrigin(session.origin, session.id);
+      /*
+       * A machine has to poll, launch and publish before a session exists, so
+       * the row arrives some seconds after the request. Saying "it will turn
+       * up" and leaving somebody to watch the list for it is the wrong end of
+       * that: the request is remembered here and its session offered the
+       * moment it appears.
+       */
+      const arrived = result.sessions.find(
+        (session) => session.origin && awaitingOpen.current.has(session.origin),
+      );
+      if (arrived?.origin) {
+        awaitingOpen.current.delete(arrived.origin);
+        setLaunching("");
+        setNotice("");
+        setLaunched(arrived);
+      }
       setSessions(result.sessions);
       setMembers(result.members ?? []);
       setYou(result.you ?? null);
@@ -235,7 +271,13 @@ export function Workspace() {
     return () => window.clearInterval(poll);
   }, []);
 
-  async function handleStart(input: { deviceId: string; command: string; name: string }) {
+  async function handleStart(input: {
+    deviceId: string;
+    command: string;
+    name: string;
+    /* Team members to seal the password to. Empty means only this browser. */
+    share: string[];
+  }) {
     setError("");
     setNotice("");
 
@@ -255,10 +297,10 @@ export function Workspace() {
 
     const queued = await startSession({ ...input, ...sealed });
     if (password) {
-      rememberForOrigin(queued.command.id, password);
+      rememberForOrigin(queued.command.id, password, input.share);
       /*
-       * Colleagues can read this session, so the password is sealed to each of
-       * them too. Held here until the session exists to attach it to.
+       * Held here until the session exists to attach the password to. The
+       * colleagues chosen above are sealed to on the poll that finds it.
        */
       pendingShares.current.set(queued.command.id, password);
     }
@@ -266,8 +308,21 @@ export function Workspace() {
      * The machine has to poll, launch, and publish, so the row shows up a
      * moment later rather than on this response.
      */
-    setNotice(`Starting ${input.name}. It appears here once the machine picks it up.`);
+    awaitingOpen.current.set(queued.command.id, input.name);
+    setLaunching(input.name);
     window.setTimeout(() => void load(), AFTER_COMMAND_MS);
+    /*
+     * A machine that is asleep, or that cannot run the command, never
+     * publishes anything. Waiting for it forever leaves a spinner that is
+     * telling the truth about nothing, so it gives up and says what happened.
+     */
+    window.setTimeout(() => {
+      if (!awaitingOpen.current.delete(queued.command.id)) return;
+      setLaunching("");
+      setNotice(
+        `${input.name} has not appeared yet. The machine may be busy or asleep; it will show up here when it starts.`,
+      );
+    }, LAUNCH_PATIENCE_MS);
   }
 
   async function handleKill(session: SessionRecord) {
@@ -310,16 +365,18 @@ export function Workspace() {
   }
 
   /*
-   * Sessions started here have a password only this browser knows. Seal it to
-   * every colleague so they can read the session too.
+   * Seals a session's password to the colleagues it was shared with.
    *
-   * Runs on each poll rather than once, because someone can join the
-   * team after a session started, and should still be able to open it.
+   * The audience is the list ticked when the session was started, plus anyone
+   * added since. It used to be everyone in the team, which meant every
+   * colleague could open every session and the choice was never offered: what
+   * looked like assigning a session to somebody was really discovering that
+   * they had held the password all along.
+   *
+   * Runs on each poll rather than once, because a browser that was closed
+   * between starting a session and it appearing still has sealing to do.
    */
   async function shareAnyPending(all: SessionRecord[], roster: Member[], me: Member | null) {
-    const targets = roster.filter((member) => member.publicKey);
-    if (targets.length === 0) return;
-
     for (const session of all) {
       if (session.closedAt) continue;
 
@@ -335,9 +392,12 @@ export function Workspace() {
       const password = passwordFor(session.id);
       if (!password) continue;
 
-      const missing = targets.filter(
-        (member) => member.uid !== me?.uid && !sharedWith.current.get(session.id)?.has(member.uid),
-      );
+      const missing = sealTargets({
+        members: roster,
+        you: me,
+        chosen: audienceFor(session.id),
+        done: sharedWith.current.get(session.id),
+      });
       if (missing.length === 0) continue;
 
       try {
@@ -385,6 +445,7 @@ export function Workspace() {
   const openSession = (session: SessionRecord) =>
     dispatch({ type: "open", session, canType: canEdit(session, you) });
   const showingList = state.activeId === null;
+  useKeyboardInset(panes, !showingList);
 
   return (
     <AppShell
@@ -451,7 +512,7 @@ export function Workspace() {
         alive while another tab is in front.
       */}
       {state.tabs.length > 0 && (
-        <div className="panes" hidden={showingList}>
+        <div className="panes" ref={panes} hidden={showingList}>
           {state.tabs.map((tab) => {
             /*
              * Permission is read from the session list on every render, not
@@ -479,6 +540,13 @@ export function Workspace() {
       )}
 
       <div className="workspace-list" hidden={!showingList}>
+        {launching && (
+          /* Something to watch while the machine picks the request up. */
+          <p className="sessions-launching" role="status">
+            <span className="sessions-spinner" aria-hidden="true" />
+            Starting {launching} on the machine
+          </p>
+        )}
         {notice && (
           <div className="sessions-alert">
             <Alert tone="success">{notice}</Alert>
@@ -633,9 +701,22 @@ export function Workspace() {
         )}
       </div>
 
+      {launched && (
+        <LaunchPrompt
+          session={launched}
+          onOpen={() => {
+            openSession(launched);
+            setLaunched(null);
+          }}
+          onClose={() => setLaunched(null)}
+        />
+      )}
+
       {composing && (
         <NewSessionModal
           devices={devices}
+          members={members}
+          you={you}
           onClose={() => setComposing(false)}
           onStart={handleStart}
         />
@@ -745,8 +826,13 @@ function SessionGroup({
                     </>
                   )}
                 </td>
-                <td className="table-person"><PersonChip person={owner} /></td>
-                <td className="table-person">
+                {/*
+                  * The label is carried on the cell, not only in the header:
+                  * on a phone the table stacks and the header is gone, and two
+                  * unlabelled faces in a row do not say which is which.
+                  */}
+                <td className="table-person" data-label="Owner"><PersonChip person={owner} /></td>
+                <td className="table-person" data-label="Assignee">
                   {live && canHandOff(session, you) ? (
                     <PersonPicker
                       people={members}
@@ -758,8 +844,8 @@ function SessionGroup({
                     <PersonChip person={assignee} />
                   )}
                 </td>
-                <td className="table-quiet">{session.host || "unknown"}</td>
-                <td className="table-quiet">
+                <td className="table-quiet" data-label="Machine">{session.host || "unknown"}</td>
+                <td className="table-quiet" data-label={live ? "Uptime" : "Ran for"}>
                   {live
                     ? elapsed(session.startedAt, now)
                     : elapsed(session.startedAt, session.closedAt ?? now)}

--- a/app/src/styles/people.css
+++ b/app/src/styles/people.css
@@ -405,6 +405,25 @@
     padding: 4px 0;
   }
 
+  /*
+   * The header is gone in this layout, so each cell carries its own. Without
+   * it the owner and the assignee are two faces in a row with nothing saying
+   * which is which.
+   */
+  .table td[data-label]::before {
+    display: block;
+    margin-bottom: 2px;
+    color: var(--faint);
+    content: attr(data-label);
+    font-size: 11px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .table td[data-label] {
+    padding: 7px 0;
+  }
+
   .table-end,
   .table-end .session-actions {
     justify-content: flex-start;

--- a/app/src/styles/shell.css
+++ b/app/src/styles/shell.css
@@ -140,8 +140,29 @@
   gap: 18px;
 }
 
+/*
+ * The wordmark lives in the rail on a desktop and in the bar on a phone, where
+ * the rail has become a strip of destinations along the bottom. Hidden by
+ * default rather than added on a phone, so there is only one of it on screen.
+ */
+.topbar-mark {
+  display: none;
+  align-items: center;
+  padding-right: 4px;
+}
+
+.topbar-heading {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 12px;
+}
+
 .topbar-title {
   margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--ink);
   font-size: 22px;
   font-weight: 500;
@@ -152,6 +173,11 @@
   display: flex;
   align-items: center;
   gap: 16px;
+}
+
+/* Shown only where the rail's foot is not; see the phone block below. */
+.topbar-account {
+  display: none;
 }
 
 .new-session {
@@ -516,8 +542,35 @@
     padding-bottom: calc(74px + env(safe-area-inset-bottom));
   }
 
+  /*
+   * Saved to the home screen there is no browser chrome above this, so the bar
+   * begins under the status bar and has to push itself clear. The inset is
+   * added to the bar rather than taken out of it: `height` with a padding on
+   * top left the title squeezed into whatever the notch did not claim, which
+   * is what a home-screen install looked like.
+   */
   .topbar {
+    height: auto;
+    min-height: calc(56px + env(safe-area-inset-top));
     padding-top: env(safe-area-inset-top);
+  }
+
+  /* The rail is a bottom bar here, so the wordmark and the account menu have
+     nowhere else to be. */
+  .topbar-mark {
+    display: flex;
+  }
+
+  .topbar-account {
+    display: block;
+  }
+
+  .topbar-right {
+    gap: 10px;
+  }
+
+  .topbar-title {
+    font-size: 19px;
   }
 
   .topbar-inner {

--- a/app/src/styles/terminal.css
+++ b/app/src/styles/terminal.css
@@ -314,8 +314,15 @@ button.tab {
 }
 
 @media (max-width: 900px) {
+  /*
+   * A phone's keyboard covers the bottom of the page rather than making the
+   * page shorter, and the prompt is at the bottom of a terminal, so the line
+   * being typed was the first thing to disappear behind it. --pane-height is
+   * what the visual viewport has left below this element; see keyboard-inset.
+   */
   .panes {
-    min-height: 60dvh;
+    height: var(--pane-height, 60dvh);
+    min-height: 0;
   }
 
   .pane {
@@ -1041,4 +1048,161 @@ button.tab {
   letter-spacing: 0.04em;
   text-transform: uppercase;
   vertical-align: middle;
+}
+
+/* ---------------------------------------------------------------
+   Who a session's password is sealed to
+   ---------------------------------------------------------------
+   A list of people rather than a password field: the password is generated
+   and sealed per person, so the only decision left is who.
+   --------------------------------------------------------------- */
+
+.share-list {
+  margin: 0;
+  padding: 12px 14px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-panel);
+}
+
+.share-list legend {
+  padding: 0 6px;
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.share-person {
+  display: flex;
+  padding: 5px 0;
+  align-items: center;
+  cursor: pointer;
+  gap: 9px;
+}
+
+.share-person input {
+  width: 16px;
+  height: 16px;
+  flex: none;
+  accent-color: var(--ink);
+}
+
+.share-name {
+  overflow: hidden;
+  color: var(--ink);
+  font-size: 13.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.share-list .sheet-help {
+  margin-top: 8px;
+}
+
+/* The same list, on a session that already exists. */
+.audience {
+  margin-top: 26px;
+}
+
+.audience-list {
+  display: flex;
+  margin: 0 0 12px;
+  padding: 0;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  list-style: none;
+}
+
+.audience-list li {
+  display: flex;
+  align-items: center;
+  color: var(--ink);
+  font-size: 13.5px;
+  gap: 8px;
+}
+
+.audience-add {
+  display: flex;
+  align-items: center;
+  color: var(--faint);
+  gap: 8px;
+}
+
+.audience-error {
+  margin: 10px 0 0;
+  color: var(--danger);
+  font-size: 13px;
+}
+
+/* ---------------------------------------------------------------
+   Starting a session
+   --------------------------------------------------------------- */
+
+.sessions-launching {
+  display: flex;
+  margin: 0 0 16px;
+  align-items: center;
+  color: var(--faint);
+  font-size: 13.5px;
+  gap: 10px;
+}
+
+.sessions-spinner {
+  width: 13px;
+  height: 13px;
+  border: 2px solid var(--line);
+  border-radius: 50%;
+  border-top-color: var(--ink);
+  animation: spin 720ms linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sessions-spinner {
+    animation-duration: 2.4s;
+  }
+}
+
+.sheet.is-compact {
+  max-width: 420px;
+}
+
+.launch-subject {
+  display: flex;
+  margin-bottom: 20px;
+  align-items: center;
+  gap: 12px;
+}
+
+.launch-icon {
+  width: 30px;
+  height: 30px;
+  flex: none;
+  object-fit: contain;
+}
+
+.launch-text {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.launch-text b {
+  overflow: hidden;
+  color: var(--ink);
+  font-size: 15px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.launch-text em {
+  color: var(--faint);
+  font-size: 12.5px;
+  font-style: normal;
 }

--- a/app/src/terminal/TerminalPane.tsx
+++ b/app/src/terminal/TerminalPane.tsx
@@ -7,7 +7,7 @@ import { DESKTOP_TERMINAL_GRID, type TerminalGrid } from "./terminal-grid";
 import { fittedTerminal, type TerminalCell } from "./terminal-fit";
 import { cellMeasurer, terminalBox } from "./terminal-metrics";
 import { encryptionFragment, resolveSessionSocket, sessionIdFromShareUrl } from "./socket-url";
-import { forget, passwordFor } from "../lib/session-passwords";
+import { forget, passwordFor, rememberFor } from "../lib/session-passwords";
 import { openSealed } from "../lib/keypair";
 import { AuditSink } from "./audit-sink";
 import { postAudit } from "../lib/api";
@@ -271,6 +271,16 @@ export function TerminalPane({
     if (!password || !connection.current) return;
     setUnlocking(true);
     setDetail("");
+    /*
+     * Kept, so this is the last time it is typed for this session.
+     *
+     * A password only proves itself when a frame opens, which happens after
+     * this returns, so it is written now and removed by the failure path
+     * above if it turns out to be wrong. Storing it early costs a dead entry;
+     * not storing it at all is what made every reload ask again.
+     */
+    const sessionId = sessionIdFromShareUrl(shareUrl);
+    if (sessionId) rememberFor(sessionId, password);
     await connection.current.submitPassword(password);
     setPassword("");
   }

--- a/app/src/terminal/keyboard-inset.test.ts
+++ b/app/src/terminal/keyboard-inset.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { paneHeight } from "./keyboard-inset";
+
+/*
+ * A phone covers the bottom of the page with its keyboard rather than making
+ * the page shorter, so the prompt goes under it. These hold the arithmetic
+ * that decides how much of the screen the terminal still has.
+ */
+describe("sizing the terminal to what the keyboard has left", () => {
+  it("uses the space below the pane when no keyboard is up", () => {
+    expect(paneHeight({ viewportHeight: 800, offsetTop: 0, paneTop: 140, gap: 16 })).toBe(644);
+  });
+
+  it("gives back the height the keyboard took", () => {
+    const closed = paneHeight({ viewportHeight: 800, offsetTop: 0, paneTop: 140, gap: 16 });
+    const open = paneHeight({ viewportHeight: 500, offsetTop: 0, paneTop: 140, gap: 16 });
+    expect(closed - open).toBe(300);
+  });
+
+  it("follows the page being scrolled while the keyboard is open", () => {
+    /* Scrolling moves the pane up the screen; the space below it grows. */
+    const still = paneHeight({ viewportHeight: 500, offsetTop: 0, paneTop: 140, gap: 16 });
+    const scrolled = paneHeight({ viewportHeight: 500, offsetTop: 60, paneTop: 140, gap: 16 });
+    expect(scrolled).toBe(still + 60);
+  });
+
+  it("keeps a usable terminal rather than collapsing to nothing", () => {
+    /* A small landscape phone with the keyboard up leaves almost no room. */
+    expect(paneHeight({ viewportHeight: 180, offsetTop: 0, paneTop: 140 })).toBe(180);
+  });
+});

--- a/app/src/terminal/keyboard-inset.ts
+++ b/app/src/terminal/keyboard-inset.ts
@@ -1,0 +1,88 @@
+import { useEffect, type RefObject } from "react";
+
+/**
+ * Keeps the terminal above the on-screen keyboard.
+ *
+ * A phone does not shrink the layout viewport when its keyboard opens; it
+ * covers the bottom of it. The prompt is at the bottom of a terminal, so the
+ * line being typed was the first thing to go under the keyboard, and the only
+ * way back to it was to dismiss the keyboard.
+ *
+ * The visual viewport is the part still on screen, so the pane is sized to
+ * what is left below its own top edge. That covers the keyboard opening,
+ * closing, and the page being scrolled while it is open.
+ */
+
+const PHONE = "(max-width: 900px)";
+
+/* Read by .panes; see terminal.css. */
+const PROPERTY = "--pane-height";
+
+/* Room under the pane for the bottom bar and the page's own padding. */
+const GAP = 16;
+const MINIMUM = 180;
+
+export function paneHeight(input: {
+  /** Height of the part of the page still visible. */
+  viewportHeight: number;
+  /** How far the visual viewport has been scrolled inside the layout one. */
+  offsetTop: number;
+  /** The pane's top edge, in layout coordinates. */
+  paneTop: number;
+  /** Space to leave below the pane. */
+  gap?: number;
+}): number {
+  const gap = input.gap ?? GAP;
+  const available = input.viewportHeight + input.offsetTop - input.paneTop - gap;
+  return Math.max(MINIMUM, Math.round(available));
+}
+
+/**
+ * Sizes the element to the space the keyboard has left it, on phones only.
+ *
+ * On anything larger the element keeps whatever the stylesheet gave it: a
+ * desktop browser has no on-screen keyboard to make room for, and a window
+ * that is merely narrow is not a phone.
+ */
+export function useKeyboardInset(target: RefObject<HTMLElement | null>, enabled: boolean): void {
+  useEffect(() => {
+    const viewport = window.visualViewport;
+    const node = target.current;
+    if (!enabled || !viewport || !node) return;
+
+    const phone = window.matchMedia(PHONE);
+    const root = document.documentElement;
+
+    /*
+     * The answer is published as a custom property rather than written onto
+     * the element. The stylesheet decides what to do with it, which keeps the
+     * layout in CSS and means this hook reads the DOM without reshaping it.
+     */
+    const apply = () => {
+      if (!phone.matches) {
+        root.style.removeProperty(PROPERTY);
+        return;
+      }
+      const paneTop = node.getBoundingClientRect().top + window.scrollY;
+      root.style.setProperty(
+        PROPERTY,
+        `${paneHeight({
+          viewportHeight: viewport.height,
+          offsetTop: viewport.offsetTop,
+          paneTop,
+        })}px`,
+      );
+    };
+
+    apply();
+    viewport.addEventListener("resize", apply);
+    viewport.addEventListener("scroll", apply);
+    phone.addEventListener("change", apply);
+    return () => {
+      viewport.removeEventListener("resize", apply);
+      viewport.removeEventListener("scroll", apply);
+      phone.removeEventListener("change", apply);
+      root.style.removeProperty(PROPERTY);
+    };
+  }, [target, enabled]);
+}


### PR DESCRIPTION
Thirteen reports from using the app. One of them turned out to be about something larger than it looked.

## Everyone could open everything

Reported as *"passwords can be bypassed on Mobile by changing assignee"*. Changing the assignee was not the bypass. `shareAnyPending` sealed a session's password to **every** team member with a browser key, on the poll after it started. So every colleague could already open every session, and handing one over merely looked like it granted something.

Who can open a session is now ticked when it is started, and it defaults to nobody. The password is still generated rather than typed — the tick boxes replace a secret to invent and pass around, which is the other half of the same report. People can be added afterwards from the session page.

Removing is deliberately not offered. It would not reach into a colleague's browser and take back the copy they hold, so a control that appeared to revoke would be describing something that had not happened.

`sealTargets` and `shareCandidates` are in `src/lib/session-share.ts` with tests, because "who gets the password" is the whole of the access rule and it was living inside a component where it could not be tested.

## Mark all as read → blank page

The list draws each notification as a person doing something. `GET /api/notifications` returned the roster; `POST /api/notifications/read` returned the same view without it, so `findPerson(undefined, …)` threw and took the page with it. The roster is part of what `inbox()` builds now, so neither route can leave it out. The client also treats a missing roster as a missing name rather than a missing page.

## The password had to be typed every time

A password typed into the gate was never stored. It is now, and the existing failure path already removes one that turns out to be wrong.

## The home-screen install

`.topbar` had a fixed height *and* `padding-top: env(safe-area-inset-top)`, so on a device with a notch the inset was taken out of the bar rather than added to it and the title was squeezed into what was left. The rail becomes a strip along the bottom on a phone, which had also taken the wordmark and the account menu off the screen — signing out was only reachable from the Account page. Both are in the bar now.

## The keyboard sat on the terminal

A phone covers the bottom of the layout viewport rather than shortening it, and the prompt is at the bottom of a terminal. `useKeyboardInset` publishes what the visual viewport has left below the pane; the stylesheet does the rest. The arithmetic is tested on its own.

## Owner and assignee

At ≤900px the table stacks and its header is hidden, leaving two unlabelled faces in a row. Each cell carries its own label in that layout.

## Smaller

- The audit log reads newest first. Runs are still built oldest-first so each one reads forwards; the grouping moved to `audit-view.ts` and is tested.
- Its chart says **By user**.
- Starting a session shows that it is starting, then offers to open it, and gives up after 45 seconds rather than spinning forever.
- Claude Code and Codex sessions can pick a model.
- The session page has the same copy menu as the list, so the password is reachable from the screen you are actually on.
- The invite explainer and the "Who you are signed in as." dek are gone.

## One nobody reported as a bug

`SessionClipboard` derived every session's password on every poll, because its effect depended on the session object the poll replaces rather than on the sealed bytes inside it. That is an ECDH derivation per session per four seconds. It is the likeliest cause of *"tabs are a bit slow on mobile"*.

## What I could not test

There is no DOM test environment here, and adding one is a dependency decision rather than a fix, so the new logic is extracted and unit-tested the way `session-view.ts` already was: 645 tests pass, up from 607. The parts that are genuinely visual — the keyboard inset on a real phone, the home-screen top bar, the stacked table labels — are reasoned from the CSS and have not been seen on a device.
