### PR TITLE
Allow sessions to have multiple assignees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable user-visible changes are recorded here. Versions follow [Semantic Ve
 
 ### Added
 
+- Assign a session to several teammates from the same dropdown. Each tick saves immediately, every assignee can type, and older clients still see the first assignee.
 - Choose who can open a session when you start it. The password is generated and sealed to each person ticked, so nothing is typed and nobody is told a secret; people can be added afterwards from the session page.
 - Offer the session you just started as soon as the machine publishes it, instead of leaving you to find its row.
 - Pick a model for Claude Code and Codex sessions.

--- a/app/server/app.test.ts
+++ b/app/server/app.test.ts
@@ -1134,6 +1134,28 @@ describe("session ownership and handoff", () => {
     expect(handed.body.session.ownerUid).toBe("uid-1");
   });
 
+  it("assigns a session to several teammates in one update", async () => {
+    await orgWithColleague();
+    const handed = await call("PUT", `/api/sessions/${session.id}/assignee`, {
+      auth: await idToken(),
+      body: { uids: ["uid-1", "uid-2", "uid-2"] },
+    });
+    expect(handed.status).toBe(200);
+    expect(handed.body.session.assigneeUids).toEqual(["uid-1", "uid-2"]);
+    expect(handed.body.session.assigneeUid).toBe("uid-1");
+  });
+
+  it("allows a session to be left unassigned", async () => {
+    await orgWithColleague();
+    const handed = await call("PUT", `/api/sessions/${session.id}/assignee`, {
+      auth: await idToken(),
+      body: { uids: [] },
+    });
+    expect(handed.status).toBe(200);
+    expect(handed.body.session.assigneeUids).toEqual([]);
+    expect(handed.body.session.assigneeUid).toBeUndefined();
+  });
+
   it("lets only the owner share a session key, and only with current members", async () => {
     const { colleague } = await orgWithColleague();
     const path = `/api/sessions/${session.id}/keys`;

--- a/app/server/app.ts
+++ b/app/server/app.ts
@@ -725,15 +725,22 @@ export function createApp(options: AppOptions) {
         const membership = await requireMember(request);
         if (!membership) return send(response, 401, { error: "sign in first" });
         const body = (await readBody(request)) as Record<string, unknown>;
-        const result = await assignSession(store, membership, assignRoute[1], String(body.uid ?? ""));
+        const requested = Array.isArray(body.uids)
+          ? body.uids.map(String)
+          : body.uid
+            ? [String(body.uid)]
+            : [];
+        const result = await assignSession(store, membership, assignRoute[1], requested);
         if (!result.ok) return send(response, result.status, { error: result.error });
-        await notifyAssigned(
-          store,
-          membership,
-          assignRoute[1],
-          String(body.uid ?? ""),
-          result.session.name || result.session.command,
-        );
+        for (const uid of result.addedUids) {
+          await notifyAssigned(
+            store,
+            membership,
+            assignRoute[1],
+            uid,
+            result.session.name || result.session.command,
+          );
+        }
         return send(response, 200, { session: result.session });
       }
 

--- a/app/server/lib/migrations/006_multi_assignees.sql
+++ b/app/server/lib/migrations/006_multi_assignees.sql
@@ -1,0 +1,13 @@
+-- Responsibility can be shared. Keep assignee_uid populated as the first
+-- assignee so a previous Worker remains safe to roll back to.
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS assignee_uids TEXT[];
+
+UPDATE sessions
+SET assignee_uids = CASE
+  WHEN assignee_uid IS NULL THEN '{}'
+  ELSE ARRAY[assignee_uid]
+END
+WHERE assignee_uids IS NULL;
+
+ALTER TABLE sessions ALTER COLUMN assignee_uids SET DEFAULT '{}';
+ALTER TABLE sessions ALTER COLUMN assignee_uids SET NOT NULL;

--- a/app/server/lib/sessions.ts
+++ b/app/server/lib/sessions.ts
@@ -82,6 +82,7 @@ export async function registerSession(
     ownerUid: input.ownerUid ?? uid,
     /* The person who started it is responsible until they hand it over. */
     assigneeUid: input.ownerUid ?? uid,
+    assigneeUids: [input.ownerUid ?? uid],
     shareUrl: input.shareUrl,
     command: input.command.slice(0, 300),
     name: typeof input.name === "string" && input.name.trim()

--- a/app/server/lib/store-conformance.test.ts
+++ b/app/server/lib/store-conformance.test.ts
@@ -368,9 +368,21 @@ for (const implementation of implementations) {
 
       it("keeps a handoff when a persistent session re-registers", async () => {
         await store.upsertSession(session());
-        await store.assignSession("org_1", "s1", "uid-2");
+        await store.assignSession("org_1", "s1", ["uid-2"]);
         await store.upsertSession(session({ assigneeUid: "uid-1" }));
         expect((await store.sessionInOrg("org_1", "s1"))?.assigneeUid).toBe("uid-2");
+      });
+
+      it("keeps multiple assignees, including an intentional empty set", async () => {
+        await store.upsertSession(session());
+        await store.assignSession("org_1", "s1", ["uid-1", "uid-2"]);
+        expect((await store.sessionInOrg("org_1", "s1"))?.assigneeUids).toEqual([
+          "uid-1",
+          "uid-2",
+        ]);
+        await store.assignSession("org_1", "s1", []);
+        await store.upsertSession(session({ assigneeUid: "uid-1" }));
+        expect((await store.sessionInOrg("org_1", "s1"))?.assigneeUids).toEqual([]);
       });
 
       it("scopes a list to one account and one organization", async () => {
@@ -436,7 +448,7 @@ for (const implementation of implementations) {
       it("says so when the session is not in the organization", async () => {
         await store.upsertSession(session());
         expect(await store.putKeyShares("org_2", "s1", [])).toBe(false);
-        expect(await store.assignSession("org_2", "s1", "uid-2")).toBeNull();
+        expect(await store.assignSession("org_2", "s1", ["uid-2"])).toBeNull();
       });
     });
 

--- a/app/server/lib/store-memory.ts
+++ b/app/server/lib/store-memory.ts
@@ -86,6 +86,12 @@ export class MemoryStore implements Store {
         changed = true;
       }
     }
+    for (const session of this.data.sessions) {
+      if (!session.assigneeUids) {
+        session.assigneeUids = session.assigneeUid ? [session.assigneeUid] : [];
+        changed = true;
+      }
+    }
     if (changed) this.flush();
   }
 
@@ -269,6 +275,7 @@ export class MemoryStore implements Store {
     );
     if (index >= 0) {
       const existing = this.data.sessions[index];
+      const hadAssignment = existing.assigneeUids !== undefined;
       this.data.sessions[index] = {
         ...existing,
         ...session,
@@ -277,10 +284,23 @@ export class MemoryStore implements Store {
          * owner as assignee. Letting that through would silently undo a
          * handoff, so an assignment already made stands.
          */
-        assigneeUid: existing.assigneeUid ?? session.assigneeUid,
+        assigneeUid: hadAssignment
+          ? existing.assigneeUid
+          : existing.assigneeUid ?? session.assigneeUid,
+        assigneeUids:
+          hadAssignment
+            ? existing.assigneeUids
+            : session.assigneeUids?.length
+              ? session.assigneeUids
+              : session.assigneeUid
+                ? [session.assigneeUid]
+                : [],
       };
     } else {
-      this.data.sessions.push(session);
+      this.data.sessions.push({
+        ...session,
+        assigneeUids: session.assigneeUids ?? (session.assigneeUid ? [session.assigneeUid] : []),
+      });
     }
     this.flush();
     return index < 0;
@@ -314,10 +334,11 @@ export class MemoryStore implements Store {
     ) ?? null;
   }
 
-  async assignSession(orgId: string, id: string, assigneeUid: string): Promise<SessionRecord | null> {
+  async assignSession(orgId: string, id: string, assigneeUids: string[]): Promise<SessionRecord | null> {
     const session = await this.sessionInOrg(orgId, id);
     if (!session) return null;
-    session.assigneeUid = assigneeUid;
+    session.assigneeUids = [...new Set(assigneeUids)];
+    session.assigneeUid = session.assigneeUids[0];
     this.flush();
     return session;
   }

--- a/app/server/lib/store-postgres.ts
+++ b/app/server/lib/store-postgres.ts
@@ -152,12 +152,18 @@ function toToken(row: Row): CliToken {
 }
 
 function toSession(row: Row, shares: SessionKeyShare[]): SessionRecord {
+  const assigneeUids = Array.isArray(row.assignee_uids)
+    ? (row.assignee_uids as string[])
+    : row.assignee_uid
+      ? [row.assignee_uid as string]
+      : [];
   const session = defined({
     id: row.id,
     uid: row.uid,
     orgId: row.org_id,
     ownerUid: row.owner_uid,
     assigneeUid: row.assignee_uid,
+    assigneeUids,
     shareUrl: row.share_url,
     command: row.command,
     origin: row.origin,
@@ -636,13 +642,14 @@ export class PostgresStore implements Store {
      */
     const row = await this.row(
       `INSERT INTO sessions
-         (uid, id, org_id, owner_uid, assignee_uid, share_url, command, origin, name,
+         (uid, id, org_id, owner_uid, assignee_uid, assignee_uids, share_url, command, origin, name,
           read_only, encrypted, persistent, host, started_at, closed_at, exit_code)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
        ON CONFLICT (uid, id) DO UPDATE SET
          org_id = EXCLUDED.org_id,
          owner_uid = EXCLUDED.owner_uid,
-         assignee_uid = COALESCE(sessions.assignee_uid, EXCLUDED.assignee_uid),
+         assignee_uid = sessions.assignee_uid,
+         assignee_uids = sessions.assignee_uids,
          share_url = EXCLUDED.share_url,
          command = EXCLUDED.command,
          origin = EXCLUDED.origin,
@@ -661,6 +668,7 @@ export class PostgresStore implements Store {
         session.orgId ?? null,
         session.ownerUid ?? null,
         session.assigneeUid ?? null,
+        session.assigneeUids ?? (session.assigneeUid ? [session.assigneeUid] : []),
         session.shareUrl,
         session.command,
         session.origin ?? null,
@@ -764,11 +772,14 @@ export class PostgresStore implements Store {
   async assignSession(
     orgId: string,
     id: string,
-    assigneeUid: string,
+    assigneeUids: string[],
   ): Promise<SessionRecord | null> {
     const row = await this.row(
-      "UPDATE sessions SET assignee_uid = $3 WHERE org_id = $1 AND id = $2 RETURNING *",
-      [orgId, id, assigneeUid],
+      `UPDATE sessions
+       SET assignee_uid = $3, assignee_uids = $4
+       WHERE org_id = $1 AND id = $2
+       RETURNING *`,
+      [orgId, id, assigneeUids[0] ?? null, assigneeUids],
     );
     return row ? (await this.hydrate([row]))[0] : null;
   }

--- a/app/server/lib/store.ts
+++ b/app/server/lib/store.ts
@@ -74,7 +74,7 @@ export interface Store {
   listSessions(uid: string): Promise<SessionRecord[]>;
   listOrgSessions(orgId: string): Promise<SessionRecord[]>;
   sessionInOrg(orgId: string, id: string): Promise<SessionRecord | null>;
-  assignSession(orgId: string, id: string, assigneeUid: string): Promise<SessionRecord | null>;
+  assignSession(orgId: string, id: string, assigneeUids: string[]): Promise<SessionRecord | null>;
   /**
    * Removes a session's record from an organization.
    *

--- a/app/server/lib/types.ts
+++ b/app/server/lib/types.ts
@@ -116,8 +116,10 @@ export interface SessionRecord {
   orgId?: string;
   /** Who started it. */
   ownerUid?: string;
-  /** Who is responsible for it now; the owner until handed off. */
+  /** First assignee, retained for clients from before multi-assignment. */
   assigneeUid?: string;
+  /** Everyone currently responsible for the session. */
+  assigneeUids?: string[];
   /**
    * The session password, sealed once per member. The service relays these
    * and can open none of them.

--- a/app/server/routes/audit.ts
+++ b/app/server/routes/audit.ts
@@ -56,8 +56,11 @@ export async function assignSession(
   store: Store,
   membership: Membership,
   sessionId: string,
-  assigneeUid: string,
-): Promise<{ ok: true; session: SessionRecord } | { ok: false; status: number; error: string }> {
+  assigneeUids: string[],
+): Promise<
+  | { ok: true; session: SessionRecord; addedUids: string[] }
+  | { ok: false; status: number; error: string }
+> {
   const session = await store.sessionInOrg(membership.orgId, sessionId);
   if (!session) return { ok: false, status: 404, error: "no such session" };
 
@@ -67,20 +70,34 @@ export async function assignSession(
     return { ok: false, status: 403, error: "only the session's owner can hand it off" };
   }
 
-  const assignee = (await store.members(membership.orgId)).find((entry) => entry.uid === assigneeUid);
-  if (!assignee) {
-    return { ok: false, status: 404, error: "that person is not in this organization" };
+  const unique = [...new Set(assigneeUids.filter(Boolean))];
+  if (unique.length > 50) {
+    return { ok: false, status: 400, error: "a session may have at most 50 assignees" };
+  }
+  const members = await store.members(membership.orgId);
+  const byUid = new Map(members.map((entry) => [entry.uid, entry]));
+  if (unique.some((uid) => !byUid.has(uid))) {
+    return { ok: false, status: 404, error: "an assignee is not in this organization" };
   }
 
-  const updated = await store.assignSession(membership.orgId, sessionId, assigneeUid);
+  const previous = session.assigneeUids?.length
+    ? session.assigneeUids
+    : session.assigneeUid
+      ? [session.assigneeUid]
+      : [];
+  const addedUids = unique.filter((uid) => !previous.includes(uid));
+
+  const updated = await store.assignSession(membership.orgId, sessionId, unique);
   if (!updated) return { ok: false, status: 404, error: "no such session" };
 
   await recordAudit(store, membership, {
     sessionId,
     kind: "handoff",
-    text: `assigned to ${assignee.email}`,
+    text: unique.length
+      ? `assigned to ${unique.map((uid) => byUid.get(uid)?.email).join(", ")}`
+      : "cleared assignees",
   });
-  return { ok: true, session: updated };
+  return { ok: true, session: updated, addedUids };
 }
 
 /** Collaboration metadata as CSV, retained for prerelease API compatibility. */

--- a/app/src/components/Avatar.tsx
+++ b/app/src/components/Avatar.tsx
@@ -59,3 +59,14 @@ export function AvatarStack({ people, max = 4 }: { people: Person[]; max?: numbe
     </span>
   );
 }
+
+/** A compact, explicit summary for a group of people. */
+export function PeopleChip({ people }: { people: Person[] }) {
+  if (people.length === 0) return <span className="people-empty">Unassigned</span>;
+  return (
+    <span className="people-chip" title={people.map(displayName).join(", ")}>
+      <AvatarStack people={people} max={3} />
+      <span>{people.length === 1 ? displayName(people[0]) : `${people.length} people`}</span>
+    </span>
+  );
+}

--- a/app/src/components/PersonPicker.tsx
+++ b/app/src/components/PersonPicker.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { CaretDown, Check, MagnifyingGlass } from "@phosphor-icons/react";
-import { Avatar } from "./Avatar";
+import { Avatar, AvatarStack } from "./Avatar";
 import { displayName, type Person } from "../lib/people";
 
 interface PersonPickerProps<T extends Person> {
@@ -145,6 +145,149 @@ export function PersonPicker<T extends Person>({
                   </button>
                 </li>
               ))
+            )}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface MultiPersonPickerProps<T extends Person> {
+  people: T[];
+  values: string[];
+  onChange(uids: string[]): void;
+  disabled?: boolean;
+  label: string;
+  align?: "left" | "right";
+}
+
+/** Multi-assignment with immediate saves: every tick is the whole operation. */
+export function MultiPersonPicker<T extends Person>({
+  people,
+  values,
+  onChange,
+  disabled,
+  label,
+  align = "left",
+}: MultiPersonPickerProps<T>) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [active, setActive] = useState(0);
+  const wrapper = useRef<HTMLDivElement>(null);
+  const search = useRef<HTMLInputElement>(null);
+  const selectedIds = new Set(values);
+  const selected = people.filter((person) => selectedIds.has(person.uid));
+  const searchable = people.length > 6;
+  const matches = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return people;
+    return people.filter((person) =>
+      `${displayName(person)} ${person.email ?? ""}`.toLowerCase().includes(needle),
+    );
+  }, [people, query]);
+
+  useEffect(() => {
+    if (!open) return;
+    const close = (event: MouseEvent) => {
+      if (!wrapper.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const escape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", close);
+    document.addEventListener("keydown", escape);
+    if (searchable) search.current?.focus();
+    return () => {
+      document.removeEventListener("mousedown", close);
+      document.removeEventListener("keydown", escape);
+    };
+  }, [open, searchable]);
+
+  function toggle(uid: string) {
+    onChange(selectedIds.has(uid) ? values.filter((value) => value !== uid) : [...values, uid]);
+  }
+
+  return (
+    <div className={`picker picker-${align}`} ref={wrapper}>
+      <button
+        type="button"
+        className="picker-trigger picker-trigger-multi"
+        onClick={() => setOpen((current) => !current)}
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={label}
+      >
+        {selected.length ? <AvatarStack people={selected} max={3} /> : null}
+        <span className={selected.length ? "picker-label" : "picker-label picker-empty"}>
+          {selected.length === 0
+            ? "Unassigned"
+            : selected.length === 1
+              ? displayName(selected[0])
+              : `${selected.length} people`}
+        </span>
+        <CaretDown size={12} weight="bold" className="picker-caret" />
+      </button>
+
+      {open && (
+        <div className="picker-pop" role="listbox" aria-label={label} aria-multiselectable="true">
+          {searchable && (
+            <div className="picker-search">
+              <MagnifyingGlass size={14} />
+              <input
+                ref={search}
+                value={query}
+                onChange={(event) => {
+                  setQuery(event.target.value);
+                  setActive(0);
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === "ArrowDown") {
+                    event.preventDefault();
+                    setActive((current) => Math.min(current + 1, matches.length - 1));
+                  } else if (event.key === "ArrowUp") {
+                    event.preventDefault();
+                    setActive((current) => Math.max(current - 1, 0));
+                  } else if (event.key === "Enter" && matches[active]) {
+                    event.preventDefault();
+                    toggle(matches[active].uid);
+                  }
+                }}
+                placeholder="Search people"
+                aria-label="Search people"
+              />
+            </div>
+          )}
+
+          <ul className="picker-list">
+            {matches.length === 0 ? (
+              <li className="picker-none">Nobody matches that.</li>
+            ) : (
+              matches.map((person, index) => {
+                const checked = selectedIds.has(person.uid);
+                return (
+                  <li key={person.uid}>
+                    <button
+                      type="button"
+                      role="option"
+                      aria-selected={checked}
+                      className={index === active && searchable ? "picker-item is-active" : "picker-item"}
+                      onMouseEnter={() => setActive(index)}
+                      onClick={() => toggle(person.uid)}
+                    >
+                      <Avatar person={person} size="sm" />
+                      <span className="picker-item-text">
+                        <span className="picker-item-name">{displayName(person)}</span>
+                        {person.email && <span className="picker-item-mail">{person.email}</span>}
+                      </span>
+                      <span className={checked ? "picker-check is-checked" : "picker-check"}>
+                        {checked && <Check size={12} weight="bold" />}
+                      </span>
+                    </button>
+                  </li>
+                );
+              })
             )}
           </ul>
         </div>

--- a/app/src/components/SessionBoard.tsx
+++ b/app/src/components/SessionBoard.tsx
@@ -1,10 +1,9 @@
 import { Terminal as TerminalIcon, Trash, Eye } from "@phosphor-icons/react";
 import { Link } from "react-router-dom";
-import { PersonChip } from "./Avatar";
-import { findPerson } from "../lib/people";
+import { PeopleChip } from "./Avatar";
 import { kindForCommand } from "../lib/session-kinds";
-import { canHandOff, canRemove } from "../lib/session-view";
-import { PersonPicker } from "./PersonPicker";
+import { assigneeIds, canHandOff, canRemove } from "../lib/session-view";
+import { MultiPersonPicker } from "./PersonPicker";
 import { ago } from "../lib/time";
 import type { Member, SessionRecord } from "../lib/api";
 import { SessionClipboard } from "./SessionClipboard";
@@ -39,10 +38,11 @@ function Card({
   members: Member[];
   you: Member | null;
   action: React.ReactNode;
-  onAssign: (session: SessionRecord, uid: string) => void;
+  onAssign: (session: SessionRecord, uids: string[]) => void;
 }) {
   const kind = kindForCommand(session.command);
-  const assignee = findPerson(members, session.assigneeUid);
+  const selected = new Set(assigneeIds(session));
+  const assignees = members.filter((member) => selected.has(member.uid));
 
   return (
     <li className="board-card">
@@ -77,16 +77,14 @@ function Card({
           * reachable by switching back to the table.
           */}
         {!session.closedAt && canHandOff(session, you) ? (
-          <PersonPicker
+          <MultiPersonPicker
             people={members}
-            value={session.assigneeUid}
-            label={`Assignee for ${session.name || session.command}`}
-            onChange={(uid) => onAssign(session, uid)}
+            values={assigneeIds(session)}
+            label={`Assignees for ${session.name || session.command}`}
+            onChange={(uids) => onAssign(session, uids)}
           />
-        ) : assignee ? (
-          <PersonChip person={assignee} />
         ) : (
-          <span className="board-card-unassigned">Unassigned</span>
+          <PeopleChip people={assignees} />
         )}
         {action}
       </div>
@@ -115,7 +113,7 @@ export function SessionBoard({
   removing: string;
   onOpen: (session: SessionRecord) => void;
   onRemove: (session: SessionRecord) => void;
-  onAssign: (session: SessionRecord, uid: string) => void;
+  onAssign: (session: SessionRecord, uids: string[]) => void;
 }) {
   const columns: Column[] = [
     {

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -108,10 +108,10 @@ export function shareSessionKeys(
   );
 }
 
-export function assignSession(sessionId: string, uid: string) {
+export function assignSession(sessionId: string, uids: string[]) {
   return request<{ session: SessionRecord }>(
     `/api/sessions/${encodeURIComponent(sessionId)}/assignee`,
-    { method: "PUT", body: JSON.stringify({ uid }) },
+    { method: "PUT", body: JSON.stringify({ uids }) },
   );
 }
 
@@ -179,7 +179,9 @@ export interface SessionRecord {
   origin?: string;
   orgId?: string;
   ownerUid?: string;
+  /** First assignee, retained for compatibility with older app versions. */
   assigneeUid?: string;
+  assigneeUids?: string[];
   /** Linked machine that owns the local process. */
   deviceId?: string;
   /** The password sealed to the caller, when one has been shared with them. */

--- a/app/src/lib/session-view.test.ts
+++ b/app/src/lib/session-view.test.ts
@@ -72,6 +72,12 @@ describe("which column a session belongs in", () => {
     expect(canEdit(session({ ownerUid: "uid-2", assigneeUid: "uid-1" }), you)).toBe(true);
   });
 
+  it("lets every assignee write to a multi-assigned session", () => {
+    expect(
+      canEdit(session({ ownerUid: "uid-3", assigneeUids: ["uid-2", "uid-1"] }), you),
+    ).toBe(true);
+  });
+
   it("puts a colleague's session in read", () => {
     expect(canEdit(session({ ownerUid: "uid-2" }), you)).toBe(false);
   });

--- a/app/src/lib/session-view.ts
+++ b/app/src/lib/session-view.ts
@@ -12,12 +12,22 @@ import type { Member, SessionRecord } from "./api";
 
 /**
  * Everyone in the team can watch a session. Typing into it belongs to the
- * person who started it and the person it is assigned to.
+ * person who started it and the people it is assigned to.
  */
 export function canEdit(session: SessionRecord, you: Member | null): boolean {
   if (!you) return false;
   if (session.readOnly) return false;
-  return session.ownerUid === you.uid || session.assigneeUid === you.uid;
+  return session.ownerUid === you.uid || assigneeIds(session).includes(you.uid);
+}
+
+/** Reads both the current array and the legacy single-assignee shape. */
+export function assigneeIds(session: SessionRecord): string[] {
+  const ids = session.assigneeUids?.length
+    ? session.assigneeUids
+    : session.assigneeUid
+      ? [session.assigneeUid]
+      : [];
+  return [...new Set(ids.filter(Boolean))];
 }
 
 /** Handing a session over is the owner's to do, or the team's to arrange. */

--- a/app/src/routes/Session.tsx
+++ b/app/src/routes/Session.tsx
@@ -6,8 +6,8 @@ import {
   Terminal as TerminalIcon,
 } from "@phosphor-icons/react";
 import { AppShell } from "../components/AppShell";
-import { Avatar, PersonChip } from "../components/Avatar";
-import { PersonPicker } from "../components/PersonPicker";
+import { Avatar, PeopleChip, PersonChip } from "../components/Avatar";
+import { MultiPersonPicker } from "../components/PersonPicker";
 import { Button } from "../components/Button";
 import { Alert } from "../components/Alert";
 import { Booting } from "../components/Booting";
@@ -24,6 +24,7 @@ import {
 import { splitMentions } from "../lib/mentions";
 import { displayName, findPerson } from "../lib/people";
 import { usePageTitle } from "../lib/page-title";
+import { assigneeIds } from "../lib/session-view";
 import { ago, elapsed } from "../lib/time";
 
 function CommentBody({ body, members }: { body: string; members: Member[] }) {
@@ -68,6 +69,8 @@ export function Session() {
   const [draft, setDraft] = useState("");
   const [posting, setPosting] = useState(false);
   const composer = useRef<HTMLTextAreaElement>(null);
+  const assignmentRevision = useRef(0);
+  const assignmentQueue = useRef<Promise<void>>(Promise.resolve());
 
   const load = useCallback(async () => {
     try {
@@ -100,7 +103,8 @@ export function Session() {
 
   const { session, members, you, comments } = detail;
   const owner = findPerson(members, session.ownerUid);
-  const assignee = findPerson(members, session.assigneeUid);
+  const selected = new Set(assigneeIds(session));
+  const assignees = members.filter((member) => selected.has(member.uid));
   const live = !session.closedAt;
   const canAssign =
     session.ownerUid === you.uid || you.role === "owner" || you.role === "admin";
@@ -126,6 +130,35 @@ export function Session() {
     const handle = `@${displayName(member)} `;
     setDraft((current) => (current.endsWith(" ") || !current ? current : `${current} `) + handle);
     composer.current?.focus();
+  }
+
+  async function handleAssign(uids: string[]) {
+    const revision = ++assignmentRevision.current;
+    const previous = assigneeIds(session);
+    setDetail((current) => current ? {
+      ...current,
+      session: { ...current.session, assigneeUid: uids[0], assigneeUids: uids },
+    } : current);
+
+    const request = assignmentQueue.current.catch(() => undefined).then(async () => {
+      const { session: updated } = await assignSession(session.id, uids);
+      if (assignmentRevision.current === revision) {
+        setDetail((current) => current ? { ...current, session: updated } : current);
+      }
+    });
+    assignmentQueue.current = request;
+    try {
+      await request;
+      if (assignmentRevision.current === revision) setError("");
+    } catch (caught) {
+      if (assignmentRevision.current === revision) {
+        setDetail((current) => current ? {
+          ...current,
+          session: { ...current.session, assigneeUid: previous[0], assigneeUids: previous },
+        } : current);
+        setError(caught instanceof Error ? caught.message : "Could not update assignees.");
+      }
+    }
   }
 
   return (
@@ -230,20 +263,17 @@ export function Session() {
               <dd><PersonChip person={owner} /></dd>
             </div>
             <div className="detail-row">
-              <dt>Assignee</dt>
+              <dt>Assignees</dt>
               <dd>
                 {canAssign && live ? (
-                  <PersonPicker
+                  <MultiPersonPicker
                     people={members}
-                    value={session.assigneeUid}
-                    label="Assignee"
-                    onChange={async (uid) => {
-                      await assignSession(session.id, uid);
-                      await load();
-                    }}
+                    values={assigneeIds(session)}
+                    label="Assignees"
+                    onChange={(uids) => void handleAssign(uids)}
                   />
                 ) : (
-                  <PersonChip person={assignee} />
+                  <PeopleChip people={assignees} />
                 )}
               </dd>
             </div>

--- a/app/src/routes/Terms.tsx
+++ b/app/src/routes/Terms.tsx
@@ -235,7 +235,7 @@ export function Terms() {
             A team is a shared workspace, and it is shared in a strong
             sense. <b>Everyone in your team can see every member&rsquo;s
             sessions</b> and can read their comments and handoff history. A
-            session has an owner and an assignee, and
+            session has an owner and may have multiple assignees, and
             only they can edit it — but visibility is not restricted that way.
           </p>
           <p>

--- a/app/src/routes/Workspace.tsx
+++ b/app/src/routes/Workspace.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { X, Trash, Terminal as TerminalIcon, List, Plus, CaretRight, MagnifyingGlass, Rows, Columns } from "@phosphor-icons/react";
 import { Link, useSearchParams } from "react-router-dom";
-import { PersonChip } from "../components/Avatar";
-import { PersonPicker } from "../components/PersonPicker";
+import { PeopleChip, PersonChip } from "../components/Avatar";
+import { MultiPersonPicker } from "../components/PersonPicker";
 import { findPerson } from "../lib/people";
 import { kindForCommand } from "../lib/session-kinds";
-import { canEdit, canHandOff, canRemove, canStop, matches } from "../lib/session-view";
+import { assigneeIds, canEdit, canHandOff, canRemove, canStop, matches } from "../lib/session-view";
 import { NewSessionModal } from "../components/NewSessionModal";
 import { LaunchPrompt } from "../components/LaunchPrompt";
 import { SessionBoard } from "../components/SessionBoard";
@@ -162,6 +162,8 @@ export function Workspace() {
   const pendingShares = useRef(new Map<string, string>());
   /* Who each session has already been shared with, so polling is not chatty. */
   const sharedWith = useRef(new Map<string, Set<string>>());
+  /* Keeps rapid multi-select ticks ordered without disabling the picker. */
+  const assignmentQueue = useRef(new Map<string, Promise<{ session: SessionRecord }>>());
 
   /*
    * The parameter is dropped as soon as it is read, so a reload or a shared
@@ -419,16 +421,47 @@ export function Workspace() {
     }
   }
 
-  async function handleAssign(session: SessionRecord, uid: string) {
+  async function handleAssign(session: SessionRecord, uids: string[]) {
     setError("");
     setNotice("");
+    const previous = assigneeIds(session);
+    const optimistic = { ...session, assigneeUid: uids[0], assigneeUids: uids };
+    setSessions((current) =>
+      current?.map((entry) => entry.id === session.id ? optimistic : entry) ?? null,
+    );
+
+    const earlier = assignmentQueue.current.get(session.id);
+    const request = (earlier?.catch(() => undefined) ?? Promise.resolve()).then(() =>
+      assignSession(session.id, uids),
+    );
+    assignmentQueue.current.set(session.id, request);
     try {
-      await assignSession(session.id, uid);
-      const to = members.find((member) => member.uid === uid);
-      setNotice(`${session.name || session.command} is now assigned to ${to?.email ?? "them"}.`);
-      await load();
+      const { session: updated } = await request;
+      if (assignmentQueue.current.get(session.id) !== request) return;
+      setSessions((current) => current?.map(
+        (entry) => entry.id === updated.id ? updated : entry,
+      ) ?? null);
+      const names = members
+        .filter((member) => uids.includes(member.uid))
+        .map((member) => member.name || member.email);
+      setNotice(
+        names.length
+          ? `${session.name || session.command} is assigned to ${names.join(", ")}.`
+          : `${session.name || session.command} is unassigned.`,
+      );
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : "Could not hand it off.");
+      if (assignmentQueue.current.get(session.id) === request) {
+        setSessions((current) => current?.map(
+          (entry) => entry.id === session.id
+            ? { ...entry, assigneeUid: previous[0], assigneeUids: previous }
+            : entry,
+        ) ?? null);
+        setError(caught instanceof Error ? caught.message : "Could not update assignees.");
+      }
+    } finally {
+      if (assignmentQueue.current.get(session.id) === request) {
+        assignmentQueue.current.delete(session.id);
+      }
     }
   }
 
@@ -593,6 +626,12 @@ export function Workspace() {
                   type="search"
                   value={query}
                   onChange={(event) => setQuery(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Escape" && query) {
+                      event.preventDefault();
+                      setQuery("");
+                    }
+                  }}
                   placeholder="Search name or command"
                   aria-label="Search sessions by name or command"
                 />
@@ -603,6 +642,7 @@ export function Workspace() {
                   type="button"
                   className={view === "list" ? "view-option is-active" : "view-option"}
                   aria-pressed={view === "list"}
+                  aria-label="Show sessions as a list"
                   onClick={() => {
                     setView("list");
                     writeViewMode("list");
@@ -615,6 +655,7 @@ export function Workspace() {
                   type="button"
                   className={view === "board" ? "view-option is-active" : "view-option"}
                   aria-pressed={view === "board"}
+                  aria-label="Show sessions as columns"
                   onClick={() => {
                     setView("board");
                     writeViewMode("board");
@@ -753,7 +794,7 @@ function SessionGroup({
   onOpen: (session: SessionRecord) => void;
   onKill: (session: SessionRecord) => void;
   onRemove: (session: SessionRecord) => void;
-  onAssign: (session: SessionRecord, uid: string) => void;
+  onAssign: (session: SessionRecord, uids: string[]) => void;
 }) {
   /*
    * Which commands are shown in full. Collapsed by default: an agent command
@@ -776,7 +817,7 @@ function SessionGroup({
           <tr>
             <th scope="col">Session</th>
             <th scope="col">Owner</th>
-            <th scope="col">Assignee</th>
+            <th scope="col">Assignees</th>
             <th scope="col" className="table-optional">Machine</th>
             <th scope="col">{live ? "Uptime" : "Ran for"}</th>
             <th scope="col" className="table-end">Actions</th>
@@ -785,7 +826,8 @@ function SessionGroup({
         <tbody>
           {sessions.map((session) => {
             const owner = findPerson(members, session.ownerUid);
-            const assignee = findPerson(members, session.assigneeUid);
+            const assigned = new Set(assigneeIds(session));
+            const assignees = members.filter((member) => assigned.has(member.uid));
             return (
               /*
                * The row is the link. `.table-subject` is stretched over the
@@ -839,16 +881,16 @@ function SessionGroup({
                   * unlabelled faces in a row do not say which is which.
                   */}
                 <td className="table-person" data-label="Owner"><PersonChip person={owner} /></td>
-                <td className="table-person" data-label="Assignee">
+                <td className="table-person" data-label="Assignees">
                   {live && canHandOff(session, you) ? (
-                    <PersonPicker
+                    <MultiPersonPicker
                       people={members}
-                      value={session.assigneeUid}
-                      label={`Assignee for ${session.name || session.command}`}
-                      onChange={(uid) => onAssign(session, uid)}
+                      values={assigneeIds(session)}
+                      label={`Assignees for ${session.name || session.command}`}
+                      onChange={(uids) => onAssign(session, uids)}
                     />
                   ) : (
-                    <PersonChip person={assignee} />
+                    <PeopleChip people={assignees} />
                   )}
                 </td>
                 <td className="table-quiet table-optional" data-label="Machine">

--- a/app/src/styles/auth.css
+++ b/app/src/styles/auth.css
@@ -1550,4 +1550,18 @@
     margin-left: auto;
     order: 1;
   }
+
+  .picker,
+  .picker-trigger-multi {
+    max-width: 100%;
+  }
+
+  .picker-trigger-multi {
+    min-height: 40px;
+  }
+
+  .table-person .picker-pop,
+  .board-card .picker-pop {
+    width: min(300px, calc(100vw - 40px));
+  }
 }

--- a/app/src/styles/people.css
+++ b/app/src/styles/people.css
@@ -60,6 +60,26 @@
   font-size: 11.5px;
 }
 
+.people-chip {
+  display: inline-flex;
+  min-width: 0;
+  color: var(--ink);
+  font-size: 13.5px;
+  align-items: center;
+  gap: 8px;
+}
+
+.people-chip > span:last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.people-empty {
+  color: var(--faint);
+  font-size: 13px;
+}
+
 /* ---------------------------------------------------------------
    Person picker
    --------------------------------------------------------------- */
@@ -84,6 +104,10 @@
   align-items: center;
   gap: 7px;
   transition: background 140ms var(--ease), border-color 140ms var(--ease);
+}
+
+.picker-trigger-multi {
+  max-width: 220px;
 }
 
 .picker-trigger:hover:not(:disabled),
@@ -118,6 +142,7 @@
   z-index: 60;
   overflow: hidden;
   width: 260px;
+  max-width: calc(100vw - 32px);
   border: 1px solid var(--line);
   border-radius: var(--radius-control);
   background: var(--white);
@@ -168,7 +193,30 @@
   font-family: inherit;
   align-items: center;
   gap: 9px;
+  min-height: 42px;
   text-align: left;
+}
+
+.picker-check {
+  display: inline-grid;
+  width: 18px;
+  height: 18px;
+  border: 1px solid var(--line-strong);
+  border-radius: 5px;
+  color: var(--white);
+  flex: none;
+  place-items: center;
+}
+
+.picker-check.is-checked {
+  border-color: var(--ink);
+  background: var(--ink);
+}
+
+.picker-trigger:focus-visible,
+.picker-item:focus-visible {
+  outline: 2px solid var(--blue);
+  outline-offset: 2px;
 }
 
 .picker-item:hover,

--- a/app/src/terminal/TerminalPane.tsx
+++ b/app/src/terminal/TerminalPane.tsx
@@ -21,7 +21,7 @@ export interface TerminalPaneProps {
   /** The password sealed to this browser by whoever started the session. */
   keyShare?: { senderPublicKey: string; sealed: string };
   /**
-   * False for a colleague who is neither owner nor assignee. They can watch
+   * False for a colleague who is neither owner nor an assignee. They can watch
    * but not type, which is what "readable by the team, editable by
    * the people responsible" means in a terminal.
    */
@@ -343,7 +343,7 @@ export function TerminalPane({
       )}
 
       {!canType && status === "connected" && (
-        <div className="pane-banner pane-watching">Watching. Only the owner and assignee can type.</div>
+        <div className="pane-banner pane-watching">Watching. Only the owner and assignees can type.</div>
       )}
 
       {status === "disconnected" && (


### PR DESCRIPTION
## What changed

- replace the single assignee picker with an immediate-save multi-person picker
- grant terminal write access to every assignee while retaining the legacy first-assignee field
- persist assignments in PostgreSQL and the development store with an additive migration
- keep rapid selections ordered and update the interface optimistically
- tighten existing search, keyboard focus, accessibility, and mobile target behavior without adding controls or steps

## Verification

- 666 tests passed; 3 PostgreSQL-only tests are exercised by CI
- TypeScript project build passed
- oxlint passed (existing warnings only)
- production client and Worker bundle passed with the repository Firebase variables
- protocol consistency check passed

## Deployment

The additive database migration must run before the Worker deployment, as the existing app deployment playbook requires.