### PR TITLE
Keep session actions inline and add contextual audit filters

### DIFF
--- a/app/src/components/SearchSelect.test.ts
+++ b/app/src/components/SearchSelect.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { filterSearchOptions, type SearchSelectOption } from "../lib/search-options";
+
+const options: SearchSelectOption[] = [
+  { value: "s1", label: "Training", detail: "python train.py · gpu-box", keywords: "running" },
+  { value: "s2", label: "Agent", detail: "claude · macbook", keywords: "finished" },
+];
+
+describe("search select", () => {
+  it("searches labels and the contextual detail shown beneath them", () => {
+    expect(filterSearchOptions(options, "gpu-box").map((option) => option.value)).toEqual(["s1"]);
+    expect(filterSearchOptions(options, "claude").map((option) => option.value)).toEqual(["s2"]);
+  });
+
+  it("also searches non-visible keywords such as state", () => {
+    expect(filterSearchOptions(options, "running").map((option) => option.value)).toEqual(["s1"]);
+  });
+});

--- a/app/src/components/SearchSelect.tsx
+++ b/app/src/components/SearchSelect.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { CaretDown, Check, MagnifyingGlass } from "@phosphor-icons/react";
+import { filterSearchOptions, type SearchSelectOption } from "../lib/search-options";
+
+/** A native-sized trigger with a richer popover on desktop and sheet on phones. */
+export function SearchSelect({
+  label,
+  value,
+  options,
+  onChange,
+  searchable = true,
+  searchPlaceholder = `Search ${label.toLocaleLowerCase()}`,
+  align = "left",
+}: {
+  label: string;
+  value: string;
+  options: SearchSelectOption[];
+  onChange(value: string): void;
+  searchable?: boolean;
+  searchPlaceholder?: string;
+  align?: "left" | "right";
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [active, setActive] = useState(0);
+  const wrapper = useRef<HTMLDivElement>(null);
+  const search = useRef<HTMLInputElement>(null);
+  const selected = options.find((option) => option.value === value) ?? options[0];
+  const matches = useMemo(() => filterSearchOptions(options, query), [options, query]);
+
+  useEffect(() => {
+    if (!open) return;
+    const close = (event: MouseEvent) => {
+      if (!wrapper.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const key = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", close);
+    document.addEventListener("keydown", key);
+    if (searchable) search.current?.focus();
+    return () => {
+      document.removeEventListener("mousedown", close);
+      document.removeEventListener("keydown", key);
+    };
+  }, [open, searchable]);
+
+  function choose(next: string) {
+    onChange(next);
+    setOpen(false);
+    setQuery("");
+    setActive(0);
+  }
+
+  return (
+    <div className={`filter-picker filter-picker-${align}`} ref={wrapper}>
+      <button
+        type="button"
+        className="filter-picker-trigger"
+        aria-label={label}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen((current) => !current)}
+        onKeyDown={(event) => {
+          if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+            event.preventDefault();
+            setOpen(true);
+          }
+        }}
+      >
+        <span>{selected?.label ?? label}</span>
+        <CaretDown size={12} weight="bold" />
+      </button>
+
+      {open && (
+        <>
+          <button
+            type="button"
+            className="filter-picker-scrim"
+            aria-label={`Close ${label.toLocaleLowerCase()} choices`}
+            onClick={() => setOpen(false)}
+          />
+          <div className="filter-picker-pop" role="listbox" aria-label={label}>
+            <div className="filter-picker-head">{label}</div>
+            {searchable && (
+              <label className="filter-picker-search">
+                <MagnifyingGlass size={15} />
+                <input
+                  ref={search}
+                  value={query}
+                  placeholder={searchPlaceholder}
+                  aria-label={searchPlaceholder}
+                  onChange={(event) => {
+                    setQuery(event.target.value);
+                    setActive(0);
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === "ArrowDown") {
+                      event.preventDefault();
+                      setActive((current) => Math.min(current + 1, matches.length - 1));
+                    } else if (event.key === "ArrowUp") {
+                      event.preventDefault();
+                      setActive((current) => Math.max(current - 1, 0));
+                    } else if (event.key === "Enter" && matches[active]) {
+                      event.preventDefault();
+                      choose(matches[active].value);
+                    }
+                  }}
+                />
+              </label>
+            )}
+            <ul className="filter-picker-list">
+              {matches.length === 0 ? (
+                <li className="filter-picker-empty">Nothing matches.</li>
+              ) : (
+                matches.map((option, index) => (
+                  <li key={option.value || "__all"}>
+                    <button
+                      type="button"
+                      role="option"
+                      aria-selected={option.value === value}
+                      className={index === active && searchable ? "filter-picker-option is-active" : "filter-picker-option"}
+                      onMouseEnter={() => setActive(index)}
+                      onClick={() => choose(option.value)}
+                    >
+                      <span className="filter-picker-copy">
+                        <b>{option.label}</b>
+                        {option.detail && <small>{option.detail}</small>}
+                      </span>
+                      <span className={option.value === value ? "filter-picker-check is-selected" : "filter-picker-check"}>
+                        {option.value === value && <Check size={12} weight="bold" />}
+                      </span>
+                    </button>
+                  </li>
+                ))
+              )}
+            </ul>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/src/lib/search-options.ts
+++ b/app/src/lib/search-options.ts
@@ -1,0 +1,16 @@
+export type SearchSelectOption = {
+  value: string;
+  label: string;
+  detail?: string;
+  keywords?: string;
+};
+
+export function filterSearchOptions(options: SearchSelectOption[], query: string): SearchSelectOption[] {
+  const needle = query.trim().toLocaleLowerCase();
+  if (!needle) return options;
+  return options.filter((option) =>
+    `${option.label} ${option.detail ?? ""} ${option.keywords ?? ""}`
+      .toLocaleLowerCase()
+      .includes(needle),
+  );
+}

--- a/app/src/routes/Audit.tsx
+++ b/app/src/routes/Audit.tsx
@@ -34,21 +34,23 @@ import {
 } from "../lib/audit-view";
 import { usePageTitle } from "../lib/page-title";
 import { displayName } from "../lib/people";
+import { SearchSelect } from "../components/SearchSelect";
+import type { SearchSelectOption } from "../lib/search-options";
 
 const RANGES = [
-  { label: "All time", value: 0 },
-  { label: "Last hour", value: 60 * 60 * 1000 },
-  { label: "Last 24 hours", value: 24 * 60 * 60 * 1000 },
-  { label: "Last 7 days", value: 7 * 24 * 60 * 60 * 1000 },
+  { label: "All time", detail: "The complete retained audit trail", value: 0 },
+  { label: "Last hour", detail: "Activity from the past 60 minutes", value: 60 * 60 * 1000 },
+  { label: "Last 24 hours", detail: "Activity since this time yesterday", value: 24 * 60 * 60 * 1000 },
+  { label: "Last 7 days", detail: "Activity from the past week", value: 7 * 24 * 60 * 60 * 1000 },
 ];
 
 const KINDS = [
-  { label: "Everything", value: "" },
-  { label: "Commands and prompts", value: "input" },
-  { label: "Interrupts", value: "interrupt" },
-  { label: "Handoffs", value: "handoff" },
-  { label: "Stopped", value: "stopped" },
-  { label: "Removed", value: "deleted" },
+  { label: "Everything", detail: "Every recorded event type", value: "" },
+  { label: "Commands and prompts", detail: "Submitted terminal input and agent prompts", value: "input" },
+  { label: "Interrupts", detail: "Ctrl-C and interrupted input", value: "interrupt" },
+  { label: "Handoffs", detail: "Assignment changes between teammates", value: "handoff" },
+  { label: "Stopped", detail: "Processes stopped from the app", value: "stopped" },
+  { label: "Removed", detail: "Sessions removed from the workspace", value: "deleted" },
 ];
 
 /** A bar chart of when things happened. Inline SVG; no charting library. */
@@ -162,6 +164,23 @@ export function Audit() {
     [events, filters],
   );
   const summary = useMemo(() => summarise(shown), [shown]);
+  const sessionOptions = useMemo<SearchSelectOption[]>(() => [
+    { value: "", label: "All sessions", detail: "Activity across every session" },
+    ...sessions.map((session) => ({
+      value: session.id,
+      label: session.name || session.command,
+      detail: `${session.command}${session.host ? ` · ${session.host}` : ""}`,
+      keywords: session.closedAt ? "finished offline" : "running live",
+    })),
+  ], [sessions]);
+  const memberOptions = useMemo<SearchSelectOption[]>(() => [
+    { value: "", label: "Everyone", detail: "Activity from every teammate" },
+    ...members.map((member) => ({
+      value: member.uid,
+      label: displayName(member),
+      detail: [member.email, member.role].filter(Boolean).join(" · "),
+    })),
+  ], [members]);
 
   function set(patch: Partial<Filters>) {
     setFilters((current) => {
@@ -227,55 +246,39 @@ export function Audit() {
           )}
         </div>
 
-        <select
+        <SearchSelect
+          label="Session"
           value={filters.session}
-          onChange={(event) => set({ session: event.target.value })}
-          aria-label="Session"
-        >
-          <option value="">All sessions</option>
-          {sessions.map((session) => (
-            <option key={session.id} value={session.id}>
-              {session.name || session.command}
-            </option>
-          ))}
-        </select>
+          options={sessionOptions}
+          onChange={(session) => set({ session })}
+          searchPlaceholder="Search sessions, commands, or machines"
+        />
 
-        <select
+        <SearchSelect
+          label="Person"
           value={filters.actor}
-          onChange={(event) => set({ actor: event.target.value })}
-          aria-label="Person"
-        >
-          <option value="">Everyone</option>
-          {members.map((member) => (
-            <option key={member.uid} value={member.uid}>
-              {displayName(member)}
-            </option>
-          ))}
-        </select>
+          options={memberOptions}
+          onChange={(actor) => set({ actor })}
+          searchPlaceholder="Search people, emails, or roles"
+        />
 
-        <select
+        <SearchSelect
+          label="Event type"
           value={filters.kind}
-          onChange={(event) => set({ kind: event.target.value })}
-          aria-label="Kind"
-        >
-          {KINDS.map((kind) => (
-            <option key={kind.value} value={kind.value}>
-              {kind.label}
-            </option>
-          ))}
-        </select>
+          options={KINDS}
+          onChange={(kind) => set({ kind })}
+          searchable={false}
+          align="right"
+        />
 
-        <select
+        <SearchSelect
+          label="Time range"
           value={String(filters.since)}
-          onChange={(event) => set({ since: Number(event.target.value) })}
-          aria-label="Time range"
-        >
-          {RANGES.map((range) => (
-            <option key={range.value} value={range.value}>
-              {range.label}
-            </option>
-          ))}
-        </select>
+          options={RANGES.map((range) => ({ ...range, value: String(range.value) }))}
+          onChange={(since) => set({ since: Number(since) })}
+          searchable={false}
+          align="right"
+        />
 
         {isFiltered(filters) && (
           <button type="button" className="filter-clear" onClick={() => {

--- a/app/src/styles/audit.css
+++ b/app/src/styles/audit.css
@@ -56,9 +56,16 @@
   color: var(--ink);
 }
 
-.filters select {
+.filter-picker {
+  position: relative;
+  flex: none;
+}
+
+.filter-picker-trigger {
+  display: inline-flex;
+  max-width: 200px;
   height: 40px;
-  padding: 0 10px;
+  padding: 0 11px 0 12px;
   border: 1px solid var(--line-strong);
   border-radius: var(--radius-control);
   outline: 0;
@@ -67,6 +74,161 @@
   cursor: pointer;
   font-family: inherit;
   font-size: 13.5px;
+  align-items: center;
+  gap: 8px;
+}
+
+.filter-picker-trigger span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.filter-picker-trigger svg {
+  color: var(--faint);
+  flex: none;
+}
+
+.filter-picker-trigger:hover,
+.filter-picker-trigger[aria-expanded="true"] {
+  border-color: var(--muted);
+}
+
+.filter-picker-trigger:focus-visible {
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px var(--blue-wash);
+}
+
+.filter-picker-scrim {
+  display: none;
+}
+
+.filter-picker-pop {
+  position: absolute;
+  z-index: 70;
+  top: calc(100% + 6px);
+  left: 0;
+  overflow: hidden;
+  width: 330px;
+  max-width: calc(100vw - 32px);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-control);
+  background: var(--white);
+  box-shadow: 0 18px 44px color-mix(in srgb, var(--ink) 16%, transparent);
+}
+
+.filter-picker-right .filter-picker-pop {
+  right: 0;
+  left: auto;
+}
+
+.filter-picker-head {
+  padding: 11px 12px 8px;
+  color: var(--faint);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.filter-picker-search {
+  display: flex;
+  height: 40px;
+  padding: 0 12px;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  color: var(--faint);
+  align-items: center;
+  gap: 8px;
+}
+
+.filter-picker-search input {
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: none;
+  color: var(--ink);
+  font: inherit;
+  flex: 1;
+}
+
+.filter-picker-list {
+  overflow-y: auto;
+  max-height: 320px;
+  padding: 5px;
+  margin: 0;
+  list-style: none;
+}
+
+.filter-picker-option {
+  display: flex;
+  width: 100%;
+  min-height: 52px;
+  padding: 7px 8px;
+  border: 0;
+  border-radius: var(--radius-chip);
+  background: none;
+  color: var(--ink);
+  cursor: pointer;
+  font-family: inherit;
+  align-items: center;
+  gap: 10px;
+  text-align: left;
+}
+
+.filter-picker-option:hover,
+.filter-picker-option.is-active {
+  background: var(--paper);
+}
+
+.filter-picker-option:focus-visible {
+  outline: 2px solid var(--blue);
+  outline-offset: -2px;
+}
+
+.filter-picker-copy {
+  display: grid;
+  min-width: 0;
+  flex: 1;
+  gap: 2px;
+}
+
+.filter-picker-copy b {
+  overflow: hidden;
+  font-size: 13.5px;
+  font-weight: 560;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.filter-picker-copy small {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 11.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.filter-picker-check {
+  display: grid;
+  width: 18px;
+  height: 18px;
+  border: 1px solid var(--line-strong);
+  border-radius: 50%;
+  color: var(--white);
+  flex: none;
+  place-items: center;
+}
+
+.filter-picker-check.is-selected {
+  border-color: var(--ink);
+  background: var(--ink);
+}
+
+.filter-picker-empty {
+  padding: 18px 10px;
+  color: var(--muted);
+  font-size: 13px;
 }
 
 .filter-clear {
@@ -386,5 +548,64 @@
 
   .filter-search {
     min-width: 100%;
+  }
+
+  .filter-picker {
+    flex: 1 1 calc(50% - 5px);
+    min-width: 0;
+  }
+
+  .filter-picker-trigger {
+    width: 100%;
+    max-width: none;
+  }
+
+  .filter-picker-scrim {
+    position: fixed;
+    z-index: 69;
+    display: block;
+    border: 0;
+    background: color-mix(in srgb, var(--ink) 32%, transparent);
+    inset: 0;
+  }
+
+  .filter-picker-pop {
+    position: fixed;
+    z-index: 70;
+    top: auto;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: auto;
+    max-width: none;
+    max-height: calc(100dvh / var(--zoom) - 20px);
+    border-width: 1px 0 0;
+    border-radius: var(--radius-panel) var(--radius-panel) 0 0;
+    box-shadow: 0 -18px 50px color-mix(in srgb, var(--ink) 20%, transparent);
+  }
+
+  .filter-picker-right .filter-picker-pop {
+    right: 0;
+    left: 0;
+  }
+
+  .filter-picker-head {
+    padding: 14px 16px 10px;
+    font-size: 12px;
+  }
+
+  .filter-picker-search {
+    height: 46px;
+    padding: 0 16px;
+  }
+
+  .filter-picker-list {
+    max-height: calc(100dvh / var(--zoom) - 120px);
+    padding: 7px 10px calc(12px + env(safe-area-inset-bottom));
+  }
+
+  .filter-picker-option {
+    min-height: 58px;
+    padding: 9px 7px;
   }
 }

--- a/app/src/styles/people.css
+++ b/app/src/styles/people.css
@@ -352,6 +352,24 @@
   justify-content: flex-end;
 }
 
+/* A row's controls are one compact sentence: open, copy, stop, remove. */
+.table .session-actions {
+  flex-wrap: nowrap;
+  gap: 4px;
+}
+
+.table .session-action {
+  height: 34px;
+  padding: 0 7px;
+  font-size: 12.5px;
+  gap: 4px;
+}
+
+.table .session-copy {
+  width: 34px;
+  height: 34px;
+}
+
 .table-subject {
   display: inline-flex;
   min-width: 0;
@@ -511,15 +529,7 @@
     min-width: 118px;
   }
 
-  .table .session-action {
-    height: 34px;
-    padding: 0 11px;
-    font-size: 13px;
-  }
-
-  .table .session-actions {
-    gap: 6px;
-  }
+  .table .session-actions { gap: 4px; }
 }
 
 /*


### PR DESCRIPTION
## What changed
- keep session row actions on one compact line down to 320px
- replace Audit native selects with custom app-styled popovers and mobile sheets
- make session and person filters searchable by contextual details
- show command, machine, state, email, role, and filter descriptions in choices
- preserve the existing filter behavior and URL state

## Validation
- 671 tests passed, 3 skipped
- typecheck passed
- lint passed with existing warnings only
- production build and bundle validation passed
- real Chromium test at 320px confirmed one-line actions with no overflow
- real Chromium test confirmed contextual search and selection in the mobile Audit sheet