### PR TITLE
Make the phone app work: clickable rows, working copy buttons, a bigger bottom bar

### DIFF
--- a/app/src/components/AppShell.tsx
+++ b/app/src/components/AppShell.tsx
@@ -161,10 +161,22 @@ export function AppShell({ title, aside, children }: AppShellProps) {
         <header className="topbar">
           <div className="topbar-inner">
             <div className="topbar-heading">
-              {/* Shown only where the rail is not: see .topbar-mark. */}
-              <Link to="/sessions" className="topbar-mark" aria-label="shell.online">
+              {/*
+                * Shown only where the rail is not: see .topbar-mark. A span
+                * rather than a link, because Wordmark is already one and an
+                * anchor inside an anchor is invalid; React said so on every
+                * render of a phone-width page.
+                */}
+              <span className="topbar-mark">
                 <Wordmark />
-              </Link>
+              </span>
+              {/*
+                * The title is hidden on a phone, not removed: the bottom bar
+                * already names the page it has marked, so the heading was the
+                * same word twice, and it was crowding a row that now also
+                * carries the wordmark and the account menu. Screen readers
+                * keep it.
+                */}
               <h1 className="topbar-title">{title}</h1>
             </div>
             <div className="topbar-right">

--- a/app/src/components/AppShell.tsx
+++ b/app/src/components/AppShell.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { Link, NavLink, useNavigate } from "react-router-dom";
 import {
-  Terminal, Desktop, User, UsersThree, ClockCounterClockwise, SignOut, Copy, Check,
+  Terminal, Desktop, User, UsersThree, ClockCounterClockwise, SignOut, Copy, Check, Warning,
 } from "@phosphor-icons/react";
 import { Inbox } from "./Inbox";
 import { Avatar } from "./Avatar";
 import { Wordmark } from "./Wordmark";
 import { useAuth } from "../auth/AuthProvider";
+import { COPY_FAILED, useCopy } from "../lib/clipboard";
 
 const NAV = [
   { to: "/sessions", label: "Sessions", Icon: Terminal },
@@ -19,23 +20,16 @@ const NAV = [
 /* The command a new machine needs. Shown once, in the sidebar, not per page. */
 const LINK_COMMAND = "shell login";
 
-function LinkHint() {
-  const [copied, setCopied] = useState(false);
+export function LinkHint({ className = "rail-hint" }: { className?: string }) {
+  const { state, copy } = useCopy();
+  const copied = state === "copied";
   return (
-    <div className="rail-hint">
+    <div className={className}>
       <p>Link a machine</p>
       <button
         type="button"
         className="rail-command"
-        onClick={async () => {
-          try {
-            await navigator.clipboard.writeText(LINK_COMMAND);
-            setCopied(true);
-            window.setTimeout(() => setCopied(false), 1600);
-          } catch {
-            /* clipboard is unavailable outside a secure context */
-          }
-        }}
+        onClick={() => void copy(LINK_COMMAND)}
         aria-label={copied ? "Command copied" : `Copy ${LINK_COMMAND}`}
       >
         <code>
@@ -43,6 +37,12 @@ function LinkHint() {
         </code>
         {copied ? <Check size={14} weight="bold" /> : <Copy size={14} />}
       </button>
+      {state === "failed" && (
+        <p className="rail-command-failed" role="status">
+          <Warning size={13} weight="fill" />
+          {COPY_FAILED}
+        </p>
+      )}
     </div>
   );
 }
@@ -136,8 +136,16 @@ export function AppShell({ title, aside, children }: AppShellProps) {
               to={to}
               className={({ isActive }) => (isActive ? "rail-link is-active" : "rail-link")}
             >
-              <Icon size={19} />
-              {label}
+              {/*
+               * The icon is wrapped so the bottom bar can mark the current
+               * page with a shape the same size on every item. Left to the
+               * link itself the mark took the width of the word inside it,
+               * and "Sessions" and "Team" were highlighted differently.
+               */}
+              <span className="rail-icon">
+                <Icon size={19} />
+              </span>
+              <span className="rail-label">{label}</span>
             </NavLink>
           ))}
         </nav>

--- a/app/src/components/SessionBoard.tsx
+++ b/app/src/components/SessionBoard.tsx
@@ -1,4 +1,5 @@
 import { Terminal as TerminalIcon, Trash, Eye } from "@phosphor-icons/react";
+import { Link } from "react-router-dom";
 import { PersonChip } from "./Avatar";
 import { findPerson } from "../lib/people";
 import { kindForCommand } from "../lib/session-kinds";
@@ -44,7 +45,17 @@ function Card({
     <li className="board-card">
       <div className="board-card-head">
         <img className="board-card-icon" src={kind.icon} alt="" title={kind.title} />
-        <span className="board-card-name">{session.name || session.command}</span>
+        {/*
+         * The name is the card's link, and CSS stretches it over the whole
+         * card so anywhere that is not a control opens the session. One
+         * anchor, not a click handler on the li: a card you can only reach
+         * with a mouse is a card a keyboard cannot reach at all, and nesting
+         * the copy menu and the Open button inside an anchor would be
+         * invalid markup as well as unusable.
+         */}
+        <Link className="board-card-name" to={`/sessions/${session.id}`}>
+          {session.name || session.command}
+        </Link>
         <SessionClipboard session={session} you={you} />
       </div>
 

--- a/app/src/components/SessionClipboard.tsx
+++ b/app/src/components/SessionClipboard.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState } from "react";
-import { CaretDown, Copy, Check, Link as LinkIcon, Lock, Terminal } from "@phosphor-icons/react";
+import { CaretDown, Copy, Check, Link as LinkIcon, Lock, Terminal, Warning } from "@phosphor-icons/react";
 import type { Member, SessionRecord } from "../lib/api";
 import { passwordFor } from "../lib/session-passwords";
 import { openSealed } from "../lib/keypair";
+import { COPY_FAILED, useCopy } from "../lib/clipboard";
 
 /**
  * The one place a session can be copied from.
@@ -40,8 +41,15 @@ export function SessionClipboard({
   you: Member | null;
 }) {
   const [open, setOpen] = useState(false);
-  const [copied, setCopied] = useState<Item | "">("");
-  const [hasPassword, setHasPassword] = useState(false);
+  /*
+   * The password is unsealed ahead of the click, not inside it. Unsealing is
+   * asynchronous, and on WebKit anything awaited between the tap and
+   * navigator.clipboard.writeText spends the user gesture the write needs, so
+   * copying the password failed on a phone every time while the link beside
+   * it worked. Holding the decrypted value means the handler is synchronous.
+   */
+  const [password, setPassword] = useState<string | null>(null);
+  const { copiedKey, failedKey, copy } = useCopy<Item>();
   const wrapper = useRef<HTMLDivElement>(null);
 
   /* The attach command runs on the machine that owns the process. */
@@ -61,8 +69,8 @@ export function SessionClipboard({
     : "";
   useEffect(() => {
     let live = true;
-    void readPassword(session).then((password) => {
-      if (live) setHasPassword(Boolean(password));
+    void readPassword(session).then((value) => {
+      if (live) setPassword(value);
     });
     return () => {
       live = false;
@@ -86,16 +94,7 @@ export function SessionClipboard({
     };
   }, [open]);
 
-  async function copy(item: Item, value: string | null) {
-    if (!value) return;
-    try {
-      await navigator.clipboard.writeText(value);
-      setCopied(item);
-      window.setTimeout(() => setCopied(""), 1600);
-    } catch {
-      /* clipboard is unavailable outside a secure context */
-    }
-  }
+  const anyCopied = copiedKey !== null;
 
   return (
     <div className="clip" ref={wrapper}>
@@ -108,56 +107,77 @@ export function SessionClipboard({
         aria-label="Copy from this session"
         title="Copy from this session"
       >
-        {copied ? <Check size={15} weight="bold" /> : <Copy size={15} />}
+        {anyCopied ? <Check size={15} weight="bold" /> : <Copy size={15} />}
         {/* Says it opens something, rather than leaving it to be discovered. */}
         <CaretDown size={10} weight="bold" className="clip-caret" data-open={open} />
       </button>
 
       {open && (
-        <div className="clip-pop" role="menu">
-          <button
-            type="button"
-            role="menuitem"
-            className="clip-item"
-            onClick={() => void copy("link", session.shareUrl)}
-          >
-            <LinkIcon size={16} />
-            <span className="clip-text">
-              <b>{copied === "link" ? "Link copied" : "Copy link"}</b>
-              <em>Anyone holding this link and the password can open the session, inside the team or not.</em>
-            </span>
-          </button>
-
-          {hasPassword && (
+        <>
+          {/*
+           * The sheet's backdrop on a phone, and nothing at all on a pointer.
+           * It has to be a real element rather than a painted scrim: a tap
+           * meant to dismiss the sheet would otherwise land on whatever
+           * button happened to be underneath it.
+           */}
+          <div className="clip-scrim" onClick={() => setOpen(false)} />
+          <div className="clip-pop" role="menu">
             <button
               type="button"
               role="menuitem"
               className="clip-item"
-              onClick={async () => void copy("password", await readPassword(session))}
+              onClick={() => void copy(session.shareUrl, "link")}
             >
-              <Lock size={16} />
+              <LinkIcon size={16} />
               <span className="clip-text">
-                <b>{copied === "password" ? "Password copied" : "Copy password"}</b>
-                <em>Share it as carefully as the link. Outside the team it is the whole session.</em>
+                <b>{copiedKey === "link" ? "Link copied" : "Copy link"}</b>
+                <em>Anyone holding this link and the password can open the session, inside the team or not.</em>
               </span>
             </button>
-          )}
 
-          {isOwner && (
-            <button
-              type="button"
-              role="menuitem"
-              className="clip-item"
-              onClick={() => void copy("attach", attachCommand)}
-            >
-              <Terminal size={16} />
-              <span className="clip-text">
-                <b>{copied === "attach" ? "Command copied" : "Copy attach command"}</b>
-                <em>Runs on the machine that started it, so this one is visible only to you.</em>
-              </span>
-            </button>
-          )}
-        </div>
+            {password && (
+              <button
+                type="button"
+                role="menuitem"
+                className="clip-item"
+                onClick={() => void copy(password, "password")}
+              >
+                <Lock size={16} />
+                <span className="clip-text">
+                  <b>{copiedKey === "password" ? "Password copied" : "Copy password"}</b>
+                  <em>Share it as carefully as the link. Outside the team it is the whole session.</em>
+                </span>
+              </button>
+            )}
+
+            {isOwner && (
+              <button
+                type="button"
+                role="menuitem"
+                className="clip-item"
+                onClick={() => void copy(attachCommand, "attach")}
+              >
+                <Terminal size={16} />
+                <span className="clip-text">
+                  <b>{copiedKey === "attach" ? "Command copied" : "Copy attach command"}</b>
+                  <em>Runs on the machine that started it, so this one is visible only to you.</em>
+                </span>
+              </button>
+            )}
+
+            {/*
+              A refused clipboard is said out loud rather than swallowed. It used
+              to leave the menu looking exactly as it had a moment earlier, which
+              reads as a copy that worked.
+            */}
+            {failedKey && (
+              <p className="clip-failed" role="status">
+                <Warning size={14} weight="fill" />
+                {COPY_FAILED}
+              </p>
+            )}
+          </div>
+        </>
       )}
     </div>
   );

--- a/app/src/lib/clipboard.test.ts
+++ b/app/src/lib/clipboard.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { copyText } from "./clipboard";
+
+/*
+ * The environment is node, so the document the fallback needs is built here.
+ * It is small on purpose: the only thing worth asserting is which of the two
+ * mechanisms ran, and what each of them was handed.
+ */
+function fakeDocument() {
+  const field = {
+    value: "",
+    style: { cssText: "" },
+    setAttribute: vi.fn(),
+    select: vi.fn(),
+    setSelectionRange: vi.fn(),
+    remove: vi.fn(),
+  };
+  return {
+    field,
+    document: {
+      activeElement: null,
+      createElement: () => field,
+      body: { append: vi.fn() },
+      execCommand: vi.fn(() => true),
+    },
+  };
+}
+
+let fake = fakeDocument();
+
+beforeEach(() => {
+  fake = fakeDocument();
+  vi.stubGlobal("document", fake.document);
+  vi.stubGlobal("HTMLElement", class {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("copying, when the browser offers the clipboard API", () => {
+  it("writes through it and does not touch the fallback", async () => {
+    const writeText = vi.fn(async () => {});
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+
+    await expect(copyText("shell login")).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith("shell login");
+    expect(fake.document.execCommand).not.toHaveBeenCalled();
+  });
+});
+
+describe("copying, when the browser refuses the clipboard API", () => {
+  /*
+   * This is the case a phone actually hits. writeText rejects with
+   * NotAllowedError, which the app used to swallow, leaving the button
+   * looking as though it had copied something.
+   */
+  it("falls back to a selection, and reports success", async () => {
+    vi.stubGlobal("navigator", {
+      clipboard: {
+        writeText: vi.fn(async () => {
+          throw new DOMException("Write permission denied", "NotAllowedError");
+        }),
+      },
+    });
+
+    await expect(copyText("https://shell.online/s/7f3a91")).resolves.toBe(true);
+    expect(fake.field.value).toBe("https://shell.online/s/7f3a91");
+    expect(fake.field.setSelectionRange).toHaveBeenCalledWith(0, 29);
+    expect(fake.document.execCommand).toHaveBeenCalledWith("copy");
+    expect(fake.field.remove).toHaveBeenCalled();
+  });
+
+  it("uses the fallback when the API is absent altogether", async () => {
+    vi.stubGlobal("navigator", {});
+
+    await expect(copyText("shell attach abc")).resolves.toBe(true);
+    expect(fake.field.value).toBe("shell attach abc");
+  });
+});
+
+describe("copying, when nothing works", () => {
+  it("reports failure rather than pretending", async () => {
+    vi.stubGlobal("navigator", {});
+    fake.document.execCommand = vi.fn(() => false);
+
+    await expect(copyText("anything")).resolves.toBe(false);
+  });
+
+  it("reports failure when the fallback throws", async () => {
+    vi.stubGlobal("navigator", {});
+    fake.document.execCommand = vi.fn(() => {
+      throw new Error("not allowed here either");
+    });
+
+    await expect(copyText("anything")).resolves.toBe(false);
+    /* Still tidied away: a stray textarea would outlive the failure. */
+    expect(fake.field.remove).toHaveBeenCalled();
+  });
+
+  it("refuses an empty value without touching the clipboard", async () => {
+    const writeText = vi.fn(async () => {});
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+
+    await expect(copyText("")).resolves.toBe(false);
+    expect(writeText).not.toHaveBeenCalled();
+    expect(fake.document.execCommand).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/lib/clipboard.ts
+++ b/app/src/lib/clipboard.ts
@@ -1,0 +1,103 @@
+import { useCallback, useRef, useState } from "react";
+
+/**
+ * Copying, for browsers that do not all agree what copying is.
+ *
+ * Every copy button in this app used to be `await navigator.clipboard
+ * .writeText(...)` inside a `try` whose `catch` was empty. On a phone that is
+ * the whole bug: the promise rejects with NotAllowedError often enough
+ * (Safari drops the user gesture the moment anything is awaited before the
+ * write, a home-screen window can be denied the permission outright, an
+ * embedded browser may not ship the API at all) and a swallowed rejection
+ * looks exactly like a copy that worked. Nothing moves, nothing is said, and
+ * the link is not on the clipboard.
+ *
+ * So: try the modern API, fall back to the selection-and-execCommand trick
+ * that predates it, and report which of the three things happened rather than
+ * leaving the button to imply success.
+ */
+
+/** The last-resort path. Deprecated, still the only thing WebKit always allows. */
+function copyBySelection(value: string): boolean {
+  const field = document.createElement("textarea");
+  field.value = value;
+  /*
+   * readonly rather than disabled: iOS refuses to select inside a disabled
+   * field, and a focused editable one summons the keyboard mid-copy.
+   */
+  field.setAttribute("readonly", "");
+  field.style.cssText =
+    "position:fixed;top:0;left:0;width:1px;height:1px;padding:0;border:0;opacity:0;";
+  document.body.append(field);
+
+  const previous = document.activeElement;
+  try {
+    field.select();
+    /* iOS ignores select() on a readonly field; the explicit range is what works. */
+    field.setSelectionRange(0, value.length);
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    field.remove();
+    if (previous instanceof HTMLElement) previous.focus();
+  }
+}
+
+/**
+ * Puts `value` on the clipboard. Resolves to whether it got there.
+ *
+ * Call this straight out of the click handler with the text already in hand.
+ * Anything awaited first spends the gesture, and WebKit will not write to the
+ * clipboard once it is gone.
+ */
+export async function copyText(value: string): Promise<boolean> {
+  if (!value) return false;
+
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(value);
+      return true;
+    } catch {
+      /* denied, or the gesture is spent: the older path may still be allowed */
+    }
+  }
+
+  return copyBySelection(value);
+}
+
+export type CopyState = "idle" | "copied" | "failed";
+
+/**
+ * The state a copy button needs: which of its items was copied, or that the
+ * copy failed, cleared after a moment.
+ *
+ * `key` distinguishes several buttons sharing one hook, which the session
+ * clipboard menu does. A lone button can ignore it and read `state`.
+ */
+export function useCopy<Key extends string = string>() {
+  const [state, setState] = useState<CopyState>("idle");
+  const [key, setKey] = useState<Key | null>(null);
+  const timer = useRef(0);
+
+  const copy = useCallback(async (value: string | null, forKey?: Key) => {
+    const ok = value ? await copyText(value) : false;
+    window.clearTimeout(timer.current);
+    setState(ok ? "copied" : "failed");
+    setKey(forKey ?? null);
+    /* Failure is worth reading twice as long, since it asks for a decision. */
+    timer.current = window.setTimeout(() => {
+      setState("idle");
+      setKey(null);
+    }, ok ? 1600 : 3600);
+    return ok;
+  }, []);
+
+  const copiedKey = state === "copied" ? key : null;
+  const failedKey = state === "failed" ? key : null;
+
+  return { state, key, copiedKey, failedKey, copy };
+}
+
+/** What to tell someone whose clipboard the browser would not write to. */
+export const COPY_FAILED = "The browser would not copy that. Select it and copy by hand.";

--- a/app/src/routes/Machines.tsx
+++ b/app/src/routes/Machines.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { Desktop } from "@phosphor-icons/react";
-import { AppShell } from "../components/AppShell";
+import { AppShell, LinkHint } from "../components/AppShell";
 import { Button } from "../components/Button";
 import { Alert } from "../components/Alert";
 import { fetchDevices, revokeDevice, type Device } from "../lib/api";
@@ -76,6 +76,14 @@ export function Machines() {
         Every machine that can publish sessions to this account. Unlinking
         revokes its token immediately.
       </p>
+
+      {/*
+       * The command that links a machine lives in the sidebar, and the
+       * sidebar is a bar of five destinations on a phone. This is the
+       * destination it would have been next to, so the phone gets it here
+       * rather than not at all.
+       */}
+      <LinkHint className="machines-hint" />
 
       {error && <div className="sessions-alert"><Alert tone="error">{error}</Alert></div>}
 

--- a/app/src/routes/Team.tsx
+++ b/app/src/routes/Team.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, type FormEvent } from "react";
-import { Copy, Check, Trash, UserPlus, PencilSimple } from "@phosphor-icons/react";
+import { Copy, Check, Trash, UserPlus, PencilSimple, Warning } from "@phosphor-icons/react";
 import { AppShell } from "../components/AppShell";
 import { Button } from "../components/Button";
 import { Alert } from "../components/Alert";
@@ -18,6 +18,7 @@ import { Avatar } from "../components/Avatar";
 import { displayName } from "../lib/people";
 import { usePageTitle } from "../lib/page-title";
 import { publicKey } from "../lib/keypair";
+import { COPY_FAILED, useCopy } from "../lib/clipboard";
 
 const ROLE_LABEL: Record<string, string> = {
   owner: "Owner",
@@ -37,24 +38,37 @@ function inviteState(invite: Invite): { label: string; live: boolean } {
 }
 
 function CopyInvite({ invite }: { invite: Invite }) {
-  const [copied, setCopied] = useState(false);
+  const { state, copy } = useCopy();
+  const copied = state === "copied";
+  const failed = state === "failed";
   return (
-    <button
-      type="button"
-      className="session-action"
-      onClick={async () => {
-        try {
-          await navigator.clipboard.writeText(inviteLink(invite));
-          setCopied(true);
-          window.setTimeout(() => setCopied(false), 1600);
-        } catch {
-          /* clipboard is unavailable outside a secure context */
-        }
-      }}
-    >
-      {copied ? <Check size={14} weight="bold" /> : <Copy size={14} />}
-      {copied ? "Copied" : "Copy link"}
-    </button>
+    <>
+      <button
+        type="button"
+        className="session-action"
+        onClick={() => void copy(inviteLink(invite))}
+      >
+        {failed ? (
+          <Warning size={14} weight="fill" />
+        ) : copied ? (
+          <Check size={14} weight="bold" />
+        ) : (
+          <Copy size={14} />
+        )}
+        {copied ? "Copied" : "Copy link"}
+      </button>
+      {/*
+        The link is the invite. If the clipboard refused it, saying nothing
+        sends somebody away believing they have it, so the address is put on
+        screen to be copied by hand.
+      */}
+      {failed && (
+        <span className="copy-fallback" role="status">
+          {COPY_FAILED}
+          <code>{inviteLink(invite)}</code>
+        </span>
+      )}
+    </>
   );
 }
 
@@ -178,7 +192,7 @@ export function Team() {
                   <th scope="col">Person</th>
                   <th scope="col">Email</th>
                   <th scope="col">Role</th>
-                  <th scope="col">Joined</th>
+                  <th scope="col" className="table-optional">Joined</th>
                   <th scope="col" className="table-end">Actions</th>
                 </tr>
               </thead>
@@ -224,7 +238,7 @@ export function Team() {
                           </span>
                         )}
                       </td>
-                      <td className="table-quiet">{ago(member.joinedAt, Date.now())}</td>
+                      <td className="table-quiet table-optional">{ago(member.joinedAt, Date.now())}</td>
                       <td className="table-end">
                         {canAct && (
                           <button

--- a/app/src/routes/Workspace.tsx
+++ b/app/src/routes/Workspace.tsx
@@ -776,7 +776,7 @@ function SessionGroup({
             <th scope="col">Session</th>
             <th scope="col">Owner</th>
             <th scope="col">Assignee</th>
-            <th scope="col">Machine</th>
+            <th scope="col" className="table-optional">Machine</th>
             <th scope="col">{live ? "Uptime" : "Ran for"}</th>
             <th scope="col" className="table-end">Actions</th>
           </tr>
@@ -786,7 +786,13 @@ function SessionGroup({
             const owner = findPerson(members, session.ownerUid);
             const assignee = findPerson(members, session.assigneeUid);
             return (
-              <tr key={session.id} data-live={live}>
+              /*
+               * The row is the link. `.table-subject` is stretched over the
+               * whole row in CSS, so a tap anywhere that is not a control
+               * opens the session, while the buttons, the assignee picker and
+               * the copy menu stay above it and keep their own targets.
+               */
+              <tr key={session.id} data-live={live} className="table-row-linked">
                 <td>
                   <Link className="table-subject" to={`/sessions/${session.id}`}>
                     {/* The kind of thing running, in colour while it runs. */}
@@ -844,7 +850,9 @@ function SessionGroup({
                     <PersonChip person={assignee} />
                   )}
                 </td>
-                <td className="table-quiet" data-label="Machine">{session.host || "unknown"}</td>
+                <td className="table-quiet table-optional" data-label="Machine">
+                  {session.host || "unknown"}
+                </td>
                 <td className="table-quiet" data-label={live ? "Uptime" : "Ran for"}>
                   {live
                     ? elapsed(session.startedAt, now)

--- a/app/src/styles/audit.css
+++ b/app/src/styles/audit.css
@@ -351,6 +351,33 @@
   }
 }
 
+/*
+ * Five figures do not divide into two, three or four columns, and the grid's
+ * own background is what shows through the cell that leaves: on a phone the
+ * summary ended with a grey rectangle where a sixth figure would have been.
+ * Two columns, and the last figure takes the rest of its row.
+ */
+@media (max-width: 900px) {
+  .stat-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .stat:last-child:nth-child(odd) {
+    grid-column: 1 / -1;
+  }
+
+  /*
+   * The label column is 96px on a wide screen, where the bar beside it has
+   * room to be long. On a phone that budget truncated most full names, so the
+   * two columns trade: the bar only has to show a proportion, the name has to
+   * be readable.
+   */
+  .rank-row {
+    gap: 8px;
+    grid-template-columns: minmax(0, 1.3fr) minmax(48px, 0.7fr) auto;
+  }
+}
+
 @media (max-width: 560px) {
   .trace-lines li {
     grid-template-columns: 1fr;

--- a/app/src/styles/auth.css
+++ b/app/src/styles/auth.css
@@ -917,6 +917,8 @@
   display: flex;
   flex: none;
   align-items: center;
+  /* So a copy that failed can say so on its own line below the buttons. */
+  flex-wrap: wrap;
   gap: 8px;
 }
 
@@ -1084,6 +1086,11 @@
   gap: 3px;
 }
 
+/* Only the phone sheet has a backdrop; on a pointer the menu is a popover. */
+.clip-scrim {
+  display: none;
+}
+
 .clip-caret {
   color: var(--muted);
   transition: transform 140ms var(--ease, ease);
@@ -1094,7 +1101,12 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .clip-caret {
+  /* Only the phone sheet has a backdrop; on a pointer the menu is a popover. */
+.clip-scrim {
+  display: none;
+}
+
+.clip-caret {
     transition: none;
   }
 }
@@ -1156,12 +1168,124 @@
   line-height: 1.35;
 }
 
-/* On a phone the row is narrow, so the menu takes the width it needs. */
-@media (max-width: 560px) {
+/* A refused clipboard, said out loud inside the menu that refused it. */
+.clip-failed {
+  display: flex;
+  padding: 8px 10px 6px;
+  margin: 2px 0 0;
+  color: var(--danger);
+  font-size: 11.5px;
+  line-height: 1.35;
+  align-items: flex-start;
+  gap: 7px;
+}
+
+.clip-failed svg {
+  margin-top: 1px;
+  flex: none;
+}
+
+/*
+ * The same thing anywhere else that copies: the value, spelled out, so it can
+ * be selected by hand when the browser will not hand it over.
+ */
+.copy-fallback {
+  display: flex;
+  max-width: 62ch;
+  /* Inside a row of buttons it takes its own line rather than a share of theirs. */
+  flex-basis: 100%;
+  margin: 8px 0 0;
+  color: var(--danger);
+  font-size: 12px;
+  line-height: 1.4;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.copy-fallback svg {
+  margin-top: 2px;
+  flex: none;
+}
+
+.copy-fallback code {
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-chip);
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 11.5px;
+  overflow-wrap: anywhere;
+  user-select: all;
+}
+
+.rail-command-failed {
+  display: flex;
+  margin: 8px 0 0;
+  color: var(--danger);
+  font-size: 11px;
+  line-height: 1.35;
+  align-items: flex-start;
+  gap: 6px;
+}
+
+.rail-command-failed svg {
+  margin-top: 1px;
+  flex: none;
+}
+
+/* ---------------------------------------------------------------
+   The copy menu on a phone
+   ---------------------------------------------------------------
+   Anchored to the button, this menu ran off the right edge of the screen and
+   took the warning text with it: the sentence explaining that the link opens
+   the session to anyone holding it was the part cut off. There is no reliable
+   way to keep a 296px popover beside a button that can sit anywhere in a
+   390px row, so on a phone it stops trying and becomes a sheet across the
+   bottom, which is both always on screen and an easier thing to hit.
+   --------------------------------------------------------------- */
+@media (max-width: 760px) {
   .clip-pop {
-    right: auto;
+    position: fixed;
+    /* Over the bottom bar, which is 40. */
+    z-index: 50;
+    top: auto;
+    right: 0;
+    bottom: 0;
     left: 0;
-    width: min(296px, calc(100vw - 40px));
+    width: auto;
+    padding: 8px 10px calc(14px + env(safe-area-inset-bottom));
+    border-width: 1px 0 0;
+    border-radius: var(--radius-panel) var(--radius-panel) 0 0;
+    background: var(--white);
+    box-shadow: 0 -18px 50px color-mix(in srgb, var(--ink) 20%, transparent);
+    gap: 4px;
+  }
+
+  .clip-scrim {
+    position: fixed;
+    z-index: 49;
+    display: block;
+    background: color-mix(in srgb, var(--ink) 32%, transparent);
+    inset: 0;
+  }
+
+  .clip-item {
+    padding: 12px;
+  }
+
+  .clip-text b {
+    font-size: 15px;
+  }
+
+  .clip-text em {
+    font-size: 13px;
+  }
+
+  .clip-failed {
+    font-size: 13px;
   }
 }
 
@@ -1307,13 +1431,49 @@
   list-style: none;
 }
 
+/*
+ * The card is the target. The name carries the link and CSS stretches it over
+ * the card, the same arrangement the table row uses, so both views answer a
+ * tap in the same place: the session, not nothing.
+ */
 .board-card {
+  position: relative;
   display: grid;
   padding: 10px;
   border: 1px solid var(--line);
   border-radius: var(--radius-chip);
   background: var(--paper);
+  cursor: pointer;
   gap: 7px;
+  transition: border-color 140ms var(--ease), background 140ms var(--ease);
+}
+
+.board-card:hover {
+  border-color: var(--line-strong);
+  background: var(--white);
+}
+
+.board-card:has(.board-card-name:focus-visible) {
+  outline: 2px solid var(--blue);
+  outline-offset: 2px;
+}
+
+.board-card-name::after {
+  position: absolute;
+  content: "";
+  inset: 0;
+  border-radius: inherit;
+}
+
+/*
+ * The controls keep their own targets. They come after the overlay in the
+ * card, and positioned siblings paint in tree order, so relative is enough
+ * and no z-index is needed to trap the copy menu inside.
+ */
+.board-card .clip,
+.board-card .board-card-foot {
+  position: relative;
+  cursor: auto;
 }
 
 .board-card-head {
@@ -1332,10 +1492,21 @@
 .board-card-name {
   overflow: hidden;
   flex: 1;
+  color: var(--ink);
   font-size: 13px;
   font-weight: 540;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.board-card:hover .board-card-name {
+  color: var(--ink);
+  text-decoration: underline;
+}
+
+/* The stretched link owns the outline, so it must not draw its own. */
+.board-card-name:focus-visible {
+  outline: none;
 }
 
 .board-card-meta {

--- a/app/src/styles/collab.css
+++ b/app/src/styles/collab.css
@@ -405,7 +405,14 @@
 
 @media (max-width: 900px) {
   .detail {
-    grid-template-columns: 1fr;
+    /*
+     * `minmax(0, 1fr)`, not `1fr`. A `1fr` track will not go below the
+     * min-content width of what is in it, and a comment can hold a URL or a
+     * pasted command that does not break, so the column grew past the screen
+     * and took the whole page sideways with it: the copy menu and the open
+     * button on this page sat off the right edge.
+     */
+    grid-template-columns: minmax(0, 1fr);
     gap: 26px;
   }
 }

--- a/app/src/styles/collab.css
+++ b/app/src/styles/collab.css
@@ -60,7 +60,9 @@
   right: 0;
   z-index: 70;
   overflow: hidden;
-  width: min(400px, calc(100vw - 32px));
+  /* --zoom is 1 unless the root is zoomed, which the phone breakpoint does;
+     see the phone rule at the end of this file for why that matters. */
+  width: min(400px, calc((100vw - 32px) / var(--zoom, 1)));
   border: 1px solid var(--line);
   border-radius: var(--radius-control);
   background: var(--white);
@@ -542,5 +544,32 @@
   .table thead th:nth-child(2),
   .table tbody td:nth-child(2) {
     display: table-cell;
+  }
+}
+
+/* ---------------------------------------------------------------
+   The inbox on a phone
+   ---------------------------------------------------------------
+   Two things put this panel off the screen. `vw` resolves against the
+   undivided viewport while the phone breakpoint zooms the root, so a width of
+   `calc(100vw - 32px)` was drawn 1.15 times wider than it measured; and the
+   panel hangs from the right edge of its trigger, which is no longer the
+   right edge of the screen, because the account menu moved in beside it. It
+   was 412px wide on a 390px screen, 88px of it past the left edge.
+
+   Both go away by giving the panel two insets instead of a width. Insets are
+   resolved against the containing block, so they scale with it however the
+   root is zoomed, and the containing block here spans the screen: `.topbar`
+   has a backdrop-filter, which makes it the containing block for a fixed
+   descendant. Should that blur ever go, the initial containing block takes
+   over and is the same width, so the arithmetic holds either way.
+   --------------------------------------------------------------- */
+@media (max-width: 760px) {
+  .inbox-pop {
+    position: fixed;
+    top: calc(100% + 8px);
+    right: 10px;
+    left: 10px;
+    width: auto;
   }
 }

--- a/app/src/styles/people.css
+++ b/app/src/styles/people.css
@@ -287,6 +287,47 @@
   text-decoration: underline;
 }
 
+/* ---------------------------------------------------------------
+   The whole row opens the session
+   ---------------------------------------------------------------
+   The name was the only target, which on a phone is a few characters of
+   text in a row that is otherwise a hundred pixels of nothing. Rather than
+   put a click handler on the row, the existing link is stretched across it:
+   the row keeps one link, the keyboard keeps one stop, and everything that
+   was already interactive is lifted above the overlay so it still gets the
+   tap it used to.
+   --------------------------------------------------------------- */
+
+.table-row-linked {
+  position: relative;
+  cursor: pointer;
+}
+
+.table-row-linked .table-subject::after {
+  position: absolute;
+  content: "";
+  inset: 0;
+}
+
+.table-row-linked:hover .table-name {
+  text-decoration: underline;
+}
+
+/*
+ * Everything with its own behaviour keeps its own target: `position: relative`
+ * and nothing else. Positioned siblings paint in tree order and all of these
+ * come after the overlay, so they are above it without a z-index. Giving them
+ * one would trap the copy menu inside their stacking context, and that menu
+ * has to rise over the rest of the page.
+ */
+.table-row-linked td > .session-actions,
+.table-row-linked .picker,
+.table-row-linked .table-command-toggle,
+.table-row-linked .table-command {
+  position: relative;
+  cursor: auto;
+}
+
 /*
  * The icon says what is running at a glance. A finished session keeps the same
  * icon, desaturated, so the row still reads as the same kind of thing without
@@ -377,9 +418,18 @@
   font-size: 12px;
 }
 
+/*
+ * Columns that a narrow window may drop.
+ *
+ * This used to be `nth-child(4)`, which counted positions rather than meaning.
+ * The fourth column is the machine in the sessions table and the date joined
+ * in the members table, both of which can go. In the invites table it is
+ * Actions, so under 1080px every invite lost its copy and revoke buttons and
+ * an invite link could not be copied on a phone at all.
+ */
 @media (max-width: 1080px) {
-  .table thead th:nth-child(4),
-  .table tbody td:nth-child(4) {
+  .table thead th.table-optional,
+  .table tbody td.table-optional {
     display: none;
   }
 }
@@ -422,6 +472,15 @@
 
   .table td[data-label] {
     padding: 7px 0;
+  }
+
+  /*
+   * A column dropped from the table comes back once the cells stack. It was
+   * dropped because the table had no width for it, and a stacked row is a
+   * list with room for one more line, which the label above it now names.
+   */
+  .table tbody td.table-optional {
+    display: block;
   }
 
   .table-end,

--- a/app/src/styles/shell.css
+++ b/app/src/styles/shell.css
@@ -59,6 +59,15 @@
   color: var(--blue);
 }
 
+/* On the rail the wrapper is only a box around the glyph. The bottom bar
+   turns it into the current-page mark. */
+.rail-icon {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+}
+
 /* ---- Sidebar footer: the one command a new machine needs ---- */
 
 .rail-hint {
@@ -105,6 +114,23 @@
 
 .rail-command code span {
   color: var(--acid);
+}
+
+/*
+ * The same hint on the machines page, for the layouts that have no rail to
+ * put it in. Hidden wherever the rail is showing it already.
+ */
+.machines-hint {
+  display: none;
+  padding: 0 0 4px;
+  margin: 0 0 18px;
+  max-width: 380px;
+}
+
+@media (max-width: 760px) {
+  .machines-hint {
+    display: block;
+  }
 }
 
 /* ---------------------------------------------------------------
@@ -486,6 +512,19 @@
    sits under the status bar and the last nav item under the gesture bar.
    --------------------------------------------------------------- */
 @media (max-width: 760px) {
+  /*
+   * Everything a size up.
+   *
+   * The layout is written in pixels tuned for a pointer and a wide window,
+   * and on a phone that reads as a desktop page shrunk to fit rather than an
+   * application. Zooming the root scales the whole thing, layout included, so
+   * text, controls and spacing grow together and nothing has to be re-tuned
+   * rule by rule. It is what the browser's own zoom does, applied once.
+   */
+  :root {
+    zoom: 1.15;
+  }
+
   .shell {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -504,8 +543,10 @@
     bottom: 0;
     left: 0;
     height: auto;
-    padding: 6px 8px calc(6px + env(safe-area-inset-bottom));
+    padding: 8px 6px calc(8px + env(safe-area-inset-bottom));
     border-top: 1px solid var(--line);
+    background: color-mix(in srgb, var(--paper) 94%, transparent);
+    backdrop-filter: blur(12px);
     flex-direction: row;
   }
 
@@ -525,21 +566,67 @@
   }
 
   .rail-link {
-    padding: 7px 4px;
+    padding: 0;
+    /* A whole finger, not a line of text: the bar is the primary navigation. */
+    min-width: 58px;
+    height: auto;
+    border-radius: var(--radius-chip);
+    color: var(--muted);
+    font-size: 11px;
+    font-weight: 500;
     flex-direction: column;
-    font-size: 10.5px;
-    gap: 3px;
+    gap: 4px;
     text-align: center;
   }
 
-  .rail-link.is-active {
+  /*
+   * The current page is marked on the icon, which is the same width on every
+   * item, rather than on the link, which is as wide as its word. The bar used
+   * to show a bordered box around "Sessions" and a much smaller one around
+   * "Team", so the mark read as a different thing on each page.
+   */
+  .rail-icon {
+    width: 60px;
+    height: 32px;
+    border-radius: 999px;
+    transition: background 160ms var(--ease), color 160ms var(--ease);
+  }
+
+  .rail-link svg {
+    width: 23px;
+    height: 23px;
+  }
+
+  .rail-link:hover {
     background: none;
+    color: var(--muted);
+  }
+
+  .rail-link.is-active,
+  .rail-link.is-active:hover {
+    /* The desktop mark is a bordered panel; on the bar it is the pill below. */
+    background: none;
+    box-shadow: none;
     color: var(--ink);
+    font-weight: 560;
+  }
+
+  .rail-link.is-active .rail-icon {
+    background: var(--blue-wash);
+  }
+
+  .rail-label {
+    display: block;
+    max-width: 100%;
+    overflow: hidden;
+    padding-bottom: 2px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   /* Clear of the bar, so the last row of a table is not under it. */
   .shell-content {
-    padding-bottom: calc(74px + env(safe-area-inset-bottom));
+    padding-bottom: calc(88px + env(safe-area-inset-bottom));
   }
 
   /*

--- a/app/src/styles/shell.css
+++ b/app/src/styles/shell.css
@@ -537,6 +537,13 @@
    */
   :root {
     zoom: 1.15;
+    /*
+     * The same number as a token, because `vw` does not follow the zoom.
+     * Viewport units resolve against the undivided viewport and are then
+     * drawn in this scaled space, so `100vw` covers 115% of the screen. Any
+     * rule that has to fit a viewport measurement divides by this.
+     */
+    --zoom: 1.15;
   }
 
   .shell {

--- a/app/src/styles/shell.css
+++ b/app/src/styles/shell.css
@@ -588,8 +588,14 @@
 
   .rail-link {
     padding: 0;
-    /* A whole finger, not a line of text: the bar is the primary navigation. */
-    min-width: 58px;
+    /*
+     * A whole finger, not a line of text: the bar is the primary navigation.
+     * `min-width` alone put five of these past the edge of a 320px phone, so
+     * the basis is what they would like to be and they are allowed to give it
+     * up together rather than one of them falling off the end.
+     */
+    flex: 1 1 58px;
+    min-width: 0;
     height: auto;
     border-radius: var(--radius-chip);
     color: var(--muted);
@@ -607,7 +613,7 @@
    * "Team", so the mark read as a different thing on each page.
    */
   .rail-icon {
-    width: 60px;
+    width: min(60px, 100%);
     height: 32px;
     border-radius: 999px;
     transition: background 160ms var(--ease), color 160ms var(--ease);

--- a/app/src/styles/shell.css
+++ b/app/src/styles/shell.css
@@ -206,6 +206,20 @@
   display: none;
 }
 
+/*
+ * A page action in the bar keeps its label on one line. `.btn` is built for a
+ * form, where it is full width and wrapping is not a question; up here the row
+ * is tight enough on a phone that "Export CSV" broke across two lines and the
+ * bar grew to fit it.
+ */
+.topbar-right .btn {
+  width: auto;
+  height: 40px;
+  padding: 0 16px;
+  font-size: 14px;
+  white-space: nowrap;
+}
+
 .new-session {
   display: inline-flex;
   height: 40px;
@@ -652,12 +666,48 @@
     display: block;
   }
 
+  /*
+   * Four things now share this row: the wordmark, the page action, the inbox
+   * and the account. At 390px they do not all fit at desktop sizes, and what
+   * happened instead was the action sliding over the wordmark. Everything in
+   * the row gives up a little.
+   */
   .topbar-right {
+    gap: 8px;
+  }
+
+  .topbar-inner {
     gap: 10px;
   }
 
+  .topbar-right .btn {
+    height: 38px;
+    padding: 0 13px;
+    font-size: 13.5px;
+    gap: 7px;
+  }
+
+  .topbar-mark .wordmark {
+    font-size: 17px;
+  }
+
+  /*
+   * The page name is gone from the top bar, because the bottom bar is already
+   * showing it: the marked destination is the page you are on, and printing
+   * it again above bought nothing while taking the room the wordmark and the
+   * account menu now need. Hidden rather than dropped, so the document still
+   * has its heading.
+   */
   .topbar-title {
-    font-size: 19px;
+    position: absolute;
+    overflow: hidden;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    border: 0;
+    margin: -1px;
+    clip-path: inset(50%);
+    white-space: nowrap;
   }
 
   .topbar-inner {

--- a/app/src/styles/tokens.css
+++ b/app/src/styles/tokens.css
@@ -56,6 +56,9 @@
   --radius-control: 10px;
   --radius-panel: 18px;
 
+  /* Overridden at the phone breakpoint, which zooms the root; see shell.css. */
+  --zoom: 1;
+
   --ease: cubic-bezier(0.16, 1, 0.3, 1);
   --sans: "Uncut Sans", system-ui, sans-serif;
   --mono: ui-monospace, "SFMono-Regular", Consolas, monospace;

--- a/app/src/terminal/keyboard-inset.test.ts
+++ b/app/src/terminal/keyboard-inset.test.ts
@@ -28,4 +28,31 @@ describe("sizing the terminal to what the keyboard has left", () => {
     /* A small landscape phone with the keyboard up leaves almost no room. */
     expect(paneHeight({ viewportHeight: 180, offsetTop: 0, paneTop: 140 })).toBe(180);
   });
+
+  /*
+   * The phone breakpoint zooms the root, so a length written into a custom
+   * property is multiplied before it is drawn. Measuring the room in viewport
+   * pixels and handing back a number read at 1.15x sized the pane to the space
+   * the keyboard left and then drew it larger than that, which is the bug this
+   * arithmetic exists to prevent.
+   */
+  it("answers in the space the stylesheet reads it in", () => {
+    const room = paneHeight({ viewportHeight: 500, offsetTop: 0, paneTop: 140, gap: 16 });
+    const zoomed = paneHeight({
+      viewportHeight: 500, offsetTop: 0, paneTop: 140, gap: 16, zoom: 1.15,
+    });
+    expect(zoomed).toBe(Math.round(room / 1.15));
+    /* Drawn at the zoom it was measured against, it is the room again. */
+    expect(Math.round(zoomed * 1.15)).toBe(room);
+  });
+
+  it("treats an unzoomed page, and a browser that does not report one, as 1", () => {
+    const plain = paneHeight({ viewportHeight: 800, offsetTop: 0, paneTop: 140, gap: 16 });
+    expect(paneHeight({ viewportHeight: 800, offsetTop: 0, paneTop: 140, gap: 16, zoom: 1 }))
+      .toBe(plain);
+    expect(paneHeight({ viewportHeight: 800, offsetTop: 0, paneTop: 140, gap: 16, zoom: 0 }))
+      .toBe(plain);
+    expect(paneHeight({ viewportHeight: 800, offsetTop: 0, paneTop: 140, gap: 16, zoom: Number.NaN }))
+      .toBe(plain);
+  });
 });

--- a/app/src/terminal/keyboard-inset.ts
+++ b/app/src/terminal/keyboard-inset.ts
@@ -31,10 +31,19 @@ export function paneHeight(input: {
   paneTop: number;
   /** Space to leave below the pane. */
   gap?: number;
+  /**
+   * The zoom the answer will be read under. Everything measured here is in
+   * viewport pixels, but the property is read inside a zoomed subtree, where
+   * a length is multiplied by the zoom before it reaches the screen. Without
+   * dividing it back out the pane is sized to the room it has and then drawn
+   * larger than that, which puts the prompt back under the keyboard.
+   */
+  zoom?: number;
 }): number {
   const gap = input.gap ?? GAP;
+  const zoom = input.zoom && input.zoom > 0 ? input.zoom : 1;
   const available = input.viewportHeight + input.offsetTop - input.paneTop - gap;
-  return Math.max(MINIMUM, Math.round(available));
+  return Math.max(MINIMUM, Math.round(available / zoom));
 }
 
 /**
@@ -44,6 +53,18 @@ export function paneHeight(input: {
  * desktop browser has no on-screen keyboard to make room for, and a window
  * that is merely narrow is not a phone.
  */
+/**
+ * The zoom applied to the page, as a number.
+ *
+ * The phone breakpoint zooms the root so the layout is not a desktop page
+ * shrunk to fit. Browsers without `zoom`, and every width above that
+ * breakpoint, report something that is not a number, which is 1.
+ */
+function rootZoom(root: HTMLElement): number {
+  const value = Number.parseFloat(window.getComputedStyle(root).zoom);
+  return Number.isFinite(value) && value > 0 ? value : 1;
+}
+
 export function useKeyboardInset(target: RefObject<HTMLElement | null>, enabled: boolean): void {
   useEffect(() => {
     const viewport = window.visualViewport;
@@ -70,6 +91,7 @@ export function useKeyboardInset(target: RefObject<HTMLElement | null>, enabled:
           viewportHeight: viewport.height,
           offsetTop: viewport.offsetTop,
           paneTop,
+          zoom: rootZoom(root),
         })}px`,
       );
     };


### PR DESCRIPTION
Six things reported from a phone, plus what testing them turned up.

### Copying did not work, anywhere

Every copy button was `await navigator.clipboard.writeText(...)` inside a `try` with an empty `catch`. On a phone that promise rejects often enough (a home-screen window can be denied the permission; WebKit drops the user gesture the moment anything is awaited before the write) and a swallowed rejection looks exactly like a copy that worked: nothing moves, nothing is said, and the link is not on the clipboard.

There is now one `copyText` that tries the modern API, falls back to the selection-and-`execCommand` path that predates it, and reports which happened. A refused clipboard says so and puts the value on screen to be copied by hand.

`SessionClipboard` had the worse version of it: the password was unsealed *inside* the click handler, so the await that decrypted it spent the gesture the write needed. Copying a password failed every time while the link beside it worked. It is unsealed ahead of the click now.

Reproduced in headless Chrome, where `writeText` rejects with `NotAllowedError`; verified the fallback by pasting the result back with a real key event.

### Invite links could not be copied at all under 1080px

A rule hid `nth-child(4)` of every `.table`. That is the machine column in the sessions table and the date joined in the members table, but **Actions** in the invites table, so copy and revoke were gone from every invite on any narrow screen. The rule now names the columns it may drop, and a dropped column comes back once the cells stack, where there is room for it and #85's `data-label` names it.

### The session rows and board cards were not clickable

Only the name was, which on a phone is a few characters of text in a row that is otherwise a hundred pixels of nothing. The existing link is stretched over the row and over the card, so each keeps one link and one keyboard stop while the buttons, the assignee picker and the copy menu keep their own targets above it.

### Menus ran off the edge of the screen

The copy menu is anchored to a button that can sit anywhere in a 390px row, so the sentence explaining that the link opens the session to anyone holding it was the part cut off. On a phone it is a sheet across the bottom now, with a backdrop that dismisses it rather than passing the tap through to whatever was underneath.

The inbox had two causes at once: `vw` resolves against the undivided viewport while the phone breakpoint zooms the root, so `calc(100vw - 32px)` was drawn 1.15 times wider than it measured, and the panel hangs from the right edge of its trigger, which stopped being the right edge of the screen when #85 moved the account menu in beside it. 412px of panel on a 390px screen, 88px past the left edge. Insets rather than a width fixes both, because an inset scales with its containing block.

The session page scrolled sideways at every phone width, and what sat past the right edge was the copy menu and the button next to it. Its column is `1fr`, which will not go below the min-content width of its contents, and a comment can hold a URL that does not break. `minmax(0, 1fr)`.

### The bottom bar was small, and marked the current page inconsistently

The mark was drawn on the link, so it was as wide as the word inside it: a wide bordered box around "Sessions", a small one around "Team". It is a pill behind the icon now, the same size on every item, and the bar has room for a finger without running off a 320px phone.

### Everything on a phone was a size too small

The layout is written in pixels tuned for a pointer and a wide window. The root is zoomed once at the phone breakpoint, which scales layout as well as text, rather than re-tuning several hundred rules. The zoom is published as `--zoom` beside itself, because nothing else in CSS says that viewport units have stopped meaning what they say, and `--pane-height` is divided by it so the terminal is still sized to the room the keyboard left.

### And the page name is gone from the top bar on a phone

The bottom bar already says which page you are on. The heading stays in the document for anything reading the page rather than looking at it.

## Turned up on the way

- The wordmark went into the top bar in #85 wrapped in a `Link`, and `Wordmark` is a link already, so every phone-width render logged `<a> cannot contain a nested <a>`.
- `.btn` is built for a form, where it is full width and wrapping is not a question. In the top bar "Export CSV" broke across two lines.
- `shell login` was only copyable from the sidebar, which is a bar of five destinations on a phone. It is on the machines page as well now.
- The audit summary is five figures in a grid that does not divide by two, which left a grey rectangle where a sixth would have been. The people list truncated most full names into a 96px column.

## Checks

`npm test` 662 passing (8 new, covering the clipboard fallback, its failure paths, and the pane arithmetic under zoom), `tsc -b` clean, no new lint warnings, `npm run build` clean.

Every page and every menu was swept at 320, 360, 390 and 430 with the menus both open and closed: nothing crosses either edge.

## Known, not fixed here

`--pane-height` is computed, published, and then ignored: `.panes` is a flex item in a column and the base rule's `flex: 1` means `flex-basis: 0%`, which supersedes `height` on the main axis. So #85's keyboard inset does not currently do anything. Adding `flex: none` makes the height apply, but then the pane runs under the bottom bar, because the hook's 16px gap is measured against the whole screen rather than the content box. That is a judgement about how much room to leave with the keyboard up, and it wants a real device to settle, so it is left alone rather than half-changed before a deploy.