### PR TITLE
Release 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-visible changes are recorded here. Versions follow [Semantic Ve
 
 ## Unreleased
 
+## [0.12.0] — 2026-09-11
+
 ### Added
 
 - A session vault. Every session's password is sealed to your account, so it

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 services:
   shell-online:
-    image: ghcr.io/teoslayer/shell.online:0.11.3
+    image: ghcr.io/teoslayer/shell.online:0.12.0
     build:
       context: .
       args:
-        VERSION: "0.11.3"
+        VERSION: "0.12.0"
     restart: unless-stopped
     environment:
       SHELL_ONLINE_E2EE_PASSWORD: "${SHELL_ONLINE_E2EE_PASSWORD:-}"

--- a/docs/content.json
+++ b/docs/content.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.11.3",
+  "version": "0.12.0",
   "pages": {
     "docs": {
       "eyebrow": "Documentation",
@@ -553,7 +553,7 @@
       "cards": [
         [
           "Start once",
-          "Pull ghcr.io/teoslayer/shell.online:0.11.3 or run docker compose up --build -d, then docker compose logs shell-online. First launch prints the stable URL and a generated eight-character password. The tagged amd64/arm64 image includes an SBOM and build provenance."
+          "Pull ghcr.io/teoslayer/shell.online:0.12.0 or run docker compose up --build -d, then docker compose logs shell-online. First launch prints the stable URL and a generated eight-character password. The tagged amd64/arm64 image includes an SBOM and build provenance."
         ],
         [
           "Two durable volumes",

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
           },
           "applicationCategory": "DeveloperApplication",
           "operatingSystem": "macOS, Windows, Linux, FreeBSD, OpenBSD, NetBSD, DragonFly BSD, Solaris",
-          "softwareVersion": "0.11.3",
+          "softwareVersion": "0.12.0",
           "softwareRequirements": "A supported architecture, outbound HTTPS and WebSockets, and a PTY or Windows ConPTY",
           "isAccessibleForFree": true,
           "downloadUrl": "https://shell.online/install",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shell-online",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shell-online",
-      "version": "0.11.3",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@xterm/xterm": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shell-online",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "description": "Turn any terminal process into a collaborative browser link.",
   "private": true,
   "license": "MIT",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -24,9 +24,9 @@ The Homebrew formula builds locally: Brew fetches the checksum-pinned tagged sou
 
 The standalone installer uses a checksum-pinned release binary. To compile and run the tagged source outside either installation path:
 
-git clone --depth 1 --branch v0.11.3 https://github.com/TeoSlayer/shell.online.git
+git clone --depth 1 --branch v0.12.0 https://github.com/TeoSlayer/shell.online.git
 cd shell.online
-go build -trimpath -ldflags="-X main.version=0.11.3" -o ./shell ./cmd/shell
+go build -trimpath -ldflags="-X main.version=0.12.0" -o ./shell ./cmd/shell
 ./shell --version
 
 The source-build path requires Go 1.26.8 or newer, except Go 1.27.x is intentionally unsupported on MIPS64 because of go.dev/issue/80978. Keep using ./shell or move it to a directory on PATH.


### PR DESCRIPTION
Bumps the version to 0.12.0 for the session vault (#111), which changes the CLI: it now seals each encrypted session's password to the account's vault when it registers.

- `package.json`, `package-lock.json`, `index.html` (`softwareVersion`), `docs/content.json`, `public/llms.txt`, `docker-compose.yml`
- `CHANGELOG.md`: the unreleased entries become 0.12.0

The Homebrew formula stays on 0.11.3 until the `v0.12.0` tag exists; its URL and checksum follow in their own PR, as with #107. Root `npm test` passes, including the formula and version checks.