### PR TITLE
Fix session row controls opening the detail view

### DIFF
--- a/app/src/components/SessionBoard.tsx
+++ b/app/src/components/SessionBoard.tsx
@@ -7,6 +7,7 @@ import { MultiPersonPicker } from "./PersonPicker";
 import { ago } from "../lib/time";
 import type { Member, SessionRecord } from "../lib/api";
 import { SessionClipboard } from "./SessionClipboard";
+import { shouldOpenSurface } from "../lib/surface-navigation";
 
 /**
  * The same sessions as three columns, one per thing you can do with them.
@@ -31,6 +32,7 @@ function Card({
   members,
   you,
   action,
+  onOpen,
   onAssign,
 }: {
   session: SessionRecord;
@@ -38,6 +40,7 @@ function Card({
   members: Member[];
   you: Member | null;
   action: React.ReactNode;
+  onOpen: (session: SessionRecord) => void;
   onAssign: (session: SessionRecord, uids: string[]) => void;
 }) {
   const kind = kindForCommand(session.command);
@@ -45,7 +48,12 @@ function Card({
   const assignees = members.filter((member) => selected.has(member.uid));
 
   return (
-    <li className="board-card">
+    <li
+      className="board-card"
+      onClick={(event) => {
+        if (shouldOpenSurface(event.target, event.defaultPrevented)) onOpen(session);
+      }}
+    >
       <div className="board-card-head">
         <img className="board-card-icon" src={kind.icon} alt="" title={kind.title} />
         {/*
@@ -157,6 +165,7 @@ export function SessionBoard({
                   now={now}
                   members={members}
                   you={you}
+                  onOpen={onOpen}
                   onAssign={onAssign}
                   action={
                     column.key === "finished" ? (

--- a/app/src/lib/surface-navigation.test.ts
+++ b/app/src/lib/surface-navigation.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { shouldOpenSurface } from "./surface-navigation";
+
+function target(insideControl: boolean): EventTarget {
+  return { closest: () => (insideControl ? {} : null) } as unknown as EventTarget;
+}
+
+describe("session surface navigation", () => {
+  it("opens when an inert part of the row or card is clicked", () => {
+    expect(shouldOpenSurface(target(false))).toBe(true);
+  });
+
+  it("does not open when a row button or picker descendant is clicked", () => {
+    expect(shouldOpenSurface(target(true))).toBe(false);
+  });
+
+  it("honours controls that already consumed the click", () => {
+    expect(shouldOpenSurface(target(false), true)).toBe(false);
+  });
+});

--- a/app/src/lib/surface-navigation.ts
+++ b/app/src/lib/surface-navigation.ts
@@ -1,0 +1,29 @@
+const INTERACTIVE_SELECTOR = [
+  "a",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  "summary",
+  "[role='button']",
+  "[role='option']",
+  "[role='menuitem']",
+  "[contenteditable='true']",
+].join(",");
+
+type ClosestTarget = EventTarget & {
+  closest(selector: string): Element | null;
+};
+
+function supportsClosest(target: EventTarget | null): target is ClosestTarget {
+  return Boolean(target && typeof (target as Partial<ClosestTarget>).closest === "function");
+}
+
+/**
+ * Lets an otherwise inert part of a row/card open its session without stealing
+ * a click from a control inside that surface.
+ */
+export function shouldOpenSurface(target: EventTarget | null, defaultPrevented = false): boolean {
+  if (defaultPrevented) return false;
+  return !supportsClosest(target) || !target.closest(INTERACTIVE_SELECTOR);
+}

--- a/app/src/routes/Workspace.tsx
+++ b/app/src/routes/Workspace.tsx
@@ -44,6 +44,7 @@ import { useKeyboardInset } from "../terminal/keyboard-inset";
 import { elapsed } from "../lib/time";
 import { usePageTitle } from "../lib/page-title";
 import { wasJustLinked, withoutLinkedFlag } from "../lib/linked";
+import { shouldOpenSurface } from "../lib/surface-navigation";
 
 const POLL_MS = 4000;
 /* Well inside the service's 15s agent-online window, so the state stays true. */
@@ -829,13 +830,14 @@ function SessionGroup({
             const assigned = new Set(assigneeIds(session));
             const assignees = members.filter((member) => assigned.has(member.uid));
             return (
-              /*
-               * The row is the link. `.table-subject` is stretched over the
-               * whole row in CSS, so a tap anywhere that is not a control
-               * opens the session, while the buttons, the assignee picker and
-               * the copy menu stay above it and keep their own targets.
-               */
-              <tr key={session.id} data-live={live} className="table-row-linked">
+              <tr
+                key={session.id}
+                data-live={live}
+                className="table-row-linked"
+                onClick={(event) => {
+                  if (shouldOpenSurface(event.target, event.defaultPrevented)) onOpen(session);
+                }}
+              >
                 <td>
                   <Link className="table-subject" to={`/sessions/${session.id}`}>
                     {/* The kind of thing running, in colour while it runs. */}

--- a/app/src/styles/auth.css
+++ b/app/src/styles/auth.css
@@ -1458,18 +1458,8 @@
   outline-offset: 2px;
 }
 
-.board-card-name::after {
-  position: absolute;
-  content: "";
-  inset: 0;
-  border-radius: inherit;
-}
-
-/*
- * The controls keep their own targets. They come after the overlay in the
- * card, and positioned siblings paint in tree order, so relative is enough
- * and no z-index is needed to trap the copy menu inside.
- */
+/* Controls remain positioned for their menus. The card click handler ignores
+ * interactive descendants instead of covering them with a stretched link. */
 .board-card .clip,
 .board-card .board-card-foot {
   position: relative;
@@ -1554,10 +1544,6 @@
   .picker,
   .picker-trigger-multi {
     max-width: 100%;
-  }
-
-  .picker-trigger-multi {
-    min-height: 40px;
   }
 
   .table-person .picker-pop,

--- a/app/src/styles/people.css
+++ b/app/src/styles/people.css
@@ -364,39 +364,19 @@
   text-decoration: underline;
 }
 
-/* ---------------------------------------------------------------
-   The whole row opens the session
-   ---------------------------------------------------------------
-   The name was the only target, which on a phone is a few characters of
-   text in a row that is otherwise a hundred pixels of nothing. Rather than
-   put a click handler on the row, the existing link is stretched across it:
-   the row keeps one link, the keyboard keeps one stop, and everything that
-   was already interactive is lifted above the overlay so it still gets the
-   tap it used to.
-   --------------------------------------------------------------- */
+/* The inert part of the row opens the session. Controls keep their native hit
+   targets; navigation is filtered by shouldOpenSurface in Workspace.tsx. */
 
 .table-row-linked {
   position: relative;
   cursor: pointer;
 }
 
-.table-row-linked .table-subject::after {
-  position: absolute;
-  content: "";
-  inset: 0;
-}
-
 .table-row-linked:hover .table-name {
   text-decoration: underline;
 }
 
-/*
- * Everything with its own behaviour keeps its own target: `position: relative`
- * and nothing else. Positioned siblings paint in tree order and all of these
- * come after the overlay, so they are above it without a z-index. Giving them
- * one would trap the copy menu inside their stacking context, and that menu
- * has to rise over the rest of the page.
- */
+/* Keep menus positioned without creating a stacking context that clips them. */
 .table-row-linked td > .session-actions,
 .table-row-linked .picker,
 .table-row-linked .table-command-toggle,


### PR DESCRIPTION
## What changed
- remove the stretched invisible link overlays that intercepted every row/card control
- open sessions only from inert row/card space while ignoring interactive descendants
- restore the compact mobile assignee trigger height
- add a regression test for control-vs-surface navigation

## Validation
- 669 tests passed, 3 skipped
- TypeScript typecheck passed
- lint passed (existing warnings only)
- production build and bundle validation passed
- real Chromium hit test passed for assignee dropdown, Open button, board controls, and blank row/card navigation at desktop and mobile sizing