### PR TITLE
Keep popover content contained

### DIFF
--- a/app/src/styles/audit.css
+++ b/app/src/styles/audit.css
@@ -115,6 +115,8 @@
   border-radius: var(--radius-control);
   background: var(--white);
   box-shadow: 0 18px 44px color-mix(in srgb, var(--ink) 16%, transparent);
+  text-align: left;
+  white-space: normal;
 }
 
 .filter-picker-right .filter-picker-pop {

--- a/app/src/styles/auth.css
+++ b/app/src/styles/auth.css
@@ -1124,10 +1124,16 @@
   background: var(--paper);
   box-shadow: 0 14px 40px color-mix(in srgb, var(--ink) 14%, transparent);
   gap: 2px;
+  /* This menu lives inside a right-aligned, no-wrap Actions table cell. Its
+     contents are prose, so neither table-cell rule may leak into the panel. */
+  text-align: left;
+  white-space: normal;
 }
 
 .clip-item {
   display: flex;
+  width: 100%;
+  min-width: 0;
   padding: 9px 10px;
   border: 1px solid transparent;
   border-radius: var(--radius-chip);
@@ -1158,6 +1164,7 @@
 .clip-text b {
   font-size: 13px;
   font-weight: 560;
+  white-space: normal;
 }
 
 /* The warning. Muted, but it wraps rather than truncating: it is the point. */
@@ -1166,6 +1173,8 @@
   font-size: 11.5px;
   font-style: normal;
   line-height: 1.35;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 /* A refused clipboard, said out loud inside the menu that refused it. */

--- a/app/src/styles/collab.css
+++ b/app/src/styles/collab.css
@@ -67,6 +67,8 @@
   border-radius: var(--radius-control);
   background: var(--white);
   box-shadow: 0 22px 56px rgb(26 31 22 / 18%);
+  text-align: left;
+  white-space: normal;
 }
 
 .inbox-head {

--- a/app/src/styles/people.css
+++ b/app/src/styles/people.css
@@ -147,6 +147,8 @@
   border-radius: var(--radius-control);
   background: var(--white);
   box-shadow: 0 18px 44px rgb(26 31 22 / 16%);
+  text-align: left;
+  white-space: normal;
 }
 
 .picker-right .picker-pop {
@@ -235,6 +237,7 @@
   color: var(--ink);
   font-size: 13.5px;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .picker-item-mail {
@@ -242,6 +245,7 @@
   color: var(--faint);
   font-size: 11.5px;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .picker-none {

--- a/app/src/styles/shell.css
+++ b/app/src/styles/shell.css
@@ -323,6 +323,8 @@
   border-radius: var(--radius-control);
   background: var(--white);
   box-shadow: 0 16px 40px rgb(26 31 22 / 12%);
+  text-align: left;
+  white-space: normal;
 }
 
 .account-pop-name {
@@ -338,6 +340,7 @@
   color: var(--faint);
   font-size: 12.5px;
   text-overflow: ellipsis;
+  white-space: nowrap;
   border-bottom: 1px solid var(--line);
   padding-bottom: 9px;
 }

--- a/app/src/styles/terminal.css
+++ b/app/src/styles/terminal.css
@@ -510,6 +510,8 @@ button.tab {
 .sheet {
   display: flex;
   overflow: hidden;
+  text-align: left;
+  white-space: normal;
   width: min(880px, 100%);
   max-height: 90dvh;
   border: 1px solid var(--line);


### PR DESCRIPTION
## What changed
- stop the session copy menu from inheriting no-wrap and right alignment from the Actions cell
- constrain copy items and let explanatory prose wrap inside the panel
- explicitly reset wrapping/alignment for assignee, Audit, inbox, account, and dialog surfaces
- preserve intentional ellipsis for compact names and emails

## Validation
- 671 tests passed, 3 skipped
- typecheck and production build passed
- exact Chromium containment checks passed at 1470px, 760px, 390px, and 320px
- every floating surface keeps normal wrapping and left alignment under a no-wrap/right-aligned parent