### PR TITLE
Add consistent filters and paginated audit history

### DIFF
--- a/app/server/app.test.ts
+++ b/app/server/app.test.ts
@@ -1317,6 +1317,27 @@ describe("audit log", () => {
     expect(log.body.events[0].text).toBe("refactor the parser");
   });
 
+  it("filters and paginates the team trail in the service", async () => {
+    await withSession();
+    await call("POST", "/api/audit", {
+      auth: await idToken(),
+      body: {
+        entries: [
+          { session_id: session.id, kind: "input", text: "npm test", at: 1000 },
+          { session_id: session.id, kind: "input", text: "git status", at: 2000 },
+          { session_id: session.id, kind: "input", text: "npm run build", at: 3000 },
+        ],
+      },
+    });
+
+    const first = await call("GET", "/api/audit?q=npm&limit=1&page=1", { auth: await idToken() });
+    const second = await call("GET", "/api/audit?q=npm&limit=1&page=2", { auth: await idToken() });
+
+    expect(first.body).toMatchObject({ total: 2, page: 1, limit: 1 });
+    expect(first.body.events.map((entry: { text: string }) => entry.text)).toEqual(["npm run build"]);
+    expect(second.body.events.map((entry: { text: string }) => entry.text)).toEqual(["npm test"]);
+  });
+
   it("will not read another organization's log", async () => {
     await withSession();
     const read = await call("GET", `/api/audit/${session.id}`, {

--- a/app/server/app.ts
+++ b/app/server/app.ts
@@ -1,6 +1,7 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import type { Store } from "./lib/store";
 import type { Invite, Membership } from "./lib/orgs";
+import type { AuditEvent } from "./lib/types";
 import type { VerifyResult } from "./lib/firebase-token";
 import { exchangeCode, issueCode } from "./lib/codes";
 import {
@@ -529,9 +530,27 @@ export function createApp(options: AppOptions) {
       if (route === "GET /api/audit") {
         const membership = await requireMember(request);
         if (!membership) return send(response, 401, { error: "sign in first" });
-        const asked = Number(url.searchParams.get("limit") ?? "");
-        const limit = Number.isFinite(asked) && asked > 0 ? Math.min(asked, 5000) : 2000;
-        return send(response, 200, { events: await store.auditForOrg(membership.orgId, limit) });
+        const askedLimit = Number(url.searchParams.get("limit") ?? "");
+        const askedPage = Number(url.searchParams.get("page") ?? "");
+        const limit = Number.isInteger(askedLimit) && askedLimit > 0
+          ? Math.min(askedLimit, 100)
+          : 50;
+        const page = Number.isInteger(askedPage) && askedPage > 0
+          ? Math.min(askedPage, 10_000)
+          : 1;
+        const askedKind = url.searchParams.get("kind") ?? "";
+        const kinds = new Set(["input", "interrupt", "opened", "handoff", "stopped", "deleted"]);
+        const askedSince = Number(url.searchParams.get("since_at") ?? "");
+        const result = await store.auditPage(membership.orgId, {
+          limit,
+          offset: (page - 1) * limit,
+          sessionId: url.searchParams.get("session")?.slice(0, 64) || undefined,
+          actorUid: url.searchParams.get("actor")?.slice(0, 256) || undefined,
+          kind: kinds.has(askedKind) ? askedKind as AuditEvent["kind"] : undefined,
+          query: url.searchParams.get("q")?.trim().slice(0, 200) || undefined,
+          sinceAt: Number.isFinite(askedSince) && askedSince > 0 ? askedSince : undefined,
+        });
+        return send(response, 200, { ...result, page, limit });
       }
 
       const auditRoute = url.pathname.match(/^\/api\/audit\/([A-Za-z0-9_-]{6,64})$/);

--- a/app/server/lib/store-conformance.test.ts
+++ b/app/server/lib/store-conformance.test.ts
@@ -615,6 +615,32 @@ for (const implementation of implementations) {
         }
         expect((await store.auditForOrg("org_1", 2)).map((entry) => entry.text)).toEqual(["3", "4"]);
       });
+
+      it("pages a filtered organization trail newest first", async () => {
+        await store.putAudit(auditEvent({ id: "a1", at: 1000, actorUid: "uid-1", text: "npm test" }));
+        await store.putAudit(auditEvent({ id: "a2", at: 2000, actorUid: "uid-2", text: "git status" }));
+        await store.putAudit(auditEvent({ id: "a3", at: 3000, actorUid: "uid-1", text: "npm run build" }));
+        await store.putAudit(auditEvent({ id: "a4", at: 4000, actorUid: "uid-1", sessionId: "s2", text: "npm lint" }));
+
+        const first = await store.auditPage("org_1", {
+          limit: 1,
+          offset: 0,
+          actorUid: "uid-1",
+          sessionId: "s1",
+          query: "NPM",
+        });
+        const second = await store.auditPage("org_1", {
+          limit: 1,
+          offset: 1,
+          actorUid: "uid-1",
+          sessionId: "s1",
+          query: "npm",
+        });
+
+        expect(first.total).toBe(2);
+        expect(first.events.map((entry) => entry.id)).toEqual(["a3"]);
+        expect(second.events.map((entry) => entry.id)).toEqual(["a1"]);
+      });
     });
 
     describe("comments and notifications", () => {

--- a/app/server/lib/store-memory.ts
+++ b/app/server/lib/store-memory.ts
@@ -2,7 +2,7 @@ import { mkdirSync, readFileSync, writeFileSync, renameSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { dirname, join } from "node:path";
 import type { Invite, Membership, Organization, Role } from "./orgs";
-import type { Store } from "./store";
+import type { AuditPage, AuditPageQuery, Store } from "./store";
 import type {
   AgentCommand,
   AuditEvent,
@@ -533,6 +533,24 @@ export class MemoryStore implements Store {
       .filter((entry) => entry.orgId === orgId)
       .sort(byTime((entry) => entry.at, (entry) => entry.id))
       .slice(-limit);
+  }
+
+  async auditPage(orgId: string, query: AuditPageQuery): Promise<AuditPage> {
+    const needle = query.query?.trim().toLocaleLowerCase();
+    const matching = this.data.audit.filter((entry) => {
+      if (entry.orgId !== orgId) return false;
+      if (query.sessionId && entry.sessionId !== query.sessionId) return false;
+      if (query.actorUid && entry.actorUid !== query.actorUid) return false;
+      if (query.kind && entry.kind !== query.kind) return false;
+      if (query.sinceAt && entry.at < query.sinceAt) return false;
+      if (needle && !entry.text.toLocaleLowerCase().includes(needle)) return false;
+      return true;
+    });
+    const newest = matching.sort(byTime((entry) => entry.at, (entry) => entry.id, true));
+    return {
+      events: newest.slice(query.offset, query.offset + query.limit),
+      total: newest.length,
+    };
   }
 
   /* ---------------------------------------------------------------

--- a/app/server/lib/store-postgres.ts
+++ b/app/server/lib/store-postgres.ts
@@ -4,7 +4,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import pg from "pg";
 import type { Invite, Membership, Organization, Role } from "./orgs";
-import type { Store } from "./store";
+import type { AuditPage, AuditPageQuery, Store } from "./store";
 import type {
   AgentCommand,
   AuditEvent,
@@ -1122,6 +1122,39 @@ export class PostgresStore implements Store {
       [orgId, limit],
     );
     return rows.map(toAudit);
+  }
+
+  async auditPage(orgId: string, query: AuditPageQuery): Promise<AuditPage> {
+    const where = ["org_id = $1"];
+    const values: unknown[] = [orgId];
+    const add = (clause: string, value: unknown) => {
+      values.push(value);
+      where.push(clause.replace("?", `$${values.length}`));
+    };
+
+    if (query.sessionId) add("session_id = ?", query.sessionId);
+    if (query.actorUid) add("actor_uid = ?", query.actorUid);
+    if (query.kind) add("kind = ?", query.kind);
+    if (query.sinceAt) add("at >= ?", query.sinceAt);
+    if (query.query) {
+      const literal = query.query.replace(/[\\%_]/g, "\\$&");
+      add("text ILIKE ? ESCAPE '\\'", `%${literal}%`);
+    }
+
+    const condition = where.join(" AND ");
+    const totalRows = await this.rows(
+      `SELECT COUNT(*)::int AS total FROM audit_events WHERE ${condition}`,
+      values,
+    );
+    const pageValues = [...values, query.limit, query.offset];
+    const rows = await this.rows(
+      `SELECT * FROM audit_events
+       WHERE ${condition}
+       ORDER BY at DESC, id COLLATE "C" DESC
+       LIMIT $${values.length + 1} OFFSET $${values.length + 2}`,
+      pageValues,
+    );
+    return { events: rows.map(toAudit), total: Number(totalRows[0]?.total ?? 0) };
   }
 
   /* ---- Comments and notifications ---- */

--- a/app/server/lib/store.ts
+++ b/app/server/lib/store.ts
@@ -13,6 +13,21 @@ import type {
 
 export * from "./types";
 
+export interface AuditPageQuery {
+  limit: number;
+  offset: number;
+  sessionId?: string;
+  actorUid?: string;
+  kind?: AuditEvent["kind"];
+  query?: string;
+  sinceAt?: number;
+}
+
+export interface AuditPage {
+  events: AuditEvent[];
+  total: number;
+}
+
 /**
  * Everything the service keeps.
  *
@@ -123,6 +138,7 @@ export interface Store {
   putAudit(event: AuditEvent): Promise<void>;
   auditFor(orgId: string, sessionId: string): Promise<AuditEvent[]>;
   auditForOrg(orgId: string, limit?: number): Promise<AuditEvent[]>;
+  auditPage(orgId: string, query: AuditPageQuery): Promise<AuditPage>;
 
   /* ---- Comments and notifications ---- */
   putComment(comment: Comment): Promise<void>;

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -339,10 +339,30 @@ export function deleteSession(sessionId: string) {
   });
 }
 
-/** The whole team's trail, including sessions that have since been removed. */
-export function fetchOrgAudit(limit?: number) {
-  const query = limit ? `?limit=${encodeURIComponent(String(limit))}` : "";
-  return request<{ events: AuditEvent[] }>(`/api/audit${query}`);
+export interface AuditPageRequest {
+  page?: number;
+  limit?: number;
+  session?: string;
+  actor?: string;
+  kind?: string;
+  query?: string;
+  sinceAt?: number;
+}
+
+/** The team's trail, filtered and paged by the service rather than the browser. */
+export function fetchOrgAudit(input: AuditPageRequest = {}) {
+  const params = new URLSearchParams();
+  if (input.page) params.set("page", String(input.page));
+  if (input.limit) params.set("limit", String(input.limit));
+  if (input.session) params.set("session", input.session);
+  if (input.actor) params.set("actor", input.actor);
+  if (input.kind) params.set("kind", input.kind);
+  if (input.query?.trim()) params.set("q", input.query.trim());
+  if (input.sinceAt) params.set("since_at", String(input.sinceAt));
+  const query = params.toString();
+  return request<{ events: AuditEvent[]; total: number; page: number; limit: number }>(
+    `/api/audit${query ? `?${query}` : ""}`,
+  );
 }
 
 export function fetchAudit(sessionId: string) {

--- a/app/src/routes/Audit.tsx
+++ b/app/src/routes/Audit.tsx
@@ -22,7 +22,6 @@ import {
 import {
   EMPTY_FILTERS,
   activity,
-  applyFilters,
   byActor,
   isFiltered,
   memberOf,
@@ -37,6 +36,8 @@ import { displayName } from "../lib/people";
 import { SearchSelect } from "../components/SearchSelect";
 import type { SearchSelectOption } from "../lib/search-options";
 
+const PAGE_SIZE = 40;
+
 const RANGES = [
   { label: "All time", detail: "The complete retained audit trail", value: 0 },
   { label: "Last hour", detail: "Activity from the past 60 minutes", value: 60 * 60 * 1000 },
@@ -48,10 +49,20 @@ const KINDS = [
   { label: "Everything", detail: "Every recorded event type", value: "" },
   { label: "Commands and prompts", detail: "Submitted terminal input and agent prompts", value: "input" },
   { label: "Interrupts", detail: "Ctrl-C and interrupted input", value: "interrupt" },
+  { label: "Opened", detail: "Sessions opened from the workspace", value: "opened" },
   { label: "Handoffs", detail: "Assignment changes between teammates", value: "handoff" },
   { label: "Stopped", detail: "Processes stopped from the app", value: "stopped" },
   { label: "Removed", detail: "Sessions removed from the workspace", value: "deleted" },
 ];
+
+const EVENT_LABEL: Record<AuditEvent["kind"], string> = {
+  input: "Submitted",
+  interrupt: "Interrupted",
+  opened: "Opened",
+  handoff: "Assigned",
+  stopped: "Stopped",
+  deleted: "Removed",
+};
 
 /** A bar chart of when things happened. Inline SVG; no charting library. */
 function ActivityChart({ events }: { events: AuditEvent[] }) {
@@ -63,7 +74,7 @@ function ActivityChart({ events }: { events: AuditEvent[] }) {
 
   return (
     <figure className="chart">
-      <figcaption>Activity</figcaption>
+      <figcaption>Activity on this page</figcaption>
       <div className="chart-bars" role="img" aria-label={`${events.length} entries over time`}>
         {buckets.map((bucket) => (
           <span
@@ -131,38 +142,63 @@ export function Audit() {
   const [members, setMembers] = useState<Member[]>([]);
   const [error, setError] = useState("");
   const [exporting, setExporting] = useState(false);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(() => Math.max(1, Number(params.get("page")) || 1));
 
   const [filters, setFilters] = useState<Filters>({
-    ...EMPTY_FILTERS,
+    actor: params.get("actor") ?? "",
+    kind: params.get("kind") ?? "",
+    query: params.get("q") ?? "",
+    since: Math.max(0, Number(params.get("since")) || 0),
     session: params.get("session") ?? "",
   });
 
-  const load = useCallback(async () => {
+  const loadContext = useCallback(async () => {
     try {
-      const [list, trail] = await Promise.all([fetchSessions(), fetchOrgAudit()]);
+      const list = await fetchSessions();
       setSessions(list.sessions);
       setMembers(list.members ?? []);
-      /*
-       * Read as one trail rather than session by session. Asking each session
-       * for its own log cannot return the entry for a session that has been
-       * removed, and that entry is exactly what somebody comes here to find.
-       */
-      setEvents([...trail.events].sort((a, b) => b.at - a.at));
-      setError("");
     } catch (caught) {
-      setEvents([]);
       setError(caught instanceof Error ? caught.message : "Could not load the audit log.");
     }
   }, []);
 
   useEffect(() => {
-    void load();
-  }, [load]);
+    void loadContext();
+  }, [loadContext]);
 
-  const shown = useMemo(
-    () => (events ? applyFilters(events, filters) : []),
-    [events, filters],
-  );
+  useEffect(() => {
+    let current = true;
+    const timer = window.setTimeout(async () => {
+      try {
+        const trail = await fetchOrgAudit({
+          page,
+          limit: PAGE_SIZE,
+          session: filters.session || undefined,
+          actor: filters.actor || undefined,
+          kind: filters.kind || undefined,
+          query: filters.query || undefined,
+          sinceAt: filters.since ? Date.now() - filters.since : undefined,
+        });
+        if (!current) return;
+        setEvents(trail.events);
+        setTotal(trail.total);
+        setError("");
+        if (trail.events.length === 0 && trail.total > 0 && page > 1) setPage(page - 1);
+      } catch (caught) {
+        if (!current) return;
+        setEvents([]);
+        setTotal(0);
+        setError(caught instanceof Error ? caught.message : "Could not load the audit log.");
+      }
+    }, filters.query ? 180 : 0);
+    return () => {
+      current = false;
+      window.clearTimeout(timer);
+    };
+  }, [filters, page]);
+
+  const shown = useMemo(() => events ?? [], [events]);
   const summary = useMemo(() => summarise(shown), [shown]);
   const sessionOptions = useMemo<SearchSelectOption[]>(() => [
     { value: "", label: "All sessions", detail: "Activity across every session" },
@@ -182,16 +218,31 @@ export function Audit() {
     })),
   ], [members]);
 
+  function writeParams(next: Filters, nextPage: number) {
+    const query = new URLSearchParams();
+    if (next.session) query.set("session", next.session);
+    if (next.actor) query.set("actor", next.actor);
+    if (next.kind) query.set("kind", next.kind);
+    if (next.query.trim()) query.set("q", next.query.trim());
+    if (next.since) query.set("since", String(next.since));
+    if (nextPage > 1) query.set("page", String(nextPage));
+    setParams(query, { replace: true });
+  }
+
   function set(patch: Partial<Filters>) {
     setFilters((current) => {
       const next = { ...current, ...patch };
-      if (patch.session !== undefined) {
-        /* Keep the address bar honest, so a filtered view can be shared. */
-        if (patch.session) setParams({ session: patch.session }, { replace: true });
-        else setParams({}, { replace: true });
-      }
+      writeParams(next, 1);
       return next;
     });
+    setPage(1);
+  }
+
+  function goToPage(nextPage: number) {
+    setPage(nextPage);
+    setEvents(null);
+    writeParams(filters, nextPage);
+    window.scrollTo({ top: 0, behavior: "smooth" });
   }
 
   async function handleExport() {
@@ -283,6 +334,7 @@ export function Audit() {
         {isFiltered(filters) && (
           <button type="button" className="filter-clear" onClick={() => {
             setFilters(EMPTY_FILTERS);
+            setPage(1);
             setParams({}, { replace: true });
           }}>
             Clear
@@ -298,42 +350,53 @@ export function Audit() {
         </div>
       ) : (
         <>
-          <div className="stat-row">
-            <Stat label="Entries" value={summary.total} />
-            <Stat label="Commands and prompts" value={summary.inputs} />
-            <Stat label="Interrupts" value={summary.interrupts} />
-            <Stat label="People" value={summary.people} />
-            <Stat label="Sessions" value={summary.sessions} />
+          <div className="audit-reading-key" aria-label="How to read the audit log">
+            <span><b>Person</b> who acted</span>
+            <ArrowRight size={13} weight="bold" />
+            <span><b>Action</b> they took</span>
+            <ArrowRight size={13} weight="bold" />
+            <span><b>Session</b> where it happened</span>
+            <small>Newest activity is first. Times use your local timezone.</small>
           </div>
 
           {shown.length > 0 && (
-            <div className="chart-row">
-              <ActivityChart events={shown} />
-              <RankChart
-                caption="By user"
-                rows={byActor(shown).slice(0, 6)}
-                onPick={(uid) => set({ actor: uid === filters.actor ? "" : uid })}
-                render={(uid) => {
-                  const member = memberOf(members, uid);
-                  return (
-                    <span className="rank-person">
-                      <Avatar person={member} size="xs" />
-                      {displayName(member)}
-                    </span>
-                  );
-                }}
-              />
-              <RankChart
-                caption="Most used"
-                rows={topCommands(shown)}
-                onPick={(word) => set({ query: word })}
-                render={(word) => <code>{word}</code>}
-              />
+            <div className="audit-page-summary">
+              <div className="stat-row">
+                <Stat label="Matching entries" value={total} />
+                <Stat label="On this page" value={summary.total} />
+                <Stat label="People on this page" value={summary.people} />
+                <Stat label="Sessions on this page" value={summary.sessions} />
+              </div>
+              <div className="chart-row">
+                <ActivityChart events={shown} />
+                <RankChart
+                  caption="People on this page"
+                  rows={byActor(shown).slice(0, 6)}
+                  onPick={(uid) => set({ actor: uid === filters.actor ? "" : uid })}
+                  render={(uid) => {
+                    const member = memberOf(members, uid);
+                    return (
+                      <span className="rank-person">
+                        <Avatar person={member} size="xs" />
+                        {displayName(member)}
+                      </span>
+                    );
+                  }}
+                />
+                <RankChart
+                  caption="Commands on this page"
+                  rows={topCommands(shown)}
+                  onPick={(word) => set({ query: word })}
+                  render={(word) => <code>{word}</code>}
+                />
+              </div>
             </div>
           )}
 
           <h2 className="detail-heading">
-            {isFiltered(filters) ? `${shown.length} matching` : "Everything"}
+            {total > 0
+              ? `Showing ${(page - 1) * PAGE_SIZE + 1}–${Math.min(page * PAGE_SIZE, total)} of ${total}`
+              : isFiltered(filters) ? "No matches" : "Everything"}
           </h2>
 
           {shown.length === 0 ? (
@@ -346,11 +409,41 @@ export function Audit() {
               </ol>
             </div>
           ) : (
-            <Trace events={shown} members={members} sessions={sessions} />
+            <>
+              <Trace events={shown} members={members} sessions={sessions} />
+              <Pagination
+                page={page}
+                pageCount={Math.max(1, Math.ceil(total / PAGE_SIZE))}
+                onPage={goToPage}
+              />
+            </>
           )}
         </>
       )}
     </AppShell>
+  );
+}
+
+function Pagination({
+  page,
+  pageCount,
+  onPage,
+}: {
+  page: number;
+  pageCount: number;
+  onPage(page: number): void;
+}) {
+  if (pageCount <= 1) return null;
+  return (
+    <nav className="pagination" aria-label="Audit pages">
+      <button type="button" onClick={() => onPage(page - 1)} disabled={page <= 1}>
+        Previous
+      </button>
+      <span>Page {page} of {pageCount}</span>
+      <button type="button" onClick={() => onPage(page + 1)} disabled={page >= pageCount}>
+        Next
+      </button>
+    </nav>
   );
 }
 
@@ -379,15 +472,16 @@ function Trace({
   sessions: SessionRecord[];
 }) {
   const groups = traceGroups(events);
-
-  let lastDay = "";
+  const withDay = groups.map((group, index) => {
+    const day = new Date(group.events[0].at).toDateString();
+    const previous = groups[index - 1];
+    const previousDay = previous ? new Date(previous.events[0].at).toDateString() : "";
+    return { group, newDay: day !== previousDay };
+  });
   return (
     <ol className="trace">
-      {groups.map((group) => {
+      {withDay.map(({ group, newDay }) => {
         const person = memberOf(members, group.actorUid);
-        const day = new Date(group.events[0].at).toDateString();
-        const newDay = day !== lastDay;
-        lastDay = day;
 
         return (
           <li key={group.key} className="trace-group">
@@ -425,6 +519,7 @@ function Trace({
                       second: "2-digit",
                     })}
                   </span>
+                  <span className="trace-kind">{EVENT_LABEL[event.kind]}</span>
                   <code>
                     {event.kind === "interrupt"
                       ? `^C${event.text ? ` while typing ${event.text}` : ""}`

--- a/app/src/routes/Machines.tsx
+++ b/app/src/routes/Machines.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from "react";
-import { Desktop } from "@phosphor-icons/react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Desktop, MagnifyingGlass, X } from "@phosphor-icons/react";
 import { AppShell, LinkHint } from "../components/AppShell";
 import { Button } from "../components/Button";
 import { Alert } from "../components/Alert";
@@ -7,12 +7,21 @@ import { fetchDevices, revokeDevice, type Device } from "../lib/api";
 import { machineOnline } from "../lib/agent";
 import { usePageTitle } from "../lib/page-title";
 import { ago } from "../lib/time";
+import { SearchSelect } from "../components/SearchSelect";
+
+const MACHINE_STATUS = [
+  { value: "all", label: "All machines", detail: "Online and offline machines" },
+  { value: "online", label: "Online", detail: "Listening for browser-started sessions" },
+  { value: "offline", label: "Offline", detail: "Linked, but not listening right now" },
+];
 
 export function Machines() {
   usePageTitle("Machines");
   const [devices, setDevices] = useState<Device[] | null>(null);
   const [error, setError] = useState("");
   const [unlinking, setUnlinking] = useState("");
+  const [query, setQuery] = useState("");
+  const [status, setStatus] = useState("all");
 
   const load = useCallback(async () => {
     try {
@@ -61,13 +70,27 @@ export function Machines() {
     return () => window.clearInterval(timer);
   }, []);
 
+  const visibleDevices = useMemo(() => {
+    const needle = query.trim().toLocaleLowerCase();
+    return (devices ?? []).filter((device) => {
+      const online = machineOnline(device, now);
+      if (status === "online" && !online) return false;
+      if (status === "offline" && online) return false;
+      if (!needle) return true;
+      return [device.label, device.id, ...(device.harnesses ?? [])]
+        .some((part) => part.toLocaleLowerCase().includes(needle));
+    });
+  }, [devices, now, query, status]);
+
   return (
     <AppShell
       title="Machines"
       aside={
         devices && devices.length > 0 ? (
           <span className="topbar-count">
-            {devices.length} linked
+            {visibleDevices.length === devices.length
+              ? `${devices.length} linked`
+              : `${visibleDevices.length} of ${devices.length}`}
           </span>
         ) : null
       }
@@ -86,6 +109,34 @@ export function Machines() {
       <LinkHint className="machines-hint" />
 
       {error && <div className="sessions-alert"><Alert tone="error">{error}</Alert></div>}
+
+      {devices && devices.length > 0 && (
+        <div className="list-toolbar">
+          <label className="sessions-search">
+            <MagnifyingGlass size={15} />
+            <input
+              type="search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search machines"
+              aria-label="Search machines by name, id, or capability"
+            />
+            {query && (
+              <button type="button" className="search-clear" onClick={() => setQuery("")} aria-label="Clear machine search">
+                <X size={12} weight="bold" />
+              </button>
+            )}
+          </label>
+          <SearchSelect
+            label="Machine status"
+            value={status}
+            options={MACHINE_STATUS}
+            onChange={setStatus}
+            searchable={false}
+            align="right"
+          />
+        </div>
+      )}
 
       {devices === null ? (
         <div className="sessions-skeleton" aria-hidden="true">
@@ -109,9 +160,16 @@ export function Machines() {
             <li>The machine appears in this list.</li>
           </ol>
         </div>
+      ) : visibleDevices.length === 0 ? (
+        <div className="sessions-empty compact-empty">
+          <p>No machines match those filters.</p>
+          <button type="button" className="session-action" onClick={() => { setQuery(""); setStatus("all"); }}>
+            Clear filters
+          </button>
+        </div>
       ) : (
         <ul className="sessions-list">
-          {devices.map((device) => (
+          {visibleDevices.map((device) => (
             <li key={device.id} className="session">
               <div className="session-main">
                 <span className="device-label">

--- a/app/src/routes/Team.tsx
+++ b/app/src/routes/Team.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState, type FormEvent } from "react";
-import { Copy, Check, Trash, UserPlus, PencilSimple, Warning } from "@phosphor-icons/react";
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
+import { Copy, Check, Trash, UserPlus, PencilSimple, Warning, MagnifyingGlass, X } from "@phosphor-icons/react";
 import { AppShell } from "../components/AppShell";
 import { Button } from "../components/Button";
 import { Alert } from "../components/Alert";
@@ -19,12 +19,35 @@ import { displayName } from "../lib/people";
 import { usePageTitle } from "../lib/page-title";
 import { publicKey } from "../lib/keypair";
 import { COPY_FAILED, useCopy } from "../lib/clipboard";
+import { SearchSelect } from "../components/SearchSelect";
 
 const ROLE_LABEL: Record<string, string> = {
   owner: "Owner",
   admin: "Admin",
   member: "Member",
 };
+
+const MEMBER_ROLES = [
+  { value: "all", label: "All roles", detail: "Owners, admins, and members" },
+  { value: "owner", label: "Owners", detail: "Full organization control" },
+  { value: "admin", label: "Admins", detail: "Can invite and manage sessions" },
+  { value: "member", label: "Members", detail: "Standard team access" },
+];
+
+const INVITE_STATES = [
+  { value: "all", label: "All invites", detail: "Every invite status" },
+  { value: "live", label: "Waiting", detail: "Can still be accepted" },
+  { value: "accepted", label: "Accepted", detail: "Already used" },
+  { value: "expired", label: "Expired", detail: "Past its expiry time" },
+  { value: "revoked", label: "Revoked", detail: "Cancelled by the team" },
+];
+
+function inviteStateKey(invite: Invite): string {
+  if (invite.acceptedAt) return "accepted";
+  if (invite.revokedAt) return "revoked";
+  if (invite.expiresAt < Date.now()) return "expired";
+  return "live";
+}
 
 function inviteLink(invite: Invite): string {
   return `${window.location.origin}/join/${invite.id}`;
@@ -82,6 +105,10 @@ export function Team() {
   const [inviteRole, setInviteRole] = useState("member");
   const [renaming, setRenaming] = useState(false);
   const [draftName, setDraftName] = useState("");
+  const [memberQuery, setMemberQuery] = useState("");
+  const [memberRole, setMemberRole] = useState("all");
+  const [inviteQuery, setInviteQuery] = useState("");
+  const [inviteStatus, setInviteStatus] = useState("all");
 
   const load = useCallback(async () => {
     try {
@@ -101,6 +128,23 @@ export function Team() {
   const you = view?.you;
   const isOwner = you?.role === "owner";
   const canInvite = you?.role === "owner" || you?.role === "admin";
+  const visibleMembers = useMemo(() => {
+    const needle = memberQuery.trim().toLocaleLowerCase();
+    return (view?.members ?? []).filter((member) => {
+      if (memberRole !== "all" && member.role !== memberRole) return false;
+      return !needle || [displayName(member), member.email, member.role]
+        .some((part) => part.toLocaleLowerCase().includes(needle));
+    });
+  }, [view, memberQuery, memberRole]);
+  const visibleInvites = useMemo(() => {
+    const needle = inviteQuery.trim().toLocaleLowerCase();
+    return (view?.invites ?? []).filter((invite) => {
+      if (inviteStatus !== "all" && inviteStateKey(invite) !== inviteStatus) return false;
+      const target = invite.email || "Anyone with the link";
+      return !needle || [target, invite.role, inviteState(invite).label]
+        .some((part) => part.toLocaleLowerCase().includes(needle));
+    });
+  }, [view, inviteQuery, inviteStatus]);
 
   async function act(work: () => Promise<unknown>, done: string) {
     setBusy(true);
@@ -186,6 +230,31 @@ export function Team() {
 
           <section className="sessions-group">
             <h2>Members</h2>
+            <div className="list-toolbar">
+              <label className="sessions-search">
+                <MagnifyingGlass size={15} />
+                <input
+                  type="search"
+                  value={memberQuery}
+                  onChange={(event) => setMemberQuery(event.target.value)}
+                  placeholder="Search people or email"
+                  aria-label="Search team members"
+                />
+                {memberQuery && (
+                  <button type="button" className="search-clear" onClick={() => setMemberQuery("")} aria-label="Clear member search">
+                    <X size={12} weight="bold" />
+                  </button>
+                )}
+              </label>
+              <SearchSelect
+                label="Member role"
+                value={memberRole}
+                options={MEMBER_ROLES}
+                onChange={setMemberRole}
+                searchable={false}
+                align="right"
+              />
+            </div>
             <table className="table">
               <thead>
                 <tr>
@@ -197,7 +266,7 @@ export function Team() {
                 </tr>
               </thead>
               <tbody>
-                {view.members.map((member) => {
+                {visibleMembers.map((member) => {
                   const isYou = member.uid === you!.uid;
                   const rank = { owner: 3, admin: 2, member: 1 } as const;
                   const canAct = !isYou && rank[you!.role] > rank[member.role];
@@ -260,6 +329,16 @@ export function Team() {
                     </tr>
                   );
                 })}
+                {visibleMembers.length === 0 && (
+                  <tr className="filtered-table-empty">
+                    <td colSpan={5}>
+                      No members match those filters.{" "}
+                      <button type="button" onClick={() => { setMemberQuery(""); setMemberRole("all"); }}>
+                        Clear filters
+                      </button>
+                    </td>
+                  </tr>
+                )}
               </tbody>
             </table>
           </section>
@@ -292,7 +371,33 @@ export function Team() {
               <h2 className="invites-heading">Invites</h2>
 
               {view.invites.length > 0 && (
-                <table className="table invites-table">
+                <>
+                  <div className="list-toolbar invites-toolbar">
+                    <label className="sessions-search">
+                      <MagnifyingGlass size={15} />
+                      <input
+                        type="search"
+                        value={inviteQuery}
+                        onChange={(event) => setInviteQuery(event.target.value)}
+                        placeholder="Search invite email"
+                        aria-label="Search invites"
+                      />
+                      {inviteQuery && (
+                        <button type="button" className="search-clear" onClick={() => setInviteQuery("")} aria-label="Clear invite search">
+                          <X size={12} weight="bold" />
+                        </button>
+                      )}
+                    </label>
+                    <SearchSelect
+                      label="Invite status"
+                      value={inviteStatus}
+                      options={INVITE_STATES}
+                      onChange={setInviteStatus}
+                      searchable={false}
+                      align="right"
+                    />
+                  </div>
+                  <table className="table invites-table">
                   <thead>
                     <tr>
                       <th scope="col">Invited</th>
@@ -302,7 +407,7 @@ export function Team() {
                     </tr>
                   </thead>
                   <tbody>
-                    {view.invites.map((invite) => {
+                    {visibleInvites.map((invite) => {
                       const state = inviteState(invite);
                       return (
                         <tr key={invite.id} data-live={state.live}>
@@ -340,8 +445,19 @@ export function Team() {
                         </tr>
                       );
                     })}
+                    {visibleInvites.length === 0 && (
+                      <tr className="filtered-table-empty">
+                        <td colSpan={4}>
+                          No invites match those filters.{" "}
+                          <button type="button" onClick={() => { setInviteQuery(""); setInviteStatus("all"); }}>
+                            Clear filters
+                          </button>
+                        </td>
+                      </tr>
+                    )}
                   </tbody>
-                </table>
+                  </table>
+                </>
               )}
             </section>
           )}

--- a/app/src/routes/Workspace.tsx
+++ b/app/src/routes/Workspace.tsx
@@ -45,6 +45,7 @@ import { elapsed } from "../lib/time";
 import { usePageTitle } from "../lib/page-title";
 import { wasJustLinked, withoutLinkedFlag } from "../lib/linked";
 import { shouldOpenSurface } from "../lib/surface-navigation";
+import { SearchSelect } from "../components/SearchSelect";
 
 const POLL_MS = 4000;
 /* Well inside the service's 15s agent-online window, so the state stays true. */
@@ -53,6 +54,13 @@ const DEVICE_POLL_MS = 5000;
 const AFTER_COMMAND_MS = 1500;
 /* How long to wait for a started session before saying so. */
 const LAUNCH_PATIENCE_MS = 45_000;
+
+const SESSION_SCOPES = [
+  { value: "all", label: "All sessions", detail: "Live and finished sessions" },
+  { value: "write", label: "Live write", detail: "Sessions you can control" },
+  { value: "read", label: "Live read", detail: "Sessions you can watch" },
+  { value: "finished", label: "Finished", detail: "Processes that have exited" },
+];
 
 /*
  * Removes a session from the lists. Asks first, because it cannot be undone
@@ -142,6 +150,7 @@ export function Workspace() {
   const [composing, setComposing] = useState(false);
   const [killing, setKilling] = useState("");
   const [query, setQuery] = useState("");
+  const [scope, setScope] = useState("all");
   const [view, setView] = useState<ViewMode>(readViewMode);
   const [removing, setRemoving] = useState("");
   const [members, setMembers] = useState<Member[]>([]);
@@ -472,7 +481,13 @@ export function Workspace() {
    * row: "Running" mixed sessions you can drive with sessions you can only
    * watch, and the difference showed only once a tab was open.
    */
-  const matching = (sessions ?? []).filter((session) => matches(session, query));
+  const matching = (sessions ?? []).filter((session) => {
+    if (!matches(session, query)) return false;
+    if (scope === "write") return !session.closedAt && canEdit(session, you);
+    if (scope === "read") return !session.closedAt && !canEdit(session, you);
+    if (scope === "finished") return Boolean(session.closedAt);
+    return true;
+  });
   const liveWrite = matching.filter((session) => !session.closedAt && canEdit(session, you));
   const liveRead = matching.filter((session) => !session.closedAt && !canEdit(session, you));
   const finished = matching.filter((session) => session.closedAt);
@@ -638,6 +653,15 @@ export function Workspace() {
                 />
               </label>
 
+              <SearchSelect
+                label="Session status"
+                value={scope}
+                options={SESSION_SCOPES}
+                onChange={setScope}
+                searchable={false}
+                align="right"
+              />
+
               <div className="view-toggle" role="group" aria-label="How to show sessions">
                 <button
                   type="button"
@@ -670,9 +694,9 @@ export function Workspace() {
 
             {matching.length === 0 ? (
               <div className="sessions-empty">
-                <p>Nothing matches that search.</p>
-                <button type="button" className="session-action" onClick={() => setQuery("")}>
-                  Clear it
+                <p>Nothing matches those filters.</p>
+                <button type="button" className="session-action" onClick={() => { setQuery(""); setScope("all"); }}>
+                  Clear filters
                 </button>
               </div>
             ) : view === "board" ? (

--- a/app/src/styles/audit.css
+++ b/app/src/styles/audit.css
@@ -250,6 +250,36 @@
   color: var(--blue-deep);
 }
 
+.audit-reading-key {
+  display: flex;
+  min-height: 48px;
+  padding: 10px 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-control);
+  margin-bottom: 18px;
+  background: var(--paper);
+  color: var(--muted);
+  font-size: 12.5px;
+  align-items: center;
+  gap: 9px;
+}
+
+.audit-reading-key b {
+  color: var(--ink);
+  font-weight: 580;
+}
+
+.audit-reading-key > svg {
+  color: var(--faint);
+  flex: none;
+}
+
+.audit-reading-key small {
+  color: var(--faint);
+  font-size: 11.5px;
+  margin-left: auto;
+}
+
 /* ---- Summary ---- */
 
 .stat-row {
@@ -480,7 +510,7 @@
   display: grid;
   padding: 3px 0;
   gap: 12px;
-  grid-template-columns: 86px minmax(0, 1fr);
+  grid-template-columns: 86px 76px minmax(0, 1fr);
   align-items: baseline;
 }
 
@@ -489,6 +519,18 @@
   font-family: var(--mono);
   font-size: 11px;
   white-space: nowrap;
+}
+
+.trace-kind {
+  color: var(--muted);
+  font-size: 11.5px;
+  font-weight: 560;
+}
+
+.trace-lines li[data-kind="interrupt"] .trace-kind,
+.trace-lines li[data-kind="stopped"] .trace-kind,
+.trace-lines li[data-kind="deleted"] .trace-kind {
+  color: var(--danger);
 }
 
 .trace-lines code {
@@ -507,6 +549,40 @@
 .trace-lines li[data-kind="handoff"] code {
   color: var(--muted);
   font-family: var(--sans);
+}
+
+.pagination {
+  display: flex;
+  padding: 18px 0 4px;
+  border-top: 1px solid var(--line);
+  margin-top: 26px;
+  color: var(--muted);
+  font-size: 12.5px;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+}
+
+.pagination button {
+  min-width: 84px;
+  height: 36px;
+  padding: 0 12px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-control);
+  background: var(--white);
+  color: var(--ink-soft);
+  cursor: pointer;
+  font: inherit;
+}
+
+.pagination button:hover:not(:disabled) {
+  border-color: var(--muted);
+  color: var(--ink);
+}
+
+.pagination button:disabled {
+  cursor: default;
+  opacity: 0.42;
 }
 
 @media (max-width: 1080px) {
@@ -544,8 +620,22 @@
 
 @media (max-width: 560px) {
   .trace-lines li {
-    grid-template-columns: 1fr;
-    gap: 2px;
+    gap: 2px 8px;
+    grid-template-columns: auto 1fr;
+  }
+
+  .trace-lines code {
+    grid-column: 1 / -1;
+  }
+
+  .audit-reading-key {
+    display: grid;
+    grid-template-columns: auto 14px auto 14px auto;
+  }
+
+  .audit-reading-key small {
+    grid-column: 1 / -1;
+    margin: 3px 0 0;
   }
 
   .filter-search {

--- a/app/src/styles/auth.css
+++ b/app/src/styles/auth.css
@@ -1308,6 +1308,13 @@
   gap: 10px;
 }
 
+.list-toolbar {
+  display: flex;
+  margin: 14px 0;
+  align-items: center;
+  gap: 10px;
+}
+
 .sessions-search {
   display: flex;
   min-width: 0;
@@ -1338,6 +1345,25 @@
 
 .sessions-search input::placeholder {
   color: var(--muted);
+}
+
+.sessions-search .search-clear {
+  display: grid;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  flex: none;
+  place-items: center;
+}
+
+.sessions-search .search-clear:hover {
+  background: var(--line);
+  color: var(--ink);
 }
 
 .sessions-search:focus-within {
@@ -1536,13 +1562,20 @@
 }
 
 @media (max-width: 560px) {
-  .sessions-toolbar {
+  .sessions-toolbar,
+  .list-toolbar {
     flex-wrap: wrap;
   }
 
-  .sessions-search {
+  .sessions-toolbar .sessions-search,
+  .list-toolbar .sessions-search {
     flex: 1 1 100%;
     order: 2;
+  }
+
+  .sessions-toolbar .filter-picker,
+  .list-toolbar .filter-picker {
+    order: 1;
   }
 
   .view-toggle {

--- a/app/src/styles/people.css
+++ b/app/src/styles/people.css
@@ -292,6 +292,35 @@
   background: color-mix(in srgb, var(--ink) 3%, transparent);
 }
 
+.filtered-table-empty:hover {
+  background: transparent !important;
+}
+
+.filtered-table-empty td {
+  padding: 22px 4px;
+  color: var(--muted);
+  text-align: center;
+}
+
+.filtered-table-empty td:first-child {
+  width: auto;
+  max-width: none;
+  min-width: 0;
+}
+
+.filtered-table-empty button {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--blue);
+  cursor: pointer;
+  font: inherit;
+}
+
+.filtered-table-empty button:hover {
+  text-decoration: underline;
+}
+
 .table td {
   padding: 12px;
   vertical-align: middle;


### PR DESCRIPTION
## What changed
- add compact, contextual search and filters to Sessions, Machines, Team members, and Team invites
- move Audit filtering and pagination into the service, with stable newest-first pages and matching totals
- make Audit read as person → action → session, with explicit event labels and local-time guidance
- keep filter/page state in the Audit URL and distinguish empty collections from empty filter results

## Verification
- `npm --prefix app run lint`
- `npm --prefix app run typecheck`
- `npm --prefix app test` (673 passed)
- production-configured app build and bundle validation
- real Chromium interaction/overflow checks at 320, 390, 768, and 1440 px
