### PR TITLE
Set Homebrew checksum for v0.12.0

### DIFF
--- a/Formula/shell-online.rb
+++ b/Formula/shell-online.rb
@@ -1,8 +1,8 @@
 class ShellOnline < Formula
   desc "Turn any terminal process into an interactive or read-only browser link"
   homepage "https://shell.online"
-  url "https://github.com/TeoSlayer/shell.online/archive/refs/tags/v0.11.3.tar.gz"
-  sha256 "c02b812951f4b173acdd1f4e08fbac818aacb0ba9a85ecad846142c216dd94bc"
+  url "https://github.com/TeoSlayer/shell.online/archive/refs/tags/v0.12.0.tar.gz"
+  sha256 "4e0e95185aed165a890fe70bc3c99787cf7efc7bb8098194970456903d731e4a"
   license "MIT"
 
   depends_on "go" => :build


### PR DESCRIPTION
Points the formula at the `v0.12.0` tag and its archive checksum, which could only be known once the tag existed. The checksum is stable across two downloads of the tag tarball, and `check-formula.mjs` passes when run as a tag build (`GITHUB_REF=refs/tags/v0.12.0`).