### PR TITLE
Fill portrait terminals and add pinch zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-visible changes are recorded here. Versions follow [Semantic Ve
 
 ## Unreleased
 
+## [0.11.2] — 2026-09-10
+
 ### Added
 
 - Document self-hosting for the relay and optional accounts app, with a

--- a/Formula/shell-online.rb
+++ b/Formula/shell-online.rb
@@ -1,8 +1,8 @@
 class ShellOnline < Formula
   desc "Turn any terminal process into an interactive or read-only browser link"
   homepage "https://shell.online"
-  url "https://github.com/TeoSlayer/shell.online/archive/refs/tags/v0.11.1.tar.gz"
-  sha256 "bdfab292df399086a811a01527bdfbecd2c3cde46304fdce0f4c6204a1d58753"
+  url "https://github.com/TeoSlayer/shell.online/archive/refs/tags/v0.11.2.tar.gz"
+  sha256 "REPLACE_WITH_TAG_TARBALL_SHA256"
   license "MIT"
 
   depends_on "go" => :build

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ npm run test:app
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) before opening a pull request.
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=TeoSlayer/shell.online&type=Date)](https://www.star-history.com/#TeoSlayer/shell.online&Date)
+
 MIT licensed. See [`LICENSE`](LICENSE).
 
 Developed by [Pilot Protocol](https://pilotprotocol.network/).

--- a/app/src/terminal/TerminalPane.tsx
+++ b/app/src/terminal/TerminalPane.tsx
@@ -198,7 +198,7 @@ export function TerminalPane({
           setReadOnly(value);
           term.options.disableStdin = value;
         },
-        /* A phone joining takes the session to 80x24, and back when it leaves. */
+        /* A portrait viewer takes a capable session to 80x40, and back when it leaves. */
         onGrid: (next) => {
           grid.current = next;
           refit();

--- a/app/src/terminal/connection.test.ts
+++ b/app/src/terminal/connection.test.ts
@@ -4,6 +4,7 @@ import { Opcode, encodeFrame } from "./protocol";
 import { BrowserFrameCipher } from "./e2ee";
 import {
   DESKTOP_TERMINAL_GRID,
+  LEGACY_MOBILE_TERMINAL_GRID,
   MOBILE_TERMINAL_GRID,
   type TerminalGrid,
 } from "./terminal-grid";
@@ -383,10 +384,16 @@ describe("the session grid", () => {
     expect(recorded.grids).toEqual([MOBILE_TERMINAL_GRID]);
   });
 
+  it("still renders the legacy mobile grid from an older CLI", async () => {
+    const { connection, socket } = await connected();
+    socket.control({ type: "terminal_size", ...LEGACY_MOBILE_TERMINAL_GRID });
+    expect(connection.grid).toEqual(LEGACY_MOBILE_TERMINAL_GRID);
+  });
+
   it("refuses a grid the CLI would reject", async () => {
     /*
-     * cmd/shell/session_unix.go only resizes the PTY to one of the two
-     * canonical grids. Drawing anything else means rendering a shape the
+     * cmd/shell/session_unix.go only resizes the PTY to a canonical grid.
+     * Drawing anything else means rendering a shape the
      * process is not writing, which is the bug this whole model prevents.
      */
     const { connection, recorded, socket } = await connected();

--- a/app/src/terminal/connection.ts
+++ b/app/src/terminal/connection.ts
@@ -2,6 +2,7 @@ import { Opcode, encodeFrame, isSnapshotOpcode } from "./protocol";
 import { BrowserFrameCipher, parseEncryptionFragment, type EncryptionFragment } from "./e2ee";
 import {
   DESKTOP_TERMINAL_GRID,
+  LEGACY_MOBILE_TERMINAL_GRID,
   MOBILE_TERMINAL_GRID,
   type TerminalGrid,
 } from "./terminal-grid";
@@ -270,14 +271,14 @@ export class TerminalConnection {
   }
 
   /*
-   * Only the two grids the CLI will actually open a PTY at are honoured. It
-   * refuses anything else (`isCanonicalTerminalSize`), so rendering a size it
+   * Only grids the CLI will actually open a PTY at are honoured. It refuses
+   * anything else (`isCanonicalTerminalSize`), so rendering a size it
    * would have rejected is how a viewer ends up drawing 94 columns of a
    * 120-column process.
    */
   private adoptGrid(cols: unknown, rows: unknown): void {
     if (typeof cols !== "number" || typeof rows !== "number") return;
-    const grid = [DESKTOP_TERMINAL_GRID, MOBILE_TERMINAL_GRID].find(
+    const grid = [DESKTOP_TERMINAL_GRID, MOBILE_TERMINAL_GRID, LEGACY_MOBILE_TERMINAL_GRID].find(
       (candidate) => candidate.cols === cols && candidate.rows === rows,
     );
     if (!grid) return;

--- a/app/src/terminal/terminal-grid.ts
+++ b/app/src/terminal/terminal-grid.ts
@@ -12,8 +12,14 @@ export interface TerminalGrid {
 }
 
 export const DESKTOP_TERMINAL_GRID: TerminalGrid = { cols: 120, rows: 36 };
-export const MOBILE_TERMINAL_GRID: TerminalGrid = { cols: 80, rows: 24 };
+export const LEGACY_MOBILE_TERMINAL_GRID: TerminalGrid = { cols: 80, rows: 24 };
+export const MOBILE_TERMINAL_GRID: TerminalGrid = { cols: 80, rows: 40 };
 
-export function terminalGridForDevices(devices: readonly string[]): TerminalGrid {
-  return devices.includes("mobile") ? MOBILE_TERMINAL_GRID : DESKTOP_TERMINAL_GRID;
+export function terminalGridForDevices(
+  devices: readonly string[],
+  supportsPortraitGrid: boolean,
+): TerminalGrid {
+  const needsPortraitGrid = devices.some((device) => device === "mobile" || device === "portrait");
+  if (!needsPortraitGrid) return DESKTOP_TERMINAL_GRID;
+  return supportsPortraitGrid ? MOBILE_TERMINAL_GRID : LEGACY_MOBILE_TERMINAL_GRID;
 }

--- a/cmd/shell/session_unix.go
+++ b/cmd/shell/session_unix.go
@@ -30,7 +30,8 @@ const (
 	desktopTerminalCols    = 120
 	desktopTerminalRows    = 36
 	mobileTerminalCols     = 80
-	mobileTerminalRows     = 24
+	mobileTerminalRows     = 40
+	legacyMobileRows       = 24
 	backgroundStartupGrace = 250 * time.Millisecond
 )
 
@@ -481,7 +482,7 @@ func sharedTerminalSize() terminalGrid {
 
 func isCanonicalTerminalSize(cols, rows uint16) bool {
 	return (cols == desktopTerminalCols && rows == desktopTerminalRows) ||
-		(cols == mobileTerminalCols && rows == mobileTerminalRows)
+		(cols == mobileTerminalCols && (rows == mobileTerminalRows || rows == legacyMobileRows))
 }
 
 func terminalEnvironment(environment []string) []string {

--- a/cmd/shell/session_unix_test.go
+++ b/cmd/shell/session_unix_test.go
@@ -295,7 +295,7 @@ func TestSharedTerminalUsesLargeGridUntilPhoneCompatibilityIsRequested(t *testin
 	if size.Cols != 120 || size.Rows != 36 {
 		t.Fatalf("shared terminal size = %dx%d, want 120x36", size.Cols, size.Rows)
 	}
-	for _, candidate := range [][2]uint16{{120, 36}, {80, 24}} {
+	for _, candidate := range [][2]uint16{{120, 36}, {80, 40}, {80, 24}} {
 		if !isCanonicalTerminalSize(candidate[0], candidate[1]) {
 			t.Fatalf("canonical terminal size %v was rejected", candidate)
 		}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 services:
   shell-online:
-    image: ghcr.io/teoslayer/shell.online:0.11.1
+    image: ghcr.io/teoslayer/shell.online:0.11.2
     build:
       context: .
       args:
-        VERSION: "0.11.1"
+        VERSION: "0.11.2"
     restart: unless-stopped
     environment:
       SHELL_ONLINE_E2EE_PASSWORD: "${SHELL_ONLINE_E2EE_PASSWORD:-}"

--- a/docs/content.json
+++ b/docs/content.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.11.1",
+  "version": "0.11.2",
   "pages": {
     "docs": {
       "eyebrow": "Documentation",
@@ -513,7 +513,7 @@
       "cards": [
         [
           "Start once",
-          "Pull ghcr.io/teoslayer/shell.online:0.11.1 or run docker compose up --build -d, then docker compose logs shell-online. First launch prints the stable URL and a generated eight-character password. The tagged amd64/arm64 image includes an SBOM and build provenance."
+          "Pull ghcr.io/teoslayer/shell.online:0.11.2 or run docker compose up --build -d, then docker compose logs shell-online. First launch prints the stable URL and a generated eight-character password. The tagged amd64/arm64 image includes an SBOM and build provenance."
         ],
         [
           "Two durable volumes",

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
           },
           "applicationCategory": "DeveloperApplication",
           "operatingSystem": "macOS, Windows, Linux, FreeBSD, OpenBSD, NetBSD, DragonFly BSD, Solaris",
-          "softwareVersion": "0.11.1",
+          "softwareVersion": "0.11.2",
           "softwareRequirements": "A supported architecture, outbound HTTPS and WebSockets, and a PTY or Windows ConPTY",
           "isAccessibleForFree": true,
           "downloadUrl": "https://shell.online/install",

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -121,6 +121,9 @@ func (connection *Connection) run(firstResult chan<- error) {
 func (connection *Connection) dial() (*websocket.Conn, *http.Response, error) {
 	header := make(http.Header)
 	header.Set("Authorization", "Bearer "+connection.hostToken)
+	// Lets the relay choose the taller portrait grid without sending it to an
+	// older CLI that only knows the original 80x24 compatibility size.
+	header.Set("X-Shell-Terminal-Grid", "80x40")
 	return websocket.Dial(connection.ctx, connection.endpoint, &websocket.DialOptions{HTTPHeader: header})
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shell-online",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shell-online",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
         "@xterm/xterm": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shell-online",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Turn any terminal process into a collaborative browser link.",
   "private": true,
   "license": "MIT",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -24,9 +24,9 @@ The Homebrew formula builds locally: Brew fetches the checksum-pinned tagged sou
 
 The standalone installer uses a checksum-pinned release binary. To compile and run the tagged source outside either installation path:
 
-git clone --depth 1 --branch v0.11.1 https://github.com/TeoSlayer/shell.online.git
+git clone --depth 1 --branch v0.11.2 https://github.com/TeoSlayer/shell.online.git
 cd shell.online
-go build -trimpath -ldflags="-X main.version=0.11.1" -o ./shell ./cmd/shell
+go build -trimpath -ldflags="-X main.version=0.11.2" -o ./shell ./cmd/shell
 ./shell --version
 
 The source-build path requires Go 1.26.8 or newer, except Go 1.27.x is intentionally unsupported on MIPS64 because of go.dev/issue/80978. Keep using ./shell or move it to a directory on PATH.

--- a/shared/terminal-grid.ts
+++ b/shared/terminal-grid.ts
@@ -4,8 +4,14 @@ export interface TerminalGrid {
 }
 
 export const DESKTOP_TERMINAL_GRID: TerminalGrid = { cols: 120, rows: 36 };
-export const MOBILE_TERMINAL_GRID: TerminalGrid = { cols: 80, rows: 24 };
+export const LEGACY_MOBILE_TERMINAL_GRID: TerminalGrid = { cols: 80, rows: 24 };
+export const MOBILE_TERMINAL_GRID: TerminalGrid = { cols: 80, rows: 40 };
 
-export function terminalGridForDevices(devices: readonly string[]): TerminalGrid {
-  return devices.includes("mobile") ? MOBILE_TERMINAL_GRID : DESKTOP_TERMINAL_GRID;
+export function terminalGridForDevices(
+  devices: readonly string[],
+  supportsPortraitGrid: boolean,
+): TerminalGrid {
+  const needsPortraitGrid = devices.some((device) => device === "mobile" || device === "portrait");
+  if (!needsPortraitGrid) return DESKTOP_TERMINAL_GRID;
+  return supportsPortraitGrid ? MOBILE_TERMINAL_GRID : LEGACY_MOBILE_TERMINAL_GRID;
 }

--- a/tests/mobile-viewport.test.ts
+++ b/tests/mobile-viewport.test.ts
@@ -56,7 +56,7 @@ describe("terminal typography", () => {
   it("uses a denser readable terminal while the mobile keyboard is open", () => {
     expect(terminalTypography(true, false, 390, 844)).toEqual({
       fontSize: 13,
-      lineHeight: 1.18,
+      lineHeight: 1.8,
     });
     expect(terminalTypography(true, true, 390, 493)).toEqual({
       fontSize: 8.5,
@@ -65,6 +65,17 @@ describe("terminal typography", () => {
     expect(terminalTypography(true, true, 360, 420)).toEqual({
       fontSize: 8,
       lineHeight: 1.08,
+    });
+  });
+
+  it("uses the available height for a portrait terminal without changing its grid", () => {
+    expect(terminalTypography(false, false, 1080, 1920)).toEqual({
+      fontSize: 14,
+      lineHeight: 1.8,
+    });
+    expect(terminalTypography(false, false, 1920, 1080)).toEqual({
+      fontSize: 14,
+      lineHeight: 1.18,
     });
   });
 

--- a/tests/terminal-fit.test.ts
+++ b/tests/terminal-fit.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { fittedTerminal, type TerminalCell } from "../web/terminal-fit";
-import { DESKTOP_TERMINAL_GRID, MOBILE_TERMINAL_GRID, terminalGridForDevices } from "../shared/terminal-grid";
+import {
+  DESKTOP_TERMINAL_GRID,
+  LEGACY_MOBILE_TERMINAL_GRID,
+  MOBILE_TERMINAL_GRID,
+  terminalGridForDevices,
+} from "../shared/terminal-grid";
 
 /*
  * A monospaced font measured the way the browser measures one: an advance
@@ -24,9 +29,11 @@ function drawn(
 
 describe("viewer-local terminal fitting", () => {
   it("uses compatibility sizing only while a phone is connected", () => {
-    expect(terminalGridForDevices([])).toEqual(DESKTOP_TERMINAL_GRID);
-    expect(terminalGridForDevices(["desktop", "tablet"])).toEqual(DESKTOP_TERMINAL_GRID);
-    expect(terminalGridForDevices(["desktop", "mobile"])).toEqual(MOBILE_TERMINAL_GRID);
+    expect(terminalGridForDevices([], true)).toEqual(DESKTOP_TERMINAL_GRID);
+    expect(terminalGridForDevices(["desktop", "tablet"], true)).toEqual(DESKTOP_TERMINAL_GRID);
+    expect(terminalGridForDevices(["desktop", "mobile"], true)).toEqual(MOBILE_TERMINAL_GRID);
+    expect(terminalGridForDevices(["desktop", "portrait"], true)).toEqual(MOBILE_TERMINAL_GRID);
+    expect(terminalGridForDevices(["mobile"], false)).toEqual(LEGACY_MOBILE_TERMINAL_GRID);
   });
 
   it("fills a pane wider than the grid instead of leaving it empty", () => {
@@ -87,6 +94,20 @@ describe("viewer-local terminal fitting", () => {
     expect(phone.fontSize).toBeLessThan(10);
     expect(desktop.fontSize).toBeGreaterThan(16);
     expect(desktop.fontSize).toBeLessThanOrEqual(24);
+  });
+
+  it("uses most of a portrait pane with the taller mobile grid", () => {
+    const box = { width: 380, height: 620 };
+    const measure = font();
+    const fitted = fittedTerminal(box, MOBILE_TERMINAL_GRID, measure, {
+      maxLineHeight: 1.8,
+      pixelRatio: 3,
+    });
+    const size = drawn(measure(fitted.fontSize), fitted.lineHeight, MOBILE_TERMINAL_GRID, 3);
+
+    expect(size.width / box.width).toBeGreaterThan(0.95);
+    expect(size.height / box.height).toBeGreaterThan(0.9);
+    expect(size.height).toBeLessThanOrEqual(box.height);
   });
 
   it("applies personal zoom without changing terminal dimensions", () => {

--- a/tests/touch-scroll.test.ts
+++ b/tests/touch-scroll.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   TerminalLineScroller,
+  TerminalPinchZoomGesture,
   TerminalTouchScrollBridge,
   TouchWheelGesture,
   type TouchSample,
@@ -72,5 +73,27 @@ describe("terminal touch scrolling", () => {
     expect(bridge.move([touch(240)])).toBe(true);
     bridge.end();
     expect(viewportY).toBe(206);
+  });
+});
+
+describe("terminal pinch zoom", () => {
+  it("scales from the zoom active when the second finger lands", () => {
+    const gesture = new TerminalPinchZoomGesture();
+    gesture.start([touch(100, 100, 1), touch(100, 200, 2)], 80);
+
+    expect(gesture.move([touch(100, 100, 1), touch(100, 202, 2)])).toBeNull();
+    expect(gesture.move([touch(100, 100, 1), touch(100, 250, 2)])).toBe(120);
+    expect(gesture.move([touch(100, 100, 1), touch(100, 175, 2)])).toBe(60);
+  });
+
+  it("clamps zoom and tracks the original two fingers", () => {
+    const gesture = new TerminalPinchZoomGesture();
+    gesture.start([touch(100, 100, 4), touch(100, 200, 9)], 100);
+
+    expect(gesture.move([touch(100, 100, 4), touch(100, 400, 9)])).toBe(150);
+    expect(gesture.move([touch(100, 100, 4), touch(100, 110, 9)])).toBe(50);
+    expect(gesture.move([touch(100, 100, 4), touch(100, 200, 7)])).toBeNull();
+    gesture.end();
+    expect(gesture.move([touch(100, 100, 4), touch(100, 250, 9)])).toBeNull();
   });
 });

--- a/web/main.ts
+++ b/web/main.ts
@@ -43,10 +43,15 @@ import {
 import { MobileViewportTracker, terminalTypography } from "./mobile-viewport";
 import { fittedTerminal } from "./terminal-fit";
 import { cellMeasurer, terminalBox } from "./terminal-metrics";
-import { DESKTOP_TERMINAL_GRID } from "../shared/terminal-grid";
+import {
+  DESKTOP_TERMINAL_GRID,
+  LEGACY_MOBILE_TERMINAL_GRID,
+  MOBILE_TERMINAL_GRID,
+} from "../shared/terminal-grid";
 import { renderStatsDashboard } from "./stats";
 import {
   TerminalLineScroller,
+  TerminalPinchZoomGesture,
   TerminalTouchScrollBridge,
   type TouchSample,
 } from "./touch-scroll";
@@ -1268,6 +1273,7 @@ function renderTerminal(sessionId: string): void {
   let lastViewportWidth = 0;
   let lastViewportHeight = 0;
   let lastKeyboardOpen = false;
+  let lastViewerPortrait: boolean | undefined;
   const mobileViewport = new MobileViewportTracker();
   let copyAttempt = 0;
   let copyResetTimer: number | undefined;
@@ -1651,6 +1657,25 @@ function renderTerminal(sessionId: string): void {
     height: Math.round(window.visualViewport?.height ?? window.innerHeight),
   });
 
+  const isPortraitViewer = (): boolean => {
+    // Keep the pre-keyboard layout while the visual viewport is compressed;
+    // otherwise opening the keyboard would falsely turn a portrait phone into
+    // a landscape viewer and resize the shared PTY underneath the user.
+    if (mobileViewport.keyboardOpen && lastViewerPortrait !== undefined) {
+      return lastViewerPortrait;
+    }
+    return window.innerHeight > window.innerWidth;
+  };
+
+  const reportViewerLayout = (): void => {
+    const portrait = isPortraitViewer();
+    if (portrait === lastViewerPortrait) return;
+    lastViewerPortrait = portrait;
+    if (socket?.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify({ type: "viewer_layout", portrait }));
+    }
+  };
+
   const commitViewport = (
     current: { width: number; height: number },
     keyboardOpen: boolean,
@@ -1666,6 +1691,7 @@ function renderTerminal(sessionId: string): void {
       document.documentElement.style.setProperty("--session-viewport-height", `${current.height}px`);
     }
     if (widthChanged || heightChanged || keyboardChanged) scheduleFit();
+    reportViewerLayout();
   };
 
   const handleViewportResize = (): void => {
@@ -1760,7 +1786,11 @@ function renderTerminal(sessionId: string): void {
     if (stopped) return;
     setStatus(waitingForCapacity ? "full" : "connecting");
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    socket = new WebSocket(`${protocol}//${window.location.host}/api/sessions/${sessionId}/ws`);
+    const portrait = isPortraitViewer();
+    lastViewerPortrait = portrait;
+    const websocketURL = new URL(`${protocol}//${window.location.host}/api/sessions/${sessionId}/ws`);
+    websocketURL.searchParams.set("layout", portrait ? "portrait" : "landscape");
+    socket = new WebSocket(websocketURL);
     socket.binaryType = "arraybuffer";
 
     socket.addEventListener("open", () => {
@@ -1884,7 +1914,11 @@ function renderTerminal(sessionId: string): void {
     }
     if (
       message.type === "terminal_size" &&
-      ((message.cols === 80 && message.rows === 24) || (message.cols === 120 && message.rows === 36))
+      typeof message.cols === "number" &&
+      typeof message.rows === "number" &&
+      [DESKTOP_TERMINAL_GRID, MOBILE_TERMINAL_GRID, LEGACY_MOBILE_TERMINAL_GRID].some(
+        (grid) => message.cols === grid.cols && message.rows === grid.rows,
+      )
     ) {
       terminalColumns = message.cols;
       terminalRows = message.rows;
@@ -2067,15 +2101,22 @@ function renderTerminal(sessionId: string): void {
     if (event.target === settingsDialog) closeSettings();
   });
 
-  zoomInput.addEventListener("input", () => {
-    terminalZoomPercent = Number(zoomInput.value);
+  const applyTerminalZoom = (zoomPercent: number, persist: boolean): void => {
+    terminalZoomPercent = Math.min(150, Math.max(50, Math.round(zoomPercent)));
+    zoomInput.value = String(terminalZoomPercent);
     zoomValue.value = `${terminalZoomPercent}%`;
-    try {
-      localStorage.setItem("shell-online-terminal-zoom", String(terminalZoomPercent));
-    } catch {
-      // Zoom remains active for this page when storage is unavailable.
+    if (persist) {
+      try {
+        localStorage.setItem("shell-online-terminal-zoom", String(terminalZoomPercent));
+      } catch {
+        // Zoom remains active for this page when storage is unavailable.
+      }
     }
     scheduleFit();
+  };
+
+  zoomInput.addEventListener("input", () => {
+    applyTerminalZoom(Number(zoomInput.value), true);
   });
 
   for (const button of themeOptionButtons) {
@@ -2121,6 +2162,7 @@ function renderTerminal(sessionId: string): void {
       / Math.max(terminal.rows, 1),
     (lines) => terminal.scrollLines(lines),
   );
+  const pinchZoom = new TerminalPinchZoomGesture();
   const touchScroll = new TerminalTouchScrollBridge((wheel) => {
     if (
       terminal.buffer.active.type === "normal" &&
@@ -2158,21 +2200,34 @@ function renderTerminal(sessionId: string): void {
       y: touch.clientY,
     }));
   terminalWrap.addEventListener("touchstart", (event) => {
+    const touches = readTouches(event.touches);
     touchLineScroller.reset();
-    touchScroll.start(readTouches(event.touches));
+    touchScroll.start(touches);
+    pinchZoom.start(touches, terminalZoomPercent);
   }, { passive: true });
   terminalWrap.addEventListener("touchmove", (event) => {
-    if (!terminalScrollSurface || !touchScroll.move(readTouches(event.touches))) return;
+    const touches = readTouches(event.touches);
+    const zoom = pinchZoom.move(touches);
+    if (zoom !== null) {
+      applyTerminalZoom(zoom, false);
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+    if (!terminalScrollSurface || !touchScroll.move(touches)) return;
     event.preventDefault();
     event.stopPropagation();
   }, { passive: false });
   terminalWrap.addEventListener("touchend", () => {
     touchLineScroller.reset();
     touchScroll.end();
+    pinchZoom.end();
+    applyTerminalZoom(terminalZoomPercent, true);
   }, { passive: true });
   terminalWrap.addEventListener("touchcancel", () => {
     touchLineScroller.reset();
     touchScroll.end();
+    pinchZoom.end();
   }, { passive: true });
 
   helperTextarea?.addEventListener("focus", () => sampleViewportTransition());

--- a/web/mobile-viewport.ts
+++ b/web/mobile-viewport.ts
@@ -66,8 +66,9 @@ export function terminalTypography(
   viewportWidth: number,
   viewportHeight: number,
 ): TerminalTypography {
-  if (!compact) return { fontSize: 14, lineHeight: 1.18 };
-  if (!keyboardOpen) return { fontSize: 13, lineHeight: 1.18 };
+  const portraitLineHeight = viewportHeight > viewportWidth * 1.15 ? 1.8 : 1.18;
+  if (!compact) return { fontSize: 14, lineHeight: portraitLineHeight };
+  if (!keyboardOpen) return { fontSize: 13, lineHeight: portraitLineHeight };
   if (viewportWidth <= 360 || viewportHeight <= 430) {
     return { fontSize: 8, lineHeight: 1.08 };
   }

--- a/web/touch-scroll.ts
+++ b/web/touch-scroll.ts
@@ -10,6 +10,52 @@ export interface TouchWheelDelta {
   y: number;
 }
 
+/** Converts a two-finger pinch into a viewer-local terminal zoom percentage. */
+export class TerminalPinchZoomGesture {
+  private touchIDs: [number, number] | undefined;
+  private startDistance = 0;
+  private startZoom = 100;
+
+  constructor(
+    private readonly minimumZoom = 50,
+    private readonly maximumZoom = 150,
+    private readonly threshold = 3,
+  ) {}
+
+  start(touches: readonly TouchSample[], zoomPercent: number): void {
+    this.reset();
+    if (touches.length !== 2) return;
+    const distance = touchDistance(touches[0], touches[1]);
+    if (distance <= 0) return;
+    this.touchIDs = [touches[0].id, touches[1].id];
+    this.startDistance = distance;
+    this.startZoom = clamp(zoomPercent, this.minimumZoom, this.maximumZoom);
+  }
+
+  move(touches: readonly TouchSample[]): number | null {
+    if (!this.touchIDs || touches.length !== 2) return null;
+    const first = touches.find((touch) => touch.id === this.touchIDs![0]);
+    const second = touches.find((touch) => touch.id === this.touchIDs![1]);
+    if (!first || !second) return null;
+    const distance = touchDistance(first, second);
+    if (Math.abs(distance - this.startDistance) < this.threshold) return null;
+    return clamp(
+      Math.round(this.startZoom * distance / this.startDistance),
+      this.minimumZoom,
+      this.maximumZoom,
+    );
+  }
+
+  end(): void {
+    this.reset();
+  }
+
+  private reset(): void {
+    this.touchIDs = undefined;
+    this.startDistance = 0;
+  }
+}
+
 /** Accumulates pixel movement into whole terminal rows without losing small pans. */
 export class TerminalLineScroller {
   private lineRemainder = 0;
@@ -112,4 +158,12 @@ export class TerminalTouchScrollBridge {
   end(): void {
     this.gesture.end();
   }
+}
+
+function touchDistance(first: TouchSample, second: TouchSample): number {
+  return Math.hypot(second.x - first.x, second.y - first.y);
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(maximum, Math.max(minimum, value));
 }

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -117,6 +117,8 @@ interface SocketAttachment {
   snapshotRequestedAt?: number;
   terminalCols?: number;
   terminalRows?: number;
+  portrait?: boolean;
+  supportsPortraitGrid?: boolean;
 }
 
 interface TrafficWindow {
@@ -904,6 +906,8 @@ export class TerminalSession extends DurableObject<Env> {
       device: analyticsContext.device,
       client: analyticsContext.client,
       referrer: analyticsContext.referrer,
+      portrait: role === "viewer" && new URL(request.url).searchParams.get("layout") === "portrait",
+      supportsPortraitGrid: role === "host" && request.headers.get("X-Shell-Terminal-Grid") === "80x40",
     };
 
     server.serializeAttachment(attachment);
@@ -1003,15 +1007,22 @@ export class TerminalSession extends DurableObject<Env> {
       return;
     }
 
-    let event: { type?: unknown; code?: unknown; attached?: unknown };
+    let event: { type?: unknown; code?: unknown; attached?: unknown; portrait?: unknown };
     try {
-      event = JSON.parse(message) as { type?: unknown; code?: unknown };
+      event = JSON.parse(message) as typeof event;
     } catch {
       safeClose(socket, 4002, "invalid control message");
       return;
     }
 
     if (attachment.role === "viewer") {
+      if (event.type === "viewer_layout" && typeof event.portrait === "boolean") {
+        if (attachment.portrait === event.portrait) return;
+        attachment.portrait = event.portrait;
+        socket.serializeAttachment(attachment);
+        this.broadcastTerminalGrid();
+        return;
+      }
       if (event.type === "snapshot_request") {
         const now = Date.now();
         if (now - (attachment.snapshotRequestedAt ?? 0) < 1_000) return;
@@ -1520,8 +1531,15 @@ export class TerminalSession extends DurableObject<Env> {
     const devices = this.state
       .getWebSockets("viewer")
       .filter((socket) => socket !== excluded && socket.readyState === 1)
-      .map((socket) => readAttachment(socket)?.device ?? "unknown");
-    const grid = terminalGridForDevices(devices);
+      .map((socket) => {
+        const attachment = readAttachment(socket);
+        return attachment?.portrait ? "portrait" : attachment?.device ?? "unknown";
+      });
+    const supportsPortraitGrid = this.state
+      .getWebSockets("host")
+      .filter((socket) => socket.readyState === 1)
+      .some((socket) => readAttachment(socket)?.supportsPortraitGrid === true);
+    const grid = terminalGridForDevices(devices, supportsPortraitGrid);
     const message = JSON.stringify({ type: "terminal_size", ...grid });
     for (const socket of this.state.getWebSockets()) {
       if (socket === excluded) continue;


### PR DESCRIPTION
## Summary
- negotiate a taller 80x40 PTY grid when a phone or portrait viewer is connected
- fall back to the existing 80x24 grid for older installed CLIs
- restore 120x36 automatically when portrait/mobile viewers leave
- use more of tall browser viewports without changing another viewer's local zoom
- add terminal-only two-finger pinch zoom from 50% to 150%
- preserve the selected zoom and keep one-finger terminal scrolling unchanged

## Compatibility
The new CLI advertises 80x40 support in its host WebSocket handshake. The relay sends 80x24 to older CLIs, so deploying the Worker before a new CLI release remains safe.

## Validation
- npm run check: 73 tests passed
- go test ./...: all packages passed
- npm --prefix app test: 674 passed, 3 skipped
- protocol vendoring check passed
- npm run build:web passed
- live local Worker + real CLI + WebSocket session at 390x844: 80x40, 640/721 terminal pixels used, zero horizontal overflow
- live orientation change restored 120x36