### PR TITLE
Deploy the checked-out production tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ coverage/
 *.pem
 *.key
 wrangler.production.jsonc
+.wrangler.production.*.jsonc
 wrangler.local.jsonc
 worker-configuration.d.ts
 

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -1,15 +1,35 @@
 #!/bin/sh
 set -eu
 
-config=${SHELL_ONLINE_WRANGLER_CONFIG:-wrangler.production.jsonc}
+repository_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+config_input=${SHELL_ONLINE_WRANGLER_CONFIG:-wrangler.production.jsonc}
+case "$config_input" in
+  /*) config=$config_input ;;
+  *) config=$(pwd)/$config_input ;;
+esac
 
 if [ ! -f "$config" ]; then
   printf 'Production Wrangler config not found: %s\n' "$config" >&2
   exit 1
 fi
 
+# Wrangler resolves `main` and `assets.directory` beside its config file. A
+# private config kept in another checkout would otherwise deploy that other
+# checkout while this script builds the current one. Stage only the config
+# beside this source tree, with owner-only permissions, and remove it on exit.
+config_directory=$(CDPATH= cd -- "$(dirname -- "$config")" && pwd)
+deployment_config=$config
+if [ "$config_directory" != "$repository_root" ]; then
+  deployment_config=$(mktemp "$repository_root/.wrangler.production.XXXXXX.jsonc")
+  cp "$config" "$deployment_config"
+  chmod 600 "$deployment_config"
+  trap 'rm -f -- "$deployment_config"' EXIT HUP INT TERM
+fi
+
+cd "$repository_root"
+
 # A Workers asset deployment replaces the previous manifest. Always rebuild and
 # verify the complete download bundle so a web-only deploy cannot remove it.
 npm run build
 npm run verify:downloads
-npx wrangler deploy --config "$config" "$@"
+npx wrangler deploy --config "$deployment_config" "$@"

--- a/scripts/test-deploy-production.sh
+++ b/scripts/test-deploy-production.sh
@@ -9,7 +9,7 @@ fake_bin="$test_root/bin"
 command_log="$test_root/commands"
 config="$test_root/wrangler.production.jsonc"
 mkdir -p "$fake_bin"
-: > "$config"
+printf 'production-test-config\n' > "$config"
 
 cat > "$fake_bin/npm" <<'SCRIPT'
 #!/bin/sh
@@ -21,23 +21,35 @@ SCRIPT
 
 cat > "$fake_bin/npx" <<'SCRIPT'
 #!/bin/sh
-printf 'npx %s\n' "$*" >> "$SHELL_ONLINE_TEST_COMMAND_LOG"
+test "$1" = "wrangler"
+test "$2" = "deploy"
+test "$3" = "--config"
+case "$4" in
+  "$SHELL_ONLINE_TEST_REPOSITORY_ROOT"/.wrangler.production.*.jsonc) ;;
+  *) printf 'config was not staged beside the source: %s\n' "$4" >&2; exit 43 ;;
+esac
+test "$(cat "$4")" = "production-test-config"
+shift 4
+printf 'npx wrangler deploy --config <repo-local>%s\n' "${*:+ $*}" >> "$SHELL_ONLINE_TEST_COMMAND_LOG"
 SCRIPT
 
 chmod 755 "$fake_bin/npm" "$fake_bin/npx"
 
 SHELL_ONLINE_TEST_COMMAND_LOG="$command_log" \
+SHELL_ONLINE_TEST_REPOSITORY_ROOT="$repository_root" \
 SHELL_ONLINE_WRANGLER_CONFIG="$config" \
 PATH="$fake_bin:$PATH" \
   sh "$repository_root/scripts/deploy-production.sh"
 
-expected=$(printf 'npm run build\nnpm run verify:downloads\nnpx wrangler deploy --config %s\n' "$config")
+expected=$(printf 'npm run build\nnpm run verify:downloads\nnpx wrangler deploy --config <repo-local>\n')
 test "$(cat "$command_log")" = "$expected"
+test -z "$(find "$repository_root" -maxdepth 1 -name '.wrangler.production.*.jsonc' -print -quit)"
 
 : > "$command_log"
 set +e
 SHELL_ONLINE_TEST_VERIFY_FAIL=1 \
 SHELL_ONLINE_TEST_COMMAND_LOG="$command_log" \
+SHELL_ONLINE_TEST_REPOSITORY_ROOT="$repository_root" \
 SHELL_ONLINE_WRANGLER_CONFIG="$config" \
 PATH="$fake_bin:$PATH" \
   sh "$repository_root/scripts/deploy-production.sh"
@@ -48,6 +60,7 @@ test "$(cat "$command_log")" = "$(printf 'npm run build\nnpm run verify:download
 
 : > "$command_log"
 if SHELL_ONLINE_TEST_COMMAND_LOG="$command_log" \
+  SHELL_ONLINE_TEST_REPOSITORY_ROOT="$repository_root" \
   SHELL_ONLINE_WRANGLER_CONFIG="$test_root/missing.jsonc" \
   PATH="$fake_bin:$PATH" \
   sh "$repository_root/scripts/deploy-production.sh" 2>/dev/null; then


### PR DESCRIPTION
Wrangler resolves relative worker and asset paths beside its configuration file. When production configuration is intentionally kept in another checkout, that could silently deploy stale code and assets. Stage an owner-only temporary copy beside the current source, remove it on exit, and cover the exact external-config case with the deployment guard test.