### PR TITLE
Keep the session row inside the page, and let the board hand a session over

### DIFF
--- a/app/src/components/SessionBoard.tsx
+++ b/app/src/components/SessionBoard.tsx
@@ -3,7 +3,8 @@ import { Link } from "react-router-dom";
 import { PersonChip } from "./Avatar";
 import { findPerson } from "../lib/people";
 import { kindForCommand } from "../lib/session-kinds";
-import { canRemove } from "../lib/session-view";
+import { canHandOff, canRemove } from "../lib/session-view";
+import { PersonPicker } from "./PersonPicker";
 import { ago } from "../lib/time";
 import type { Member, SessionRecord } from "../lib/api";
 import { SessionClipboard } from "./SessionClipboard";
@@ -31,12 +32,14 @@ function Card({
   members,
   you,
   action,
+  onAssign,
 }: {
   session: SessionRecord;
   now: number;
   members: Member[];
   you: Member | null;
   action: React.ReactNode;
+  onAssign: (session: SessionRecord, uid: string) => void;
 }) {
   const kind = kindForCommand(session.command);
   const assignee = findPerson(members, session.assigneeUid);
@@ -67,7 +70,20 @@ function Card({
       </p>
 
       <div className="board-card-foot">
-        {assignee ? (
+        {/*
+          * Handing a session over is a thing you do to a card, not only to a
+          * row. The board showed who it was assigned to and gave you no way to
+          * change it, so the answer to "who should pick this up" was only
+          * reachable by switching back to the table.
+          */}
+        {!session.closedAt && canHandOff(session, you) ? (
+          <PersonPicker
+            people={members}
+            value={session.assigneeUid}
+            label={`Assignee for ${session.name || session.command}`}
+            onChange={(uid) => onAssign(session, uid)}
+          />
+        ) : assignee ? (
           <PersonChip person={assignee} />
         ) : (
           <span className="board-card-unassigned">Unassigned</span>
@@ -88,6 +104,7 @@ export function SessionBoard({
   removing,
   onOpen,
   onRemove,
+  onAssign,
 }: {
   liveWrite: SessionRecord[];
   liveRead: SessionRecord[];
@@ -98,6 +115,7 @@ export function SessionBoard({
   removing: string;
   onOpen: (session: SessionRecord) => void;
   onRemove: (session: SessionRecord) => void;
+  onAssign: (session: SessionRecord, uid: string) => void;
 }) {
   const columns: Column[] = [
     {
@@ -141,6 +159,7 @@ export function SessionBoard({
                   now={now}
                   members={members}
                   you={you}
+                  onAssign={onAssign}
                   action={
                     column.key === "finished" ? (
                       /*

--- a/app/src/routes/Workspace.tsx
+++ b/app/src/routes/Workspace.tsx
@@ -644,6 +644,7 @@ export function Workspace() {
                 removing={removing}
                 onOpen={openSession}
                 onRemove={handleRemove}
+                onAssign={handleAssign}
               />
             ) : (
               <>

--- a/app/src/styles/people.css
+++ b/app/src/styles/people.css
@@ -262,6 +262,35 @@
   width: 100%;
 }
 
+/*
+ * ...and absorbing the slack must not mean setting the table's width.
+ *
+ * Auto table layout still gives every column its widest unbreakable content,
+ * and an agent command is long: `claude --dangerously-skip-permissions` is a
+ * routine one. Column one then asked for more than the page had, the table
+ * grew past its container, and the actions ran off the right edge. max-width
+ * on a cell that is already width:100% is what lets the browser shrink it, so
+ * the name truncates as .table-name always meant it to.
+ */
+.table td:first-child {
+  max-width: 0;
+  min-width: 180px;
+}
+
+.table-subject {
+  max-width: 100%;
+}
+
+/* The row's actions are the point of the row; they do not get compressed. */
+.table-end {
+  white-space: nowrap;
+}
+
+
+.session-actions .session-action {
+  flex: none;
+}
+
 /* Enough for a first name and surname before the ellipsis earns its place. */
 .table-person {
   min-width: 152px;
@@ -421,20 +450,56 @@
 /*
  * Columns that a narrow window may drop.
  *
- * This used to be `nth-child(4)`, which counted positions rather than meaning.
- * The fourth column is the machine in the sessions table and the date joined
- * in the members table, both of which can go. In the invites table it is
- * Actions, so under 1080px every invite lost its copy and revoke buttons and
- * an invite link could not be copied on a phone at all.
+ * Marked rather than counted. This used to be `nth-child(4)`, which counted
+ * positions rather than meaning: the fourth column is the machine in the
+ * sessions table and the date joined in the members table, both of which can
+ * go, but in the invites table it is Actions, so every invite lost its copy
+ * and revoke buttons and an invite link could not be copied on a phone.
+ *
+ * They go at 1240px rather than 1080px because the sessions row has four
+ * action buttons to keep on screen, and the machine is the column you are
+ * least often reading.
  */
-@media (max-width: 1080px) {
+@media (max-width: 1240px) {
   .table thead th.table-optional,
   .table tbody td.table-optional {
     display: none;
   }
 }
 
-@media (max-width: 900px) {
+/*
+ * Between the machine column going and the stacked layout arriving there is a
+ * band where four action buttons and two person columns do not both fit. The
+ * row gets tighter rather than losing its actions off the right edge.
+ */
+@media (max-width: 1120px) and (min-width: 1001px) {
+  .table td,
+  .table thead th {
+    padding-right: 7px;
+    padding-left: 7px;
+  }
+
+  .table-person {
+    min-width: 118px;
+  }
+
+  .table .session-action {
+    height: 34px;
+    padding: 0 11px;
+    font-size: 13px;
+  }
+
+  .table .session-actions {
+    gap: 6px;
+  }
+}
+
+/*
+ * Below this the columns stop fitting whatever is trimmed, so the row becomes
+ * a stack. Raised from 900px, where the last action button was being cut off
+ * the right edge instead.
+ */
+@media (max-width: 1000px) {
   .table,
   .table thead,
   .table tbody,


### PR DESCRIPTION
The sessions table set its own width and overflowed the page: column one carries the command, an agent command is long, and auto table layout gives every column its widest unbreakable content. The actions ran off the right edge.

`.table-name` always meant to truncate and never could, because nothing bounded the cell it was in. Fixed with a max-width on a cell that is already `width: 100%`, the machine column dropping at 1240px, a tighter row between 1000 and 1120, and the stacked layout starting at 1000px rather than 900px.

The board now has the same assignee picker the table row has.