### PR TITLE
Set Homebrew checksum for v0.11.2

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -54,6 +54,6 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
           build-args: VERSION=${{ steps.metadata.outputs.version }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
           provenance: mode=max
           sbom: true

--- a/Formula/shell-online.rb
+++ b/Formula/shell-online.rb
@@ -2,7 +2,7 @@ class ShellOnline < Formula
   desc "Turn any terminal process into an interactive or read-only browser link"
   homepage "https://shell.online"
   url "https://github.com/TeoSlayer/shell.online/archive/refs/tags/v0.11.2.tar.gz"
-  sha256 "REPLACE_WITH_TAG_TARBALL_SHA256"
+  sha256 "8e42cbb55af859999b399ba8f7830bee40e56a0fab7049b1414a46f78dcd6992"
   license "MIT"
 
   depends_on "go" => :build


### PR DESCRIPTION
Pins the SHA-256 checksum of GitHub's v0.11.2 source archive after publishing the tag.\n\nValidated with `node scripts/check-formula.mjs`.