### PR TITLE
Offer the same operations from the board and the session page

### DIFF
--- a/app/src/components/SessionBoard.tsx
+++ b/app/src/components/SessionBoard.tsx
@@ -1,8 +1,8 @@
-import { Terminal as TerminalIcon, Trash, Eye } from "@phosphor-icons/react";
+import { Eye, Stop as StopIcon, Terminal as TerminalIcon, Trash } from "@phosphor-icons/react";
 import { Link } from "react-router-dom";
 import { PeopleChip } from "./Avatar";
 import { kindForCommand } from "../lib/session-kinds";
-import { assigneeIds, canHandOff, canRemove } from "../lib/session-view";
+import { assigneeIds, canHandOff, canRemove, canStop } from "../lib/session-view";
 import { MultiPersonPicker } from "./PersonPicker";
 import { ago } from "../lib/time";
 import type { Member, SessionRecord } from "../lib/api";
@@ -34,6 +34,8 @@ function Card({
   action,
   onOpen,
   onAssign,
+  onStop,
+  stopping,
 }: {
   session: SessionRecord;
   now: number;
@@ -42,6 +44,8 @@ function Card({
   action: React.ReactNode;
   onOpen: (session: SessionRecord) => void;
   onAssign: (session: SessionRecord, uids: string[]) => void;
+  onStop: (session: SessionRecord) => void;
+  stopping: string;
 }) {
   const kind = kindForCommand(session.command);
   const selected = new Set(assigneeIds(session));
@@ -94,6 +98,22 @@ function Card({
         ) : (
           <PeopleChip people={assignees} />
         )}
+        {/*
+          * Stopping was reachable from the table and not from here, so the
+          * board could show a session that was yours to stop and give you no
+          * way to stop it.
+          */}
+        {canStop(session, you) && (
+          <button
+            type="button"
+            className="session-action"
+            onClick={() => void onStop(session)}
+            disabled={stopping === session.id}
+          >
+            <StopIcon size={14} weight="bold" />
+            {stopping === session.id ? "Stopping" : "Stop"}
+          </button>
+        )}
         {action}
       </div>
     </li>
@@ -111,6 +131,8 @@ export function SessionBoard({
   onOpen,
   onRemove,
   onAssign,
+  onStop,
+  stopping,
 }: {
   liveWrite: SessionRecord[];
   liveRead: SessionRecord[];
@@ -122,6 +144,8 @@ export function SessionBoard({
   onOpen: (session: SessionRecord) => void;
   onRemove: (session: SessionRecord) => void;
   onAssign: (session: SessionRecord, uids: string[]) => void;
+  onStop: (session: SessionRecord) => void;
+  stopping: string;
 }) {
   const columns: Column[] = [
     {
@@ -167,6 +191,8 @@ export function SessionBoard({
                   you={you}
                   onOpen={onOpen}
                   onAssign={onAssign}
+                  onStop={onStop}
+                  stopping={stopping}
                   action={
                     column.key === "finished" ? (
                       /*

--- a/app/src/routes/Session.tsx
+++ b/app/src/routes/Session.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useRef, useState, type FormEvent } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import {
   ArrowLeft,
   PaperPlaneTilt,
+  Stop as StopIcon,
   Terminal as TerminalIcon,
+  Trash,
 } from "@phosphor-icons/react";
 import { AppShell } from "../components/AppShell";
 import { Avatar, PeopleChip, PersonChip } from "../components/Avatar";
@@ -15,8 +17,10 @@ import { SessionClipboard } from "../components/SessionClipboard";
 import { SessionAudience } from "../components/SessionAudience";
 import {
   assignSession,
+  deleteSession,
   fetchSession,
   postComment,
+  stopSession,
   type Comment,
   type Member,
   type SessionDetail,
@@ -24,7 +28,7 @@ import {
 import { splitMentions } from "../lib/mentions";
 import { displayName, findPerson } from "../lib/people";
 import { usePageTitle } from "../lib/page-title";
-import { assigneeIds } from "../lib/session-view";
+import { assigneeIds, canRemove, canStop } from "../lib/session-view";
 import { ago, elapsed } from "../lib/time";
 
 function CommentBody({ body, members }: { body: string; members: Member[] }) {
@@ -68,7 +72,9 @@ export function Session() {
   const [error, setError] = useState("");
   const [draft, setDraft] = useState("");
   const [posting, setPosting] = useState(false);
+  const [working, setWorking] = useState("");
   const composer = useRef<HTMLTextAreaElement>(null);
+  const navigate = useNavigate();
   const assignmentRevision = useRef(0);
   const assignmentQueue = useRef<Promise<void>>(Promise.resolve());
 
@@ -120,6 +126,42 @@ export function Session() {
   const live = !session.closedAt;
   const canAssign =
     session.ownerUid === you.uid || you.role === "owner" || you.role === "admin";
+
+  /*
+   * Stopping and removing belong here too.
+   *
+   * They were reachable from the list and not from the session's own page, so
+   * opening a session to look at it meant going back to the list to act on it.
+   * On a phone this page is the one you are on.
+   */
+  async function handleStop() {
+    if (!detail?.session.deviceId) return;
+    setWorking("stop");
+    setError("");
+    try {
+      await stopSession(detail.session.deviceId, detail.session.id);
+      /* The machine has to poll and report, so the row catches up shortly. */
+      window.setTimeout(() => void load(), 1500);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Could not stop that session.");
+    } finally {
+      setWorking("");
+    }
+  }
+
+  async function handleRemove() {
+    if (!detail) return;
+    setWorking("remove");
+    setError("");
+    try {
+      await deleteSession(detail.session.id);
+      /* The page it was showing is gone, so there is nothing to stay on. */
+      navigate("/sessions");
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Could not remove that session.");
+      setWorking("");
+    }
+  }
 
   async function handleComment(event: FormEvent) {
     event.preventDefault();
@@ -207,6 +249,29 @@ export function Session() {
               * on a phone is the screen you are actually on.
               */}
             <SessionClipboard session={session} you={you} />
+            {canStop(session, you) && (
+              <button
+                type="button"
+                className="session-action"
+                onClick={() => void handleStop()}
+                disabled={working === "stop"}
+              >
+                <StopIcon size={15} weight="bold" />
+                {working === "stop" ? "Stopping" : "Stop"}
+              </button>
+            )}
+            {canRemove(session, you) && (
+              <button
+                type="button"
+                className="session-action"
+                onClick={() => void handleRemove()}
+                disabled={working === "remove"}
+                title="Remove from the list. The machine is not touched."
+              >
+                <Trash size={15} />
+                {working === "remove" ? "Removing" : "Remove"}
+              </button>
+            )}
           </div>
 
           <SessionAudience session={session} members={members} you={you} />

--- a/app/src/routes/Workspace.tsx
+++ b/app/src/routes/Workspace.tsx
@@ -726,6 +726,8 @@ export function Workspace() {
                 onOpen={openSession}
                 onRemove={handleRemove}
                 onAssign={handleAssign}
+                onStop={handleKill}
+                stopping={killing}
               />
             ) : (
               <>

--- a/app/src/styles/auth.css
+++ b/app/src/styles/auth.css
@@ -1479,6 +1479,23 @@
  * the card, the same arrangement the table row uses, so both views answer a
  * tap in the same place: the session, not nothing.
  */
+/*
+ * Its children may shrink.
+ *
+ * A grid item's automatic minimum is its min-content, and both the card's name
+ * and its meta line are `white-space: nowrap`, so a long machine name set a
+ * floor the card could not go below: the card pushed the column and the column
+ * pushed the page. They were always meant to ellipsize; this is what lets them.
+ */
+.board,
+.board-column,
+.board-cards,
+.board-card,
+.board-card > *,
+.board-card-head > * {
+  min-width: 0;
+}
+
 .board-card {
   position: relative;
   display: grid;


### PR DESCRIPTION
A session could be stopped from the table and not from the board, and neither stopped nor removed from its own page — which on a phone is the page you are on. Both have them now, gated by the same `canStop` and `canRemove` the table uses.

Board cards could not shrink either: a grid item's automatic minimum is its min-content, and both the card's name and meta line are `white-space: nowrap`, so a long machine name set a floor the card could not go below and pushed the column past the page.

**Rebuilt on current main.** The row CSS and overlay fixes this branch used to carry are gone — main fixed the same things while it was open (#90's filtered click handler instead of a stretched overlay, #91's `flex-wrap: nowrap` on the row actions). Re-applying mine would have undone better versions of them.